### PR TITLE
Using MADV_FREE on Solaris/Illumos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,7 @@ case "${host}" in
   *-*-solaris2*)
 	CFLAGS="$CFLAGS"
 	abi="elf"
+	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	RPATH='-Wl,-R,$(1)'
 	dnl Solaris needs this for sigwait().
 	CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"


### PR DESCRIPTION
Solaris/Illumos does not have  Linux's MADV_DONTNEED and MADV_FREE does the equivalent. This three line commit does it and works fine on SmartOS (an Illumos based distribution http://smartos.org/). 

It may be better to do in the platform specific code in configure.ac. I could not figure that out. If somebody who is more familiar with this add it there that would be great as well.
