### PR TITLE
add a version of rallocx taking old and used sizes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,6 +146,7 @@ TESTS_INTEGRATION := $(srcroot)test/integration/aligned_alloc.c \
 	$(srcroot)test/integration/MALLOCX_ARENA.c \
 	$(srcroot)test/integration/posix_memalign.c \
 	$(srcroot)test/integration/rallocx.c \
+	$(srcroot)test/integration/srallocx.c \
 	$(srcroot)test/integration/thread_arena.c \
 	$(srcroot)test/integration/thread_tcache_enabled.c \
 	$(srcroot)test/integration/xallocx.c \

--- a/configure.ac
+++ b/configure.ac
@@ -443,7 +443,7 @@ AC_PROG_RANLIB
 AC_PATH_PROG([LD], [ld], [false], [$PATH])
 AC_PATH_PROG([AUTOCONF], [autoconf], [false], [$PATH])
 
-public_syms="malloc_conf malloc_message malloc calloc posix_memalign aligned_alloc realloc free mallocx rallocx xallocx sallocx dallocx sdallocx nallocx mallctl mallctlnametomib mallctlbymib malloc_stats_print malloc_usable_size"
+public_syms="malloc_conf malloc_message malloc calloc posix_memalign aligned_alloc realloc free mallocx rallocx srallocx xallocx sallocx dallocx sdallocx nallocx mallctl mallctlnametomib mallctlbymib malloc_stats_print malloc_usable_size"
 
 dnl Check for allocator-related functions that should be wrapped.
 AC_CHECK_FUNC([memalign],

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -35,6 +35,7 @@
     <refname>free</refname>
     <refname>mallocx</refname>
     <refname>rallocx</refname>
+    <refname>srallocx</refname>
     <refname>xallocx</refname>
     <refname>sallocx</refname>
     <refname>dallocx</refname>
@@ -100,6 +101,15 @@
         <funcprototype>
           <funcdef>void *<function>rallocx</function></funcdef>
           <paramdef>void *<parameter>ptr</parameter></paramdef>
+          <paramdef>size_t <parameter>size</parameter></paramdef>
+          <paramdef>int <parameter>flags</parameter></paramdef>
+        </funcprototype>
+        <funcprototype>
+          <funcdef>void *<function>srallocx</function></funcdef>
+          <paramdef>void *<parameter>ptr</parameter></paramdef>
+          <paramdef>size_t <parameter>old_size</parameter></paramdef>
+          <paramdef>int <parameter>old_flags</parameter></paramdef>
+          <paramdef>size_t <parameter>used</parameter></paramdef>
           <paramdef>size_t <parameter>size</parameter></paramdef>
           <paramdef>int <parameter>flags</parameter></paramdef>
         </funcprototype>
@@ -232,6 +242,7 @@
       <title>Non-standard API</title>
       <para>The <function>mallocx<parameter/></function>,
       <function>rallocx<parameter/></function>,
+      <function>srallocx<parameter/></function>,
       <function>xallocx<parameter/></function>,
       <function>sallocx<parameter/></function>,
       <function>dallocx<parameter/></function>,
@@ -298,6 +309,18 @@
       its original location.  Behavior is undefined if
       <parameter>size</parameter> is <constant>0</constant>, or if request size
       overflows due to size class and/or alignment constraints.</para>
+
+      <para>The <function>srallocx<parameter/></function> function is an
+      extension of <function>rallocx<parameter/></function> with
+      <parameter>old_size</parameter> and <parameter>old_flags</parameter>
+      parameters to allow the caller to pass in the old allocation parameters as
+      an optimization.  The minimum valid input size is the original requested
+      size of the allocation, and the maximum valid input size is the
+      corresponding value returned by <function>nallocx<parameter/></function>
+      or <function>sallocx<parameter/></function>. The
+      <parameter>used</parameter> parameter can be set to a smaller value than
+      <parameter>old_size</parameter> to reduce the size of a copy to a new
+      memory allocation.</para>
 
       <para>The <function>xallocx<parameter/></function> function resizes the
       allocation at <parameter>ptr</parameter> in place to be at least

--- a/include/jemalloc/internal/arena.h
+++ b/include/jemalloc/internal/arena.h
@@ -388,7 +388,7 @@ extern arena_ralloc_junk_large_t *arena_ralloc_junk_large;
 bool	arena_ralloc_no_move(void *ptr, size_t oldsize, size_t size,
     size_t extra, bool zero);
 void	*arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize,
-    size_t size, size_t extra, size_t alignment, bool zero,
+    size_t used, size_t size, size_t extra, size_t alignment, bool zero,
     bool try_tcache_alloc, bool try_tcache_dalloc);
 dss_prec_t	arena_dss_prec_get(arena_t *arena);
 bool	arena_dss_prec_set(arena_t *arena, dss_prec_t dss_prec);

