### PR TITLE
Mark malloc_conf as a weak symbol

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -7,7 +7,7 @@
 malloc_tsd_data(, arenas, arena_t *, NULL)
 
 /* Runtime configuration options. */
-const char	*je_malloc_conf;
+const char	*je_malloc_conf JEMALLOC_ATTR(weak);
 bool	opt_abort =
 #ifdef JEMALLOC_DEBUG
     true


### PR DESCRIPTION
This fixes issue #113 - je_malloc_conf is not respected on OS X.

Tested on OS X Mavericks (clang-600.0.51) & Ubuntu 14.04.1 (4.8.2) against test case from https://github.com/daverigby/jemalloc_conf
