### PR TITLE
Fix a crashing case where arena_chunk_init_hard returns NULL.

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -614,8 +614,11 @@ arena_chunk_alloc(arena_t *arena)
 
 	if (arena->spare != NULL)
 		chunk = arena_chunk_init_spare(arena);
-	else
+	else {
 		chunk = arena_chunk_init_hard(arena);
+		if (chunk == NULL)
+			return (NULL);
+	}
 
 	/* Insert the run into the runs_avail tree. */
 	arena_avail_insert(arena, chunk, map_bias, chunk_npages-map_bias,


### PR DESCRIPTION
This happens when it fails to allocate a new chunk. Which
arena_chunk_alloc then passes into arena_avail_insert without any
checks. This then causes a crash when arena_avail_insert tries
to check chunk->ndirty.

This was introduced by the refactoring of arena_chunk_alloc
which previously would have returned NULL immediately after
calling chunk_alloc. This is now the return from
arena_chunk_init_hard so we need to check that return, and
not continue if it was NULL.
