### PR TITLE
autoconf: Support cygwin in addition to mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,7 @@ case "${host}" in
 	fi
 	abi="xcoff"
 	;;
-  *-*-mingw*)
+  *-*-mingw* | *-*-cygwin*)
 	abi="pecoff"
 	force_tls="0"
 	RPATH=""


### PR DESCRIPTION
Exisiting autoconf support for mingw is sufficient to also build with cygwin.
