### PR TITLE
Cross support for PNaCl.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,20 @@ if test "x${je_cv_osatomic}" = "xyes" ; then
 fi
 
 dnl ============================================================================
+dnl Check for madvise
+
+JE_COMPILABLE([madvise], [
+#include <sys/mman.h>
+], [
+	{
+		madvise((void*)0, 0, 0);
+	}
+], [je_cv_madvise])
+if test "x${je_cv_madvise}" = "xyes" ; then
+  AC_DEFINE([JEMALLOC_HAVE_MADVISE])
+fi
+
+dnl ============================================================================
 dnl Check whether __sync_{add,sub}_and_fetch() are available despite
 dnl __GCC_HAVE_SYNC_COMPARE_AND_SWAP_n macros being undefined.
 

--- a/src/chunk_mmap.c
+++ b/src/chunk_mmap.c
@@ -116,12 +116,12 @@ pages_trim(void *addr, size_t alloc_size, size_t leadsize, size_t size)
 bool
 pages_purge(void *addr, size_t length)
 {
-	bool unzeroed;
+	bool unzeroed = false;
 
 #ifdef _WIN32
 	VirtualAlloc(addr, length, MEM_RESET, PAGE_READWRITE);
 	unzeroed = true;
-#else
+#elifdef JEMALLOC_HAVE_MADVISE
 #  ifdef JEMALLOC_PURGE_MADVISE_DONTNEED
 #    define JEMALLOC_MADV_PURGE MADV_DONTNEED
 #    define JEMALLOC_MADV_ZEROS true


### PR DESCRIPTION
PNaCl/Newlib doesn't have ffsl/ffs, so I added a replacement utilizing gcc's ~~__builtin_clz~~ (_EDIT_: __builtin_ffs) and removed the requirement for it in configure.ac.
Additionally, PNaCl doesn't provide access to madvise, however there's nothing that can be done about it, so pages_purge is basically a no-op on that platform.
