### PR TITLE
Fixed iOS build

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1404,6 +1404,9 @@ case $os in
 	-mac*)
 		os=`echo $os | sed -e 's|mac|macos|'`
 		;;
+	# Apple iOS
+	-ios*)
+		;;
 	-linux-dietlibc)
 		os=-linux-dietlibc
 		;;


### PR DESCRIPTION
It seems iOS was deleted by a mistake while doing OpenRISC clean up