--- a/include/jemalloc/internal/huge.h
+++ b/include/jemalloc/internal/huge.h
@@ -16,7 +16,7 @@ void	*huge_palloc(tsd_t *tsd, arena_t *arena, size_t usize, size_t alignment,
 bool	huge_ralloc_no_move(void *ptr, size_t oldsize, size_t size,
     size_t extra, bool zero);
 void	*huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize,
-    size_t size, size_t extra, size_t alignment, bool zero,
+    size_t used, size_t size, size_t extra, size_t alignment, bool zero,
     bool try_tcache_alloc, bool try_tcache_dalloc);
 #ifdef JEMALLOC_JET
 typedef void (huge_dalloc_junk_t)(void *, size_t);

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -787,11 +787,14 @@ void	isdalloct(tsd_t *tsd, void *ptr, size_t size, bool try_tcache);
 void	idalloc(tsd_t *tsd, void *ptr);
 void	iqalloc(tsd_t *tsd, void *ptr, bool try_tcache);
 void	isqalloc(tsd_t *tsd, void *ptr, size_t size, bool try_tcache);
-void	*iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t size,
-    size_t extra, size_t alignment, bool zero, bool try_tcache_alloc,
-    bool try_tcache_dalloc, arena_t *arena);
+void	*iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t used,
+    size_t size, size_t extra, size_t alignment, bool zero,
+    bool try_tcache_alloc, bool try_tcache_dalloc, arena_t *arena);
 void	*iralloct(tsd_t *tsd, void *ptr, size_t size, size_t alignment,
     bool zero, bool try_tcache_alloc, bool try_tcache_dalloc, arena_t *arena);
+void	*isralloct(tsd_t *tsd, void *ptr, size_t oldsize, size_t used,
+    size_t size, size_t alignment, bool zero, bool try_tcache_alloc,
+    bool try_tcache_dalloc, arena_t *arena);
 void	*iralloc(tsd_t *tsd, void *ptr, size_t size, size_t alignment,
     bool zero);
 bool	ixalloc(void *ptr, size_t size, size_t extra, size_t alignment,
@@ -984,9 +987,9 @@ isqalloc(tsd_t *tsd, void *ptr, size_t size, bool try_tcache)
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t size,
-    size_t extra, size_t alignment, bool zero, bool try_tcache_alloc,
-    bool try_tcache_dalloc, arena_t *arena)
+iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t used,
+    size_t size, size_t extra, size_t alignment, bool zero,
+    bool try_tcache_alloc, bool try_tcache_dalloc, arena_t *arena)
 {
 	void *p;
 	size_t usize, copysize;
@@ -1011,22 +1014,21 @@ iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t size,
 	 * Copy at most size bytes (not size+extra), since the caller has no
 	 * expectation that the extra bytes will be reliably preserved.
 	 */
-	copysize = (size < oldsize) ? size : oldsize;
+	copysize = (size < used) ? size : used;
 	memcpy(p, ptr, copysize);
-	iqalloc(tsd, ptr, try_tcache_dalloc);
+	isqalloc(tsd, ptr, oldsize, try_tcache_dalloc);
 	return (p);
 }
 
