### PR TITLE
Remove extra definition of je_tsd_boot on win32.

### DIFF
--- a/include/jemalloc/internal/tsd.h
+++ b/include/jemalloc/internal/tsd.h
@@ -364,12 +364,6 @@ a_name##tsd_boot(void)							\
 	a_name##tsd_boot1();						\
 	return (false);							\
 }									\
-a_attr bool								\
-a_name##tsd_boot(void)							\
-{									\
-									\
-	return (false);							\
-}									\
 /* Get/set. */								\
 a_attr a_type *								\
 a_name##tsd_get(void)							\


### PR DESCRIPTION
Looks like `je_tsd_boot` gets defined twice when building on Windows. This causes a [C2084 build error](https://treeherder.mozilla.org/ui/logviewer.html#?job_id=3229575&repo=try) whenever `tsd.h` gets included. I have tried to fix this by removing the trivial implementation of `je_tsd_boot`, since the other seems to be the correct one.
