### PR TITLE
avoid conflict with the POSIX timer_t type

### DIFF
--- a/test/include/test/timer.h
+++ b/test/include/test/timer.h
@@ -7,9 +7,9 @@
 typedef struct {
 	struct timeval tv0;
 	struct timeval tv1;
-} timer_t;
+} timedelta_t;
 
-void	timer_start(timer_t *timer);
-void	timer_stop(timer_t *timer);
-uint64_t	timer_usec(const timer_t *timer);
-void	timer_ratio(timer_t *a, timer_t *b, char *buf, size_t buflen);
+void	timer_start(timedelta_t *timer);
+void	timer_stop(timedelta_t *timer);
+uint64_t	timer_usec(const timedelta_t *timer);
+void	timer_ratio(timedelta_t *a, timedelta_t *b, char *buf, size_t buflen);

--- a/test/src/timer.c
+++ b/test/src/timer.c
@@ -1,21 +1,21 @@
 #include "test/jemalloc_test.h"
 
 void
-timer_start(timer_t *timer)
+timer_start(timedelta_t *timer)
 {
 
 	gettimeofday(&timer->tv0, NULL);
 }
 
 void
-timer_stop(timer_t *timer)
+timer_stop(timedelta_t *timer)
 {
 
 	gettimeofday(&timer->tv1, NULL);
 }
 
 uint64_t
-timer_usec(const timer_t *timer)
+timer_usec(const timedelta_t *timer)
 {
 
 	return (((timer->tv1.tv_sec - timer->tv0.tv_sec) * 1000000) +
@@ -23,7 +23,7 @@ timer_usec(const timer_t *timer)
 }
 
 void
-timer_ratio(timer_t *a, timer_t *b, char *buf, size_t buflen)
+timer_ratio(timedelta_t *a, timedelta_t *b, char *buf, size_t buflen)
 {
 	uint64_t t0 = timer_usec(a);
 	uint64_t t1 = timer_usec(b);

--- a/test/stress/microbench.c
+++ b/test/stress/microbench.c
@@ -1,7 +1,7 @@
 #include "test/jemalloc_test.h"
 
 JEMALLOC_INLINE_C void
-time_func(timer_t *timer, uint64_t nwarmup, uint64_t niter, void (*func)(void))
+time_func(timedelta_t *timer, uint64_t nwarmup, uint64_t niter, void (*func)(void))
 {
 	uint64_t i;
 
@@ -17,7 +17,7 @@ void
 compare_funcs(uint64_t nwarmup, uint64_t niter, const char *name_a,
     void (*func_a), const char *name_b, void (*func_b))
 {
-	timer_t timer_a, timer_b;
+	timedelta_t timer_a, timer_b;
 	char ratio_buf[6];
 
 	time_func(&timer_a, nwarmup, niter, func_a);


### PR DESCRIPTION
It hits a compilation error with glibc 2.19 without a rename.
