### PR TITLE
Remove valgrind related code from tcache

### DIFF
--- a/include/jemalloc/internal/tcache.h
+++ b/include/jemalloc/internal/tcache.h
@@ -314,13 +314,11 @@ tcache_alloc_small(tcache_t *tcache, size_t size, bool zero)
 			} else if (opt_zero)
 				memset(ret, 0, size);
 		}
-		VALGRIND_MAKE_MEM_UNDEFINED(ret, size);
 	} else {
 		if (config_fill && opt_junk) {
 			arena_alloc_junk_small(ret, &arena_bin_info[binind],
 			    true);
 		}
-		VALGRIND_MAKE_MEM_UNDEFINED(ret, size);
 		memset(ret, 0, size);
 	}
 
@@ -369,9 +367,7 @@ tcache_alloc_large(tcache_t *tcache, size_t size, bool zero)
 				else if (opt_zero)
 					memset(ret, 0, size);
 			}
-			VALGRIND_MAKE_MEM_UNDEFINED(ret, size);
 		} else {
-			VALGRIND_MAKE_MEM_UNDEFINED(ret, size);
 			memset(ret, 0, size);
 		}
 


### PR DESCRIPTION
In jemalloc.c we already call VALGRIND_MALLOCLIKE_BLOCK. In addition,
malloc_conf_init appears to disable opt_tcache if RUNNING_ON_VALGRIND
is true.

Removing this code saves about 10% of the bytes in the body of malloc
in addition, it saves about 224 bytes (65%) of the stack space malloc
reserves.
