### PR TITLE
Add support for user-specified chunk allocators/deallocators.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -142,7 +142,8 @@ TESTS_INTEGRATION := $(srcroot)test/integration/aligned_alloc.c \
 	$(srcroot)test/integration/rallocx.c \
 	$(srcroot)test/integration/thread_arena.c \
 	$(srcroot)test/integration/thread_tcache_enabled.c \
-	$(srcroot)test/integration/xallocx.c
+	$(srcroot)test/integration/xallocx.c \
+	$(srcroot)test/integration/chunk.c
 TESTS_STRESS :=
 TESTS := $(TESTS_UNIT) $(TESTS_INTEGRATION) $(TESTS_STRESS)
 

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1283,6 +1283,69 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         </para></listitem>
       </varlistentry>
 
+      <varlistentry id="arena.i.chunk.alloc">
+        <term>
+          <mallctl>arena.&lt;i&gt;.chunk.alloc</mallctl>
+          (<type>chunk_alloc_t *</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Get or set the chunk allocation function for arena
+        &lt;i&gt;.  If setting, the chunk deallocation function should
+        also be set via <link linkend="arena.i.chunk.dealloc">
+        <mallctl>arena.&lt;i&gt;.chunk.dealloc</mallctl></link> to a companion
+        function that knows how to deallocate the chunks.
+        <funcprototype>
+          <funcdef>typedef void *<function>(chunk_alloc_t)</function></funcdef>
+          <paramdef>size_t <parameter>size</parameter></paramdef>
+          <paramdef>size_t <parameter>alignment</parameter></paramdef>
+          <paramdef>bool *<parameter>zero</parameter></paramdef>
+          <paramdef>unsigned <parameter>arena_ind</parameter></paramdef>
+        </funcprototype>
+        A chunk allocation function conforms to the <type>chunk_alloc_t</type>
+        type and upon success returns a pointer to <parameter>size</parameter>
+        bytes of memory on behalf of arena <parameter>arena_ind</parameter> such
+        that the chunk's base address is a multiple of
+        <parameter>alignment</parameter>, as well as setting
+        <parameter>*zero</parameter> to indicate whether the chunk is zeroed.
+        Upon error the function returns <constant>NULL</constant> and leaves
+        <parameter>*zero</parameter> unmodified.  The
+        <parameter>size</parameter> parameter is always a multiple of the chunk
+        size.  The <parameter>alignment</parameter> parameter is always a power
+        of two at least as large as the chunk size.  Zeroing is mandatory if
+        <parameter>*zero</parameter> is true upon function
+        entry.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="arena.i.chunk.dealloc">
+        <term>
+          <mallctl>arena.&lt;i&gt;.chunk.dealloc</mallctl>
+          (<type>chunk_dealloc_t *</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Get or set the chunk deallocation function for arena
+        &lt;i&gt;.  If setting, the chunk deallocation function must
+        be capable of deallocating all extant chunks associated with arena
+        &lt;i&gt;, usually by passing unknown chunks to the deallocation
+        function that was replaced.  In practice, it is feasible to control
+        allocation for arenas created via <link
+        linkend="arenas.extend"><mallctl>arenas.extend</mallctl></link> such
+        that all chunks originate from an application-supplied chunk allocator
+        (by setting custom chunk allocation/deallocation functions just after
+        arena creation), but the automatically created arenas may have already
+        created chunks prior to the application having an opportunity to take
+        over chunk allocation.
+        <funcprototype>
+          <funcdef>typedef void <function>(chunk_dealloc_t)</function></funcdef>
+          <paramdef>void *<parameter>chunk</parameter></paramdef>
+          <paramdef>size_t <parameter>size</parameter></paramdef>
+          <paramdef>unsigned <parameter>arena_ind</parameter></paramdef>
+        </funcprototype>
+        A chunk deallocation function conforms to the
+        <type>chunk_dealloc_t</type> type and deallocates a
+        <parameter>chunk</parameter> of given <parameter>size</parameter> on
+        behalf of arena <parameter>arena_ind</parameter>.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="arenas.narenas">
         <term>
           <mallctl>arenas.narenas</mallctl>

--- a/include/jemalloc/internal/arena.h
+++ b/include/jemalloc/internal/arena.h
@@ -370,6 +370,12 @@ struct arena_s {
 	 */
 	arena_avail_tree_t	runs_avail;
 
+	/*
+	 * user-configureable chunk allocation and deallocation functions.
+	 */
+	chunk_alloc_t		*chunk_alloc;
+	chunk_dealloc_t		*chunk_dealloc;
+
 	/* bins is used to store trees of free regions. */
 	arena_bin_t		bins[NBINS];
 };

--- a/include/jemalloc/internal/chunk.h
+++ b/include/jemalloc/internal/chunk.h
@@ -43,10 +43,12 @@ extern size_t		chunk_npages;
 extern size_t		map_bias; /* Number of arena chunk header pages. */
 extern size_t		arena_maxclass; /* Max size class for arenas. */
 
-void	*chunk_alloc(size_t size, size_t alignment, bool base, bool *zero,
-    dss_prec_t dss_prec);
+void	*chunk_alloc(arena_t *arena, size_t size, size_t alignment, bool base,
+    bool *zero, dss_prec_t dss_prec);
+void	*chunk_alloc_default(size_t size, size_t alignment, bool *zero,
+    unsigned arena_ind);
 void	chunk_unmap(void *chunk, size_t size);
-void	chunk_dealloc(void *chunk, size_t size, bool unmap);
+void	chunk_dealloc(arena_t *arena, void *chunk, size_t size, bool unmap);
 bool	chunk_boot(void);
 void	chunk_prefork(void);
 void	chunk_postfork_parent(void);

--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -24,6 +24,9 @@ struct extent_node_s {
 	/* Total region size. */
 	size_t			size;
 
+	/* Arena from which this extent came, if any */
+	arena_t			*arena;
+
 	/* True if zero-filled; used by chunk recycling code. */
 	bool			zeroed;
 };

--- a/include/jemalloc/internal/huge.h
+++ b/include/jemalloc/internal/huge.h
@@ -17,13 +17,15 @@ extern size_t		huge_allocated;
 /* Protects chunk-related data structures. */
 extern malloc_mutex_t	huge_mtx;
 
-void	*huge_malloc(size_t size, bool zero, dss_prec_t dss_prec);
-void	*huge_palloc(size_t size, size_t alignment, bool zero,
+void	*huge_malloc(arena_t *arena, size_t size, bool zero,
+    dss_prec_t dss_prec);
+void	*huge_palloc(arena_t *arena, size_t size, size_t alignment, bool zero,
     dss_prec_t dss_prec);
 bool	huge_ralloc_no_move(void *ptr, size_t oldsize, size_t size,
     size_t extra);
-void	*huge_ralloc(void *ptr, size_t oldsize, size_t size, size_t extra,
-    size_t alignment, bool zero, bool try_tcache_dalloc, dss_prec_t dss_prec);
+void	*huge_ralloc(arena_t *arena, void *ptr, size_t oldsize, size_t size,
+    size_t extra, size_t alignment, bool zero, bool try_tcache_dalloc,
+    dss_prec_t dss_prec);
 #ifdef JEMALLOC_JET
 typedef void (huge_dalloc_junk_t)(void *, size_t);
 extern huge_dalloc_junk_t *huge_dalloc_junk;

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -702,7 +702,8 @@ imalloct(size_t size, bool try_tcache, arena_t *arena)
 	if (size <= arena_maxclass)
 		return (arena_malloc(arena, size, false, try_tcache));
 	else
-		return (huge_malloc(size, false, huge_dss_prec_get(arena)));
+		return (huge_malloc(arena, size, false,
+		    huge_dss_prec_get(arena)));
 }
 
 JEMALLOC_ALWAYS_INLINE void *
@@ -719,7 +720,8 @@ icalloct(size_t size, bool try_tcache, arena_t *arena)
 	if (size <= arena_maxclass)
 		return (arena_malloc(arena, size, true, try_tcache));
 	else
-		return (huge_malloc(size, true, huge_dss_prec_get(arena)));
+		return (huge_malloc(arena, size, true,
+		    huge_dss_prec_get(arena)));
 }
 
 JEMALLOC_ALWAYS_INLINE void *
@@ -745,9 +747,11 @@ ipalloct(size_t usize, size_t alignment, bool zero, bool try_tcache,
 			ret = arena_palloc(choose_arena(arena), usize,
 			    alignment, zero);
 		} else if (alignment <= chunksize)
-			ret = huge_malloc(usize, zero, huge_dss_prec_get(arena));
+			ret = huge_malloc(arena, usize, zero,
+			    huge_dss_prec_get(arena));
 		else
-			ret = huge_palloc(usize, alignment, zero, huge_dss_prec_get(arena));
+			ret = huge_palloc(arena, usize, alignment, zero,
+			    huge_dss_prec_get(arena));
 	}
 
 	assert(ALIGNMENT_ADDR2BASE(ret, alignment) == ret);
