### PR TITLE
fine-grained locking for huge allocations (but not the default chunk allocator)

### DIFF
--- a/include/jemalloc/internal/huge.h
+++ b/include/jemalloc/internal/huge.h
@@ -25,7 +25,7 @@ void	huge_dalloc(tsd_t *tsd, void *ptr);
 size_t	huge_salloc(const void *ptr);
 prof_tctx_t	*huge_prof_tctx_get(const void *ptr);
 void	huge_prof_tctx_set(const void *ptr, prof_tctx_t *tctx);
-bool	huge_boot(void);
+bool	huge_boot(unsigned ncpus);
 void	huge_prefork(void);
 void	huge_postfork_parent(void);
 void	huge_postfork_child(void);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1044,11 +1044,6 @@ malloc_init_hard(void)
 		return (true);
 	}
 
-	if (huge_boot()) {
-		malloc_mutex_unlock(&init_lock);
-		return (true);
-	}
-
 	if (malloc_mutex_init(&arenas_lock)) {
 		malloc_mutex_unlock(&init_lock);
 		return (true);
@@ -1079,7 +1074,10 @@ malloc_init_hard(void)
 
 	malloc_mutex_unlock(&init_lock);
 	/**********************************************************************/
-	/* Recursive allocation may follow. */
+	/*
+	 * Recursive allocation may follow. Note that the huge allocator is not
+	 * booted here, as it is not currently necessary.
+	 */
 
 	ncpus = malloc_ncpus();
 
@@ -1097,6 +1095,11 @@ malloc_init_hard(void)
 	/* Done recursively allocating. */
 	/**********************************************************************/
 	malloc_mutex_lock(&init_lock);
+
+	if (huge_boot(ncpus)) {
+		malloc_mutex_unlock(&init_lock);
+		return (true);
+	}
 
 	if (mutex_boot()) {
 		malloc_mutex_unlock(&init_lock);


### PR DESCRIPTION
This does succeed in removing the huge allocation code as a bottleneck, but the default chunk allocator has a global lock so it only kills the serialization in the code paths that are not obtaining or releasing chunks like a no-op reallocation. The chosen hash function is quite bad, but the good hash function that's already in-tree is designed for strings and would be very expensive here.