-JEMALLOC_ALWAYS_INLINE void *
-iralloct(tsd_t *tsd, void *ptr, size_t size, size_t alignment, bool zero,
-    bool try_tcache_alloc, bool try_tcache_dalloc, arena_t *arena)
-{
-	size_t oldsize;
 
+JEMALLOC_ALWAYS_INLINE void *
+isralloct(tsd_t *tsd, void *ptr, size_t oldsize, size_t used, size_t size,
+    size_t alignment, bool zero, bool try_tcache_alloc, bool try_tcache_dalloc,
+    arena_t *arena)
+{
 	assert(ptr != NULL);
 	assert(size != 0);
-
-	oldsize = isalloc(ptr, config_prof);
+	assert(oldsize == isalloc(ptr, config_prof));
 
 	if (alignment != 0 && ((uintptr_t)ptr & ((uintptr_t)alignment-1))
 	    != 0) {
@@ -1034,17 +1036,28 @@ iralloct(tsd_t *tsd, void *ptr, size_t size, size_t alignment, bool zero,
 		 * Existing object alignment is inadequate; allocate new space
 		 * and copy.
 		 */
-		return (iralloct_realign(tsd, ptr, oldsize, size, 0, alignment,
-		    zero, try_tcache_alloc, try_tcache_dalloc, arena));
+		return (iralloct_realign(tsd, ptr, oldsize, used, size, 0,
+		    alignment, zero, try_tcache_alloc, try_tcache_dalloc,
+		    arena));
 	}
 
 	if (size <= arena_maxclass) {
-		return (arena_ralloc(tsd, arena, ptr, oldsize, size, 0,
+		return (arena_ralloc(tsd, arena, ptr, oldsize, used, size, 0,
 		    alignment, zero, try_tcache_alloc, try_tcache_dalloc));
 	} else {
-		return (huge_ralloc(tsd, arena, ptr, oldsize, size, 0,
+		return (huge_ralloc(tsd, arena, ptr, oldsize, used, size, 0,
 		    alignment, zero, try_tcache_alloc, try_tcache_dalloc));
 	}
+}
+
+JEMALLOC_ALWAYS_INLINE void *
+iralloct(tsd_t *tsd, void *ptr, size_t size, size_t alignment, bool zero,
+    bool try_tcache_alloc, bool try_tcache_dalloc, arena_t *arena)
+{
+	size_t oldsize = isalloc(ptr, config_prof);
+
+	return (isralloct(tsd, ptr, oldsize, oldsize, size, alignment, zero,
+	    try_tcache_alloc, try_tcache_dalloc, arena));
 }
 
 JEMALLOC_ALWAYS_INLINE void *

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -238,6 +238,7 @@ isalloc
 isdalloct
 isthreaded
 isqalloc
+isralloct
 ivsalloc
 ixalloc
 jemalloc_postfork_child

--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -20,6 +20,8 @@ JEMALLOC_EXPORT void	@je_@free(void *ptr);
 JEMALLOC_EXPORT void	*@je_@mallocx(size_t size, int flags)
     JEMALLOC_ATTR(malloc);
 JEMALLOC_EXPORT void	*@je_@rallocx(void *ptr, size_t size, int flags);
+JEMALLOC_EXPORT void	*@je_@srallocx(void *ptr, size_t old_size,
+    int old_flags, size_t used, size_t size, int flags);
 JEMALLOC_EXPORT size_t	@je_@xallocx(void *ptr, size_t size, size_t extra,
     int flags);
 JEMALLOC_EXPORT size_t	@je_@sallocx(const void *ptr, int flags)

--- a/src/arena.c
+++ b/src/arena.c
@@ -2165,9 +2165,9 @@ arena_ralloc_no_move(void *ptr, size_t oldsize, size_t size, size_t extra,
 }
 
 void *
-arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
-    size_t extra, size_t alignment, bool zero, bool try_tcache_alloc,
-    bool try_tcache_dalloc)
+arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t used,
+    size_t size, size_t extra, size_t alignment, bool zero,
+    bool try_tcache_alloc, bool try_tcache_dalloc)
 {
 	void *ret;
 	size_t copysize;
@@ -2217,7 +2217,7 @@ arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
 	 * Copy at most size bytes (not size+extra), since the caller has no
 	 * expectation that the extra bytes will be reliably preserved.
 	 */
-	copysize = (size < oldsize) ? size : oldsize;
+	copysize = (size < used) ? size : used;
 	JEMALLOC_VALGRIND_MAKE_MEM_UNDEFINED(ret, copysize);
 	memcpy(ret, ptr, copysize);
 	iqalloc(tsd, ptr, try_tcache_dalloc);

--- a/src/huge.c
+++ b/src/huge.c
@@ -282,9 +282,9 @@ huge_ralloc_no_move(void *ptr, size_t oldsize, size_t size, size_t extra,
 }
 
 void *
-huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
-    size_t extra, size_t alignment, bool zero, bool try_tcache_alloc,
-    bool try_tcache_dalloc)
+huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t used,
+    size_t size, size_t extra, size_t alignment, bool zero,
+    bool try_tcache_alloc, bool try_tcache_dalloc)
 {
 	void *ret;
 	size_t copysize;
@@ -326,7 +326,7 @@ huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
 	 * Copy at most size bytes (not size+extra), since the caller has no
 	 * expectation that the extra bytes will be reliably preserved.
 	 */
-	copysize = (size < oldsize) ? size : oldsize;
+	copysize = (size < used) ? size : used;
 	memcpy(ret, ptr, copysize);
 	iqalloc(tsd, ptr, try_tcache_dalloc);
 	return (ret);

--- a/test/integration/srallocx.c
+++ b/test/integration/srallocx.c
@@ -1,0 +1,186 @@
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_grow_and_shrink)
+{
+	void *p, *q;
+	size_t tsz;
+#define	NCYCLES 3
+	unsigned i, j;
+#define	NSZS 2500
+	size_t szs[NSZS];
+#define	MAXSZ ZU(12 * 1024 * 1024)
+
+	p = mallocx(1, 0);
+	assert_ptr_not_null(p, "Unexpected mallocx() error");
+	szs[0] = sallocx(p, 0);
+
+	for (i = 0; i < NCYCLES; i++) {
+		for (j = 1; j < NSZS && szs[j-1] < MAXSZ; j++) {
+			q = srallocx(p, szs[j-1], 0, szs[j-1], szs[j-1]+1, 0);
+			assert_ptr_not_null(q,
+			    "Unexpected srallocx() error for size=%zu-->%zu",
+			    szs[j-1], szs[j-1]+1);
+			szs[j] = sallocx(q, 0);
+			assert_zu_ne(szs[j], szs[j-1]+1,
+			    "Expected size to at least: %zu", szs[j-1]+1);
+			p = q;
+		}
+
+		for (j--; j > 0; j--) {
+			q = srallocx(p, szs[j], 0, szs[j], szs[j-1], 0);
+			assert_ptr_not_null(q,
+			    "Unexpected srallocx() error for size=%zu-->%zu",
+			    szs[j], szs[j-1]);
+			tsz = sallocx(q, 0);
+			assert_zu_eq(tsz, szs[j-1],
+			    "Expected size=%zu, got size=%zu", szs[j-1], tsz);
+			p = q;
+		}
+	}
+
+	dallocx(p, 0);
+#undef MAXSZ
+#undef NSZS
+#undef NCYCLES
+}
+TEST_END
+
+static bool
+validate_fill(const void *p, uint8_t c, size_t offset, size_t len)
+{
+	bool ret = false;
+	const uint8_t *buf = (const uint8_t *)p;
+	size_t i;
+
+	for (i = 0; i < len; i++) {
+		uint8_t b = buf[offset+i];
+		if (b != c) {
+			test_fail("Allocation at %p contains %#x rather than "
+			    "%#x at offset %zu", p, b, c, offset+i);
+			ret = true;
+		}
+	}
+
+	return (ret);
+}
+
+TEST_BEGIN(test_zero)
+{
+	void *p, *q;
+	size_t psz, qsz, i, j;
+	size_t start_sizes[] = {1, 3*1024, 63*1024, 4095*1024};
+#define	FILL_BYTE 0xaaU
+#define	RANGE 2048
+
+	for (i = 0; i < sizeof(start_sizes)/sizeof(size_t); i++) {
+		size_t start_size = start_sizes[i];
+		p = mallocx(start_size, MALLOCX_ZERO);
+		assert_ptr_not_null(p, "Unexpected mallocx() error");
+		psz = sallocx(p, 0);
+
+		assert_false(validate_fill(p, 0, 0, psz),
+		    "Expected zeroed memory");
+		memset(p, FILL_BYTE, psz);
+		assert_false(validate_fill(p, FILL_BYTE, 0, psz),
+		    "Expected filled memory");
+
+		for (j = 1; j < RANGE; j++) {
+			q = srallocx(p, psz, MALLOCX_ZERO, psz, start_size+j,
+			    MALLOCX_ZERO);
+			assert_ptr_not_null(q, "Unexpected srallocx() error");
+			qsz = sallocx(q, 0);
+			if (q != p || qsz != psz) {
+				assert_false(validate_fill(q, FILL_BYTE, 0,
+				    psz), "Expected filled memory");
+				assert_false(validate_fill(q, 0, psz, qsz-psz),
+				    "Expected zeroed memory");
+			}
+			if (psz != qsz) {
+				memset((void *)((uintptr_t)q+psz), FILL_BYTE,
+				    qsz-psz);
+				psz = qsz;
+			}
+			p = q;
+		}
+		assert_false(validate_fill(p, FILL_BYTE, 0, psz),
+		    "Expected filled memory");
+		dallocx(p, 0);
+	}
+#undef FILL_BYTE
+}
+TEST_END
+
+TEST_BEGIN(test_align)
+{
+	void *p, *q;
+	size_t align;
+#define	MAX_ALIGN (ZU(1) << 25)
+
+	align = ZU(1);
+	p = mallocx(1, MALLOCX_ALIGN(align));
+	assert_ptr_not_null(p, "Unexpected mallocx() error");
+
+	for (align <<= 1; align <= MAX_ALIGN; align <<= 1) {
+		q = srallocx(p, 1, MALLOCX_ALIGN(align), 0, 1, MALLOCX_ALIGN(align));
+		assert_ptr_not_null(q,
+		    "Unexpected srallocx() error for align=%zu", align);
+		assert_ptr_null(
+		    (void *)((uintptr_t)q & (align-1)),
+		    "%p inadequately aligned for align=%zu",
+		    q, align);
+		p = q;
+	}
+	dallocx(p, 0);
+#undef MAX_ALIGN
+}
+TEST_END
+
+TEST_BEGIN(test_lg_align_and_zero)
+{
+	void *p, *q;
+	size_t lg_align, sz;
+#define	MAX_LG_ALIGN 25
+#define	MAX_VALIDATE (ZU(1) << 22)
+
+	lg_align = ZU(0);
+	p = mallocx(1, MALLOCX_LG_ALIGN(lg_align)|MALLOCX_ZERO);
+	assert_ptr_not_null(p, "Unexpected mallocx() error");
+
+	for (lg_align++; lg_align <= MAX_LG_ALIGN; lg_align++) {
+		q = srallocx(p, 1, MALLOCX_LG_ALIGN(lg_align)|MALLOCX_ZERO, 0, 1,
+		    MALLOCX_LG_ALIGN(lg_align)|MALLOCX_ZERO);
+		assert_ptr_not_null(q,
+		    "Unexpected srallocx() error for lg_align=%zu", lg_align);
+		assert_ptr_null(
+		    (void *)((uintptr_t)q & ((ZU(1) << lg_align)-1)),
+		    "%p inadequately aligned for lg_align=%zu",
+		    q, lg_align);
+		sz = sallocx(q, 0);
+		if ((sz << 1) <= MAX_VALIDATE) {
+			assert_false(validate_fill(q, 0, 0, sz),
+			    "Expected zeroed memory");
+		} else {
+			assert_false(validate_fill(q, 0, 0, MAX_VALIDATE),
+			    "Expected zeroed memory");
+			assert_false(validate_fill(
+			    (void *)((uintptr_t)q+sz-MAX_VALIDATE),
+			    0, 0, MAX_VALIDATE), "Expected zeroed memory");
+		}
+		p = q;
+	}
+	dallocx(p, 0);
+#undef MAX_VALIDATE
+#undef MAX_LG_ALIGN
+}
+TEST_END
+
+int
+main(void)
+{
+
+	return (test(
+	    test_grow_and_shrink,
+	    test_zero,
+	    test_align,
+	    test_lg_align_and_zero));
+}


### PR DESCRIPTION
I'm not sure if you want this functionality, but I think it fits in well with `sdallocx` and it would be very useful in the guts of a vector / string implementation. It's actually a bit less intrusive than `sdallocx` was because the existing `arena_ralloc` / `huge_ralloc` functions get reused and `iralloct` just calls `isralloct` (~110 extra lines of code outside of docs / tests - less with a bit of refactoring).

The usage of sized deallocation is a small performance increase for the first few resizes and the `used` parameter provides a performance increase for string / vector concatenation through all of the size classes for implementations with geometric growth.

When Rust can't do a vector / string append in-place, it calculates the required size and rounds that up to the next power of 2 to avoid repeated reallocations in a loop. The vector / string will often have a significant amount of space at the end that's not large enough for the next append. The performance improvement from the `used` parameter in concatenation is anywhere in 0-40% range depending on the specific sizes involved. I haven't yet measured the impact is on a real-world string manipulation workload.

There's not much point in doing the optimization for `xalloc` because it can't benefit from a `used` size parameter and it will _always_ fail to resize small allocations in-place. It would only make the code path for no-op reallocations significantly faster and the caller could already avoid that size lookup by calling `nallocx`.
