### PR TITLE
Cleanup profiling code

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1051,6 +1051,7 @@ label_oom:
 		    "out of memory\n");
 		abort();
 	}
+	prof_sample_reset_threshold();
 	ret = ENOMEM;
 	goto label_return;
 }
@@ -1165,6 +1166,7 @@ label_return:
 			    "memory\n");
 			abort();
 		}
+		prof_sample_reset_threshold();
 		set_errno(ENOMEM);
 	}
 	if (config_stats && ret != NULL) {
@@ -1284,6 +1286,7 @@ je_realloc(void *ptr, size_t size)
 			    "out of memory\n");
 			abort();
 		}
+		prof_sample_reset_threshold();
 		set_errno(ENOMEM);
 	}
 	if (config_stats && ret != NULL) {
@@ -1479,6 +1482,7 @@ label_oom:
 		malloc_write("<jemalloc>: Error in mallocx(): out of memory\n");
 		abort();
 	}
+	prof_sample_reset_threshold();
 	UTRACE(0, size, 0);
 	return (NULL);
 }
@@ -1534,6 +1538,9 @@ irallocx_prof(void *oldptr, size_t old_usize, size_t size, size_t alignment,
 		 * serendipitously satisfied.  Additionally, old_usize may not
 		 * be the same as the current usize because of in-place large
 		 * reallocation.  Therefore, query the actual value of usize.
+		 *
+		 * FIXME: check if the old bytes_until_sample is < usize. reset
+		 * sampling rate.
 		 */
 		*usize = isalloc(p, config_prof);
 	}
@@ -1612,6 +1619,7 @@ label_oom:
 		malloc_write("<jemalloc>: Error in rallocx(): out of memory\n");
 		abort();
 	}
+	prof_sample_reset_threshold();
 	UTRACE(ptr, size, 0);
 	return (NULL);
 }

--- a/src/prof.c
+++ b/src/prof.c
@@ -1225,9 +1225,9 @@ prof_tdata_init(void)
 		return (NULL);
 	}
 
-	prof_tdata->prng_state = 0;
-	prof_tdata->threshold = 0;
-	prof_tdata->accum = 0;
+        /* initalize each thread to a different seed */
+	prof_tdata->prng_state = (uint64_t)(uintptr_t)prof_tdata;
+	prof_sample_threshold_update(prof_tdata);
 
 	prof_tdata->enq = false;
 	prof_tdata->enq_idump = false;


### PR DESCRIPTION
Jason -- wanted to get some feedback from you on this. I haven't tested it very well and there's also one FIXME, but wanted to see what you thought of the overall approach.

This diff cleans up the profiling code in two ways:

(1) It turns the two part prepare-commit process into a one step
process. This is good because it could make it easier to reduce
code duplication in the future. For example, today multiple copies
of arena_malloc are inlined inside malloc(). This could make it
easier to de-duplicate these inlined versions.

In a few exceptional codepaths (eg realloc with an alignment
constraint where the allocation is resized but not moved or OOM)
we simply reset the sampling code rather than try to account for
things correctly.

(2) replaces the 2 variable accumulated / threshold accounting
with a 1 variable bytes until sample. This is the same as the
way tcmalloc does the accounting.
