### PR TITLE
Separate bits from the rest of the chunk map

### DIFF
--- a/include/jemalloc/internal/chunk.h
+++ b/include/jemalloc/internal/chunk.h
@@ -41,6 +41,7 @@ extern size_t		chunksize;
 extern size_t		chunksize_mask; /* (chunksize - 1). */
 extern size_t		chunk_npages;
 extern size_t		map_bias; /* Number of arena chunk header pages. */
+extern size_t		chunk_map_offset;
 extern size_t		arena_maxclass; /* Max size class for arenas. */
 
 void	*chunk_alloc(size_t size, size_t alignment, bool base, bool *zero,

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -28,6 +28,7 @@ size_t		chunksize;
 size_t		chunksize_mask; /* (chunksize - 1). */
 size_t		chunk_npages;
 size_t		map_bias;
+size_t		chunk_map_offset;
 size_t		arena_maxclass; /* Max size class for arenas. */
 
 /******************************************************************************/


### PR DESCRIPTION
This splits the "bits" portion of the map into it's own data structure. The first diff does some refactoring to make the transition easier, the second diff implements the split.

In theory, I think it might be possible to get bit set down to 1 byte per page -- we could take advantage of the unused middle bits to describe the size of large runs.

Right now, for applications with profiling active, this patch causes a net-loss because we access the profiling context on every malloc. If we disable prof promote as we've discussed we can make this a non-issue.