@@ -915,7 +919,7 @@ iralloct(void *ptr, size_t size, size_t extra, size_t alignment, bool zero,
 		    alignment, zero, try_tcache_alloc,
 		    try_tcache_dalloc));
 	} else {
-		return (huge_ralloc(ptr, oldsize, size, extra,
+		return (huge_ralloc(arena, ptr, oldsize, size, extra,
 		    alignment, zero, try_tcache_dalloc, huge_dss_prec_get(arena)));
 	}
 }

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -104,6 +104,7 @@ buferror
 choose_arena
 choose_arena_hard
 chunk_alloc
+chunk_alloc_default
 chunk_alloc_dss
 chunk_alloc_mmap
 chunk_boot

--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -44,3 +44,6 @@ JEMALLOC_EXPORT void *	@je_@memalign(size_t alignment, size_t size)
 #ifdef JEMALLOC_OVERRIDE_VALLOC
 JEMALLOC_EXPORT void *	@je_@valloc(size_t size) JEMALLOC_ATTR(malloc);
 #endif
+
+typedef void *(chunk_alloc_t)(size_t, size_t, bool *, unsigned);
+typedef bool (chunk_dealloc_t)(void *, size_t, unsigned);

--- a/src/arena.c
+++ b/src/arena.c
@@ -570,8 +570,8 @@ arena_chunk_init_hard(arena_t *arena)
 
 	zero = false;
 	malloc_mutex_unlock(&arena->lock);
-	chunk = (arena_chunk_t *)chunk_alloc(chunksize, chunksize, false,
-	    &zero, arena->dss_prec);
+	chunk = (arena_chunk_t *)chunk_alloc(arena, chunksize, chunksize,
+	    false, &zero, arena->dss_prec);
 	malloc_mutex_lock(&arena->lock);
 	if (chunk == NULL)
 		return (NULL);
@@ -668,7 +668,7 @@ arena_chunk_dealloc(arena_t *arena, arena_chunk_t *chunk)
 
 		arena->spare = chunk;
 		malloc_mutex_unlock(&arena->lock);
-		chunk_dealloc((void *)spare, chunksize, true);
+		chunk_dealloc(arena, (void *)spare, chunksize, true);
 		malloc_mutex_lock(&arena->lock);
 		if (config_stats)
 			arena->stats.mapped -= chunksize;
@@ -2319,6 +2319,8 @@ arena_new(arena_t *arena, unsigned ind)
 
 	arena->ind = ind;
 	arena->nthreads = 0;
+	arena->chunk_alloc = chunk_alloc_default;
+	arena->chunk_dealloc = (chunk_dealloc_t *)chunk_unmap;
 
 	if (malloc_mutex_init(&arena->lock))
 		return (true);

--- a/src/base.c
+++ b/src/base.c
@@ -32,7 +32,7 @@ base_pages_alloc(size_t minsize)
 	assert(minsize != 0);
 	csize = CHUNK_CEILING(minsize);
 	zero = false;
-	base_pages = chunk_alloc(csize, chunksize, true, &zero,
+	base_pages = chunk_alloc(NULL, csize, chunksize, true, &zero,
 	    chunk_dss_prec_get());
 	if (base_pages == NULL)
 		return (true);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1983,7 +1983,7 @@ a0alloc(size_t size, bool zero)
 	if (size <= arena_maxclass)
 		return (arena_malloc(arenas[0], size, zero, false));
 	else
-		return (huge_malloc(size, zero, huge_dss_prec_get(arenas[0])));
+		return (huge_malloc(NULL, size, zero, huge_dss_prec_get(arenas[0])));
 }
 
 void *

--- a/test/integration/chunk.c
+++ b/test/integration/chunk.c
@@ -1,0 +1,61 @@
+#include "test/jemalloc_test.h"
+
+chunk_alloc_t *old_alloc;
+chunk_dealloc_t *old_dealloc;
+
+bool
+chunk_dealloc(void *chunk, size_t size, unsigned arena_ind)
+{
+
+	return (old_dealloc(chunk, size, arena_ind));
+}
+
+void *
+chunk_alloc(size_t size, size_t alignment, bool *zero, unsigned arena_ind)
+{
+
+	return (old_alloc(size, alignment, zero, arena_ind));
+}
+
+TEST_BEGIN(test_chunk)
+{
+	void *p;
+	chunk_alloc_t *new_alloc;
+	chunk_dealloc_t *new_dealloc;
+	size_t old_size, new_size;
+
+	new_alloc = chunk_alloc;
+	new_dealloc = chunk_dealloc;
+	old_size = sizeof(chunk_alloc_t *);
+	new_size = sizeof(chunk_alloc_t *);
+
+	assert_d_eq(mallctl("arena.0.chunk.alloc", &old_alloc,
+	    &old_size, &new_alloc, new_size), 0,
+	    "Unexpected alloc error");
+	assert_ptr_ne(old_alloc, new_alloc,
+	    "Unexpected alloc error");
+	assert_d_eq(mallctl("arena.0.chunk.dealloc", &old_dealloc,
+	    &old_size, &new_dealloc, new_size), 0,
+	    "Unexpected dealloc error");
+	assert_ptr_ne(old_dealloc, new_dealloc,
+	    "Unexpected dealloc error");
+
+	p = mallocx(42, 0);
+	assert_ptr_ne(p, NULL, "Unexpected alloc error");
+	free(p);
+
+	assert_d_eq(mallctl("arena.0.chunk.alloc", NULL,
+	    NULL, &old_alloc, old_size), 0,
+	    "Unexpected alloc error");
+	assert_d_eq(mallctl("arena.0.chunk.dealloc", NULL,
+	    NULL, &old_dealloc, old_size), 0,
+	    "Unexpected dealloc error");
+}
+TEST_END
+
+int
+main(void)
+{
+
+	return (test(test_chunk));
+}


### PR DESCRIPTION
Add new mallctl endpoints "arena<i>.chunk.alloc" and
"arena<i>.chunk.dealloc" to allow userspace to configure
jemalloc's chunk allocator and deallocator on a per-arena
basis.
