### PR TITLE
fix isqalloct (should call isdalloct)

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -827,7 +827,7 @@ isqalloc(void *ptr, size_t size, bool try_tcache)
 	if (config_fill && opt_quarantine)
 		quarantine(ptr);
 	else
-		idalloct(ptr, try_tcache);
+		isdalloct(ptr, size, try_tcache);
 }
 
 JEMALLOC_ALWAYS_INLINE void *


### PR DESCRIPTION
I screwed this up at some point but didn't notice because I hadn't regenerated the headers.
