### PR TITLE
Fix variable declaration with no type in the configure script.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1363,7 +1363,7 @@ if test "x${enable_zone_allocator}" = "x1" ; then
   AC_DEFUN([JE_ZONE_PROGRAM],
     [AC_LANG_PROGRAM(
       [#include <malloc/malloc.h>],
-      [static foo[[sizeof($1) $2 sizeof(void *) * $3 ? 1 : -1]]]
+      [static int foo[[sizeof($1) $2 sizeof(void *) * $3 ? 1 : -1]]]
     )])
 
   AC_COMPILE_IFELSE([JE_ZONE_PROGRAM(malloc_zone_t,==,14)],[JEMALLOC_ZONE_VERSION=3],[


### PR DESCRIPTION
We recently attempted to turn several warnings into errors in Gecko (see [bug 1076698](https://bugzilla.mozilla.org/show_bug.cgi?id=1076698)). However, the checks made in jemalloc's configure script to determine the version of the malloc zone API in OSX trigger -Wimplicit-int, which breaks the build in that platform (I filed [bug 1080851](https://bugzilla.mozilla.org/show_bug.cgi?id=1080851) for that). The patch in this PR properly declares the `foo` vector in the configure script, thus silencing the warning. 
