### PR TITLE
Add programmatic introspection and discoverability for `mallctl`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.gcov.*
 
 /bin/jemalloc.sh
+/bin/mallctl
 
 /config.stamp
 /config.log

--- a/Makefile.in
+++ b/Makefile.in
@@ -73,7 +73,7 @@ endif
 LIBJEMALLOC := $(LIBPREFIX)jemalloc$(install_suffix)
 
 # Lists of files.
-BINS := $(srcroot)bin/pprof $(objroot)bin/jemalloc.sh
+BINS := $(srcroot)bin/pprof $(objroot)bin/jemalloc.sh $(objroot)bin/mallctl$(EXE)
 C_HDRS := $(objroot)include/jemalloc/jemalloc$(install_suffix).h
 C_SRCS := $(srcroot)src/jemalloc.c $(srcroot)src/arena.c \
 	$(srcroot)src/atomic.c $(srcroot)src/base.c $(srcroot)src/bitmap.c \
@@ -175,7 +175,7 @@ TESTS_OBJS := $(TESTS_UNIT_OBJS) $(TESTS_INTEGRATION_OBJS) $(TESTS_STRESS_OBJS)
 .SECONDARY : $(TESTS_OBJS)
 
 # Default target.
-all: build_lib
+all: build_lib build_bin
 
 dist: build_doc
 
@@ -271,6 +271,12 @@ $(objroot)test/stress/%$(EXE): $(objroot)test/stress/%.$(O) $(C_JET_OBJS) $(C_TE
 build_lib_shared: $(DSOS)
 build_lib_static: $(STATIC_LIBS)
 build_lib: build_lib_shared build_lib_static
+
+$(objroot)bin/%$(EXE): $(objroot)bin/%.c $(DSOS)
+	@mkdir -p $(@D)
+	$(CC) -I$(srcroot)include $(CFLAGS) -Wno-strict-aliasing $(LDTARGET) $^ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB)
+
+build_bin: $(BINS)
 
 install_bin:
 	install -d $(BINDIR)

--- a/bin/mallctl.c
+++ b/bin/mallctl.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2014 Conrad Meyer <cse.cem@gmail.com>
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <err.h>
+
+#include "jemalloc/internal/jemalloc_internal.h"
+
+static void
+usage(void)
+{
+
+	printf("Usage: mallctl [ctl.name]\n\n"
+
+	    "When invoked with no arguments, prints all defined controls and\n"
+	    "their current value.\n\n"
+
+	    "With a control name alone, prints the current value of that control.\n");
+	exit(0);
+}
+
+static int
+mib_next(size_t *mibout, size_t *miblen, size_t *mibin, size_t miblenin)
+{
+	static size_t next_mib[10], next_miblen = SIZE_MAX;
+
+	int error;
+
+	if (next_miblen == SIZE_MAX) {
+		next_miblen = sizeof(next_mib) / sizeof(next_mib[0]);
+		error = mallctlnametomib("introspect.next", next_mib, &next_miblen);
+		if (error) {
+			errno = error;
+			err(2, "mallctlnametomib");
+		}
+	}
+
+	error = mallctlbymib(next_mib, next_miblen,
+	    mibout, miblen, mibin, miblenin);
+	if (error != 0 && error != ENOENT) {
+		errno = error;
+		err(2, "mib_next");
+	}
+
+	return (error);
+}
+
+static const char *
+mib_name(size_t *mib, size_t len)
+{
+	static size_t name_mib[10], name_miblen = SIZE_MAX;
+	static char name_buf[256];
+
+	size_t bsz;
+	int error;
+
+	if (name_miblen == SIZE_MAX) {
+		name_miblen = sizeof(name_mib) / sizeof(name_mib[0]);
+		error = mallctlnametomib("introspect.name", name_mib, &name_miblen);
+		if (error) {
+			errno = error;
+			err(2, "mallctlnametomib");
+		}
+	}
+
+	bsz = sizeof(name_buf);
+	error = mallctlbymib(name_mib, name_miblen, name_buf, &bsz, mib, len);
+	if (error) {
+		errno = error;
+		err(2, "mib_name");
+	}
+
+	return (name_buf);
+}
+
+static unsigned
+mib_kind(size_t *mib, size_t len)
+{
+	static size_t kind_mib[10], kind_miblen = SIZE_MAX;
+
+	size_t usz;
+	unsigned res;
+	int error;
+
+	if (kind_miblen == SIZE_MAX) {
+		kind_miblen = sizeof(kind_mib) / sizeof(kind_mib[0]);
+		error = mallctlnametomib("introspect.kind", kind_mib, &kind_miblen);
+		if (error) {
+			errno = error;
+			err(2, "mallctlnametomib");
+		}
+	}
+
+	usz = sizeof(res);
+	error = mallctlbymib(kind_mib, kind_miblen, &res, &usz, mib, len);
+	if (error) {
+		errno = error;
+		err(2, "mib_kind");
+	}
+
+	return (res);
+}
+
+static size_t type_sizes[MCTLTYPE + 1] = {
+	[MCTLTYPE_U64] = sizeof(uint64_t),
+	[MCTLTYPE_SIZE] = sizeof(size_t),
+	[MCTLTYPE_SSIZE] = sizeof(ssize_t),
+	[MCTLTYPE_U32] = sizeof(uint32_t),
+	[MCTLTYPE_UINT] = sizeof(unsigned),
+	[MCTLTYPE_BOOL] = sizeof(bool),
+	[MCTLTYPE_STRP] = sizeof(const char *),
+};
+
+static void
+fmt_mib(size_t *mib, size_t miblen)
+{
+	static char buf[512];
+
+	const char *name;
+	unsigned kind;
+	size_t sz;
+	int error;
+
+	kind = mib_kind(mib, miblen * sizeof(*mib));
+	name = mib_name(mib, miblen * sizeof(*mib));
+
+	if (kind == MCTLTYPE_NODE) {
+		warnx("'%s' isn't a leaf node", name);
+		return;
+	}
+
+	printf("%s: ", name);
+
+	sz = sizeof(buf);
+	if (type_sizes[kind] > 0)
+		sz = type_sizes[kind];
+
+	error = mallctlbymib(mib, miblen, buf, &sz, NULL, 0);
+	if (error) {
+		printf("<error(%d): %s>\n", error, strerror(error));
+		return;
+	}
+
+	switch (kind) {
+	case MCTLTYPE_U64:
+		printf("%ju", (uintmax_t) *(uint64_t *)buf);
+		break;
+
+	case MCTLTYPE_SIZE:
+		printf("%zu", *(size_t *)buf);
+		break;
+
+	case MCTLTYPE_SSIZE:
+		printf("%zd", *(ssize_t *)buf);
+		break;
+
+	case MCTLTYPE_U32:
+		printf("%ju", (uintmax_t) *(uint32_t *)buf);
+		break;
+
+	case MCTLTYPE_UINT:
+		printf("%u", *(unsigned *)buf);
+		break;
+
+	case MCTLTYPE_BOOL:
+		printf("%u", (unsigned) *(bool *)buf);
+		break;
+
+	case MCTLTYPE_STRP:
+		printf("%s", *(const char **)buf);
+		break;
+
+	case MCTLTYPE_STRING:
+		printf("%.*s", (int)sz, buf);
+		break;
+
+	case MCTLTYPE_OPAQUE:
+		printf("<opaque>");
+		break;
+
+	default:
+		printf("<unrecognized kind %u>", kind);
+		break;
+	}
+
+	printf("\n");
+}
+
+int
+main(int argc, char **argv)
+{
+	size_t mib[10], miblen;
+	int error;
+
+	if (argc > 2)
+		usage();
+
+	/* XXX: One could also list all ctl's below a specific node. */
+	if (argc > 1) {
+		if (strcmp(argv[1], "-h") == 0 ||
+		    strcmp(argv[1], "--help") == 0)
+			usage();
+
+		miblen = sizeof(mib) / sizeof(mib[0]);
+		error = mallctlnametomib(argv[1], mib, &miblen);
+		if (error == ENOENT) {
+			printf("No such ctl `%s'\n", argv[1]);
+			return (1);
+		} else if (error) {
+			errno = error;
+			err(2, "mallctlnametomib");
+		}
+
+		fmt_mib(mib, miblen);
+	} else {
+		size_t lastlen = 0;
+
+		while (true) {
+			miblen = sizeof(mib);
+			error = mib_next(mib, &miblen, mib, lastlen);
+			if (error == ENOENT)
+				break;
+
+			lastlen = miblen;
+			fmt_mib(mib, miblen / sizeof(mib[0]));
+		}
+	}
+
+	return (0);
+}

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -7,6 +7,26 @@ typedef struct ctl_indexed_node_s ctl_indexed_node_t;
 typedef struct ctl_arena_stats_s ctl_arena_stats_t;
 typedef struct ctl_stats_s ctl_stats_t;
 
+#define	MCTLTYPE	0xf	/* Mask for the type */
+typedef enum {
+	MCTLTYPE_NODE	= 1,
+	MCTLTYPE_INT	= 2,
+	MCTLTYPE_STRING	= 3,
+	MCTLTYPE_S64	= 4,
+	MCTLTYPE_OPAQUE	= 5,
+	MCTLTYPE_STRUCT	= MCTLTYPE_OPAQUE,
+	MCTLTYPE_UINT	= 6,
+	MCTLTYPE_LONG	= 7,
+	MCTLTYPE_ULONG	= 8,
+	MCTLTYPE_U64	= 9,
+	/* Deviations from the FreeBSD kernel sysctl types: */
+	MCTLTYPE_U32	= 0xb,
+	MCTLTYPE_SIZE	= 0xc,		/* size_t and ssize_t */
+	MCTLTYPE_SSIZE	= 0xd,
+	MCTLTYPE_STRP	= 0xe,		/* Pointer to string */
+	MCTLTYPE_BOOL	= 0xf,
+} ctl_kind_t;
+
 #endif /* JEMALLOC_H_TYPES */
 /******************************************************************************/
 #ifdef JEMALLOC_H_STRUCTS
@@ -23,6 +43,7 @@ struct ctl_named_node_s {
 	const			ctl_node_t *children;
 	int			(*ctl)(const size_t *, size_t, void *, size_t *,
 	    void *, size_t);
+	unsigned		kind;
 };
 
 struct ctl_indexed_node_s {

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -199,8 +199,16 @@ CTL_PROTO(stats_mapped)
 #define	CHILD(t, c)							\
 	sizeof(c##_node) / sizeof(ctl_##t##_node_t),			\
 	(ctl_node_t *)c##_node,						\
-	NULL
-#define	CTL(c)	0, NULL, c##_ctl
+	NULL,								\
+	MCTLTYPE_NODE
+#define	CTL(c)		0, NULL, c##_ctl, MCTLTYPE_OPAQUE
+#define	CTL_BOOL(c)	0, NULL, c##_ctl, MCTLTYPE_BOOL
+#define	CTL_STRP(c)	0, NULL, c##_ctl, MCTLTYPE_STRP
+#define	CTL_SSZ(c)	0, NULL, c##_ctl, MCTLTYPE_SSIZE
+#define	CTL_SZ(c)	0, NULL, c##_ctl, MCTLTYPE_SIZE
+#define	CTL_U32(c)	0, NULL, c##_ctl, MCTLTYPE_U32
+#define	CTL_U64(c)	0, NULL, c##_ctl, MCTLTYPE_U64
+#define	CTL_UINT(c)	0, NULL, c##_ctl, MCTLTYPE_UINT
 
 /*
  * Only handles internal indexed nodes, since there are currently no external
@@ -209,66 +217,66 @@ CTL_PROTO(stats_mapped)
 #define	INDEX(i)	{false},	i##_index
 
 static const ctl_named_node_t	thread_tcache_node[] = {
-	{NAME("enabled"),	CTL(thread_tcache_enabled)},
+	{NAME("enabled"),	CTL_BOOL(thread_tcache_enabled)},
 	{NAME("flush"),		CTL(thread_tcache_flush)}
 };
 
 static const ctl_named_node_t	thread_prof_node[] = {
-	{NAME("name"),		CTL(thread_prof_name)},
-	{NAME("active"),	CTL(thread_prof_active)}
+	{NAME("name"),		CTL_STRP(thread_prof_name)},
+	{NAME("active"),	CTL_BOOL(thread_prof_active)}
 };
 
 static const ctl_named_node_t	thread_node[] = {
-	{NAME("arena"),		CTL(thread_arena)},
-	{NAME("allocated"),	CTL(thread_allocated)},
-	{NAME("allocatedp"),	CTL(thread_allocatedp)},
-	{NAME("deallocated"),	CTL(thread_deallocated)},
-	{NAME("deallocatedp"),	CTL(thread_deallocatedp)},
+	{NAME("arena"),		CTL_UINT(thread_arena)},
+	{NAME("allocated"),	CTL_U64(thread_allocated)},
+	{NAME("allocatedp"),	CTL_U64(thread_allocatedp)},
+	{NAME("deallocated"),	CTL_U64(thread_deallocated)},
+	{NAME("deallocatedp"),	CTL_U64(thread_deallocatedp)},
 	{NAME("tcache"),	CHILD(named, thread_tcache)},
 	{NAME("prof"),		CHILD(named, thread_prof)}
 };
 
 static const ctl_named_node_t	config_node[] = {
-	{NAME("debug"),		CTL(config_debug)},
-	{NAME("fill"),		CTL(config_fill)},
-	{NAME("lazy_lock"),	CTL(config_lazy_lock)},
-	{NAME("munmap"),	CTL(config_munmap)},
-	{NAME("prof"),		CTL(config_prof)},
-	{NAME("prof_libgcc"),	CTL(config_prof_libgcc)},
-	{NAME("prof_libunwind"), CTL(config_prof_libunwind)},
-	{NAME("stats"),		CTL(config_stats)},
-	{NAME("tcache"),	CTL(config_tcache)},
-	{NAME("tls"),		CTL(config_tls)},
-	{NAME("utrace"),	CTL(config_utrace)},
-	{NAME("valgrind"),	CTL(config_valgrind)},
-	{NAME("xmalloc"),	CTL(config_xmalloc)}
+	{NAME("debug"),		CTL_BOOL(config_debug)},
+	{NAME("fill"),		CTL_BOOL(config_fill)},
+	{NAME("lazy_lock"),	CTL_BOOL(config_lazy_lock)},
+	{NAME("munmap"),	CTL_BOOL(config_munmap)},
+	{NAME("prof"),		CTL_BOOL(config_prof)},
+	{NAME("prof_libgcc"),	CTL_BOOL(config_prof_libgcc)},
+	{NAME("prof_libunwind"), CTL_BOOL(config_prof_libunwind)},
+	{NAME("stats"),		CTL_BOOL(config_stats)},
+	{NAME("tcache"),	CTL_BOOL(config_tcache)},
+	{NAME("tls"),		CTL_BOOL(config_tls)},
+	{NAME("utrace"),	CTL_BOOL(config_utrace)},
+	{NAME("valgrind"),	CTL_BOOL(config_valgrind)},
+	{NAME("xmalloc"),	CTL_BOOL(config_xmalloc)}
 };
 
 static const ctl_named_node_t opt_node[] = {
-	{NAME("abort"),		CTL(opt_abort)},
-	{NAME("dss"),		CTL(opt_dss)},
-	{NAME("lg_chunk"),	CTL(opt_lg_chunk)},
-	{NAME("narenas"),	CTL(opt_narenas)},
-	{NAME("lg_dirty_mult"),	CTL(opt_lg_dirty_mult)},
-	{NAME("stats_print"),	CTL(opt_stats_print)},
-	{NAME("junk"),		CTL(opt_junk)},
-	{NAME("zero"),		CTL(opt_zero)},
-	{NAME("quarantine"),	CTL(opt_quarantine)},
-	{NAME("redzone"),	CTL(opt_redzone)},
-	{NAME("utrace"),	CTL(opt_utrace)},
-	{NAME("xmalloc"),	CTL(opt_xmalloc)},
-	{NAME("tcache"),	CTL(opt_tcache)},
-	{NAME("lg_tcache_max"),	CTL(opt_lg_tcache_max)},
-	{NAME("prof"),		CTL(opt_prof)},
-	{NAME("prof_prefix"),	CTL(opt_prof_prefix)},
-	{NAME("prof_active"),	CTL(opt_prof_active)},
-	{NAME("prof_thread_active_init"), CTL(opt_prof_thread_active_init)},
-	{NAME("lg_prof_sample"), CTL(opt_lg_prof_sample)},
-	{NAME("lg_prof_interval"), CTL(opt_lg_prof_interval)},
-	{NAME("prof_gdump"),	CTL(opt_prof_gdump)},
-	{NAME("prof_final"),	CTL(opt_prof_final)},
-	{NAME("prof_leak"),	CTL(opt_prof_leak)},
-	{NAME("prof_accum"),	CTL(opt_prof_accum)}
+	{NAME("abort"),		CTL_BOOL(opt_abort)},
+	{NAME("dss"),		CTL_STRP(opt_dss)},
+	{NAME("lg_chunk"),	CTL_SZ(opt_lg_chunk)},
+	{NAME("narenas"),	CTL_SZ(opt_narenas)},
+	{NAME("lg_dirty_mult"),	CTL_SSZ(opt_lg_dirty_mult)},
+	{NAME("stats_print"),	CTL_BOOL(opt_stats_print)},
+	{NAME("junk"),		CTL_BOOL(opt_junk)},
+	{NAME("zero"),		CTL_BOOL(opt_zero)},
+	{NAME("quarantine"),	CTL_SZ(opt_quarantine)},
+	{NAME("redzone"),	CTL_BOOL(opt_redzone)},
+	{NAME("utrace"),	CTL_BOOL(opt_utrace)},
+	{NAME("xmalloc"),	CTL_BOOL(opt_xmalloc)},
+	{NAME("tcache"),	CTL_BOOL(opt_tcache)},
+	{NAME("lg_tcache_max"),	CTL_SSZ(opt_lg_tcache_max)},
+	{NAME("prof"),		CTL_BOOL(opt_prof)},
+	{NAME("prof_prefix"),	CTL_STRP(opt_prof_prefix)},
+	{NAME("prof_active"),	CTL_BOOL(opt_prof_active)},
+	{NAME("prof_thread_active_init"), CTL_BOOL(opt_prof_thread_active_init)},
+	{NAME("lg_prof_sample"), CTL_SZ(opt_lg_prof_sample)},
+	{NAME("lg_prof_interval"), CTL_SSZ(opt_lg_prof_interval)},
+	{NAME("prof_gdump"),	CTL_BOOL(opt_prof_gdump)},
+	{NAME("prof_final"),	CTL_BOOL(opt_prof_final)},
+	{NAME("prof_leak"),	CTL_BOOL(opt_prof_leak)},
+	{NAME("prof_accum"),	CTL_BOOL(opt_prof_accum)}
 };
 
 static const ctl_named_node_t chunk_node[] = {
@@ -278,7 +286,7 @@ static const ctl_named_node_t chunk_node[] = {
 
 static const ctl_named_node_t arena_i_node[] = {
 	{NAME("purge"),		CTL(arena_i_purge)},
-	{NAME("dss"),		CTL(arena_i_dss)},
+	{NAME("dss"),		CTL_STRP(arena_i_dss)},
 	{NAME("chunk"),		CHILD(named, chunk)},
 };
 static const ctl_named_node_t super_arena_i_node[] = {
@@ -290,9 +298,9 @@ static const ctl_indexed_node_t arena_node[] = {
 };
 
 static const ctl_named_node_t arenas_bin_i_node[] = {
-	{NAME("size"),		CTL(arenas_bin_i_size)},
-	{NAME("nregs"),		CTL(arenas_bin_i_nregs)},
-	{NAME("run_size"),	CTL(arenas_bin_i_run_size)}
+	{NAME("size"),		CTL_SZ(arenas_bin_i_size)},
+	{NAME("nregs"),		CTL_U32(arenas_bin_i_nregs)},
+	{NAME("run_size"),	CTL_SZ(arenas_bin_i_run_size)}
 };
 static const ctl_named_node_t super_arenas_bin_i_node[] = {
 	{NAME(""),		CHILD(named, arenas_bin_i)}
@@ -303,7 +311,7 @@ static const ctl_indexed_node_t arenas_bin_node[] = {
 };
 
 static const ctl_named_node_t arenas_lrun_i_node[] = {
-	{NAME("size"),		CTL(arenas_lrun_i_size)}
+	{NAME("size"),		CTL_SZ(arenas_lrun_i_size)}
 };
 static const ctl_named_node_t super_arenas_lrun_i_node[] = {
 	{NAME(""),		CHILD(named, arenas_lrun_i)}
@@ -314,7 +322,7 @@ static const ctl_indexed_node_t arenas_lrun_node[] = {
 };
 
 static const ctl_named_node_t arenas_hchunk_i_node[] = {
-	{NAME("size"),		CTL(arenas_hchunk_i_size)}
+	{NAME("size"),		CTL_SZ(arenas_hchunk_i_size)}
 };
 static const ctl_named_node_t super_arenas_hchunk_i_node[] = {
 	{NAME(""),		CHILD(named, arenas_hchunk_i)}
@@ -325,67 +333,67 @@ static const ctl_indexed_node_t arenas_hchunk_node[] = {
 };
 
 static const ctl_named_node_t arenas_node[] = {
-	{NAME("narenas"),	CTL(arenas_narenas)},
-	{NAME("initialized"),	CTL(arenas_initialized)},
-	{NAME("quantum"),	CTL(arenas_quantum)},
-	{NAME("page"),		CTL(arenas_page)},
-	{NAME("tcache_max"),	CTL(arenas_tcache_max)},
-	{NAME("nbins"),		CTL(arenas_nbins)},
-	{NAME("nhbins"),	CTL(arenas_nhbins)},
+	{NAME("narenas"),	CTL_UINT(arenas_narenas)},
+	{NAME("initialized"),	CTL_BOOL(arenas_initialized)},
+	{NAME("quantum"),	CTL_SZ(arenas_quantum)},
+	{NAME("page"),		CTL_SZ(arenas_page)},
+	{NAME("tcache_max"),	CTL_SZ(arenas_tcache_max)},
+	{NAME("nbins"),		CTL_UINT(arenas_nbins)},
+	{NAME("nhbins"),	CTL_UINT(arenas_nhbins)},
 	{NAME("bin"),		CHILD(indexed, arenas_bin)},
-	{NAME("nlruns"),	CTL(arenas_nlruns)},
+	{NAME("nlruns"),	CTL_UINT(arenas_nlruns)},
 	{NAME("lrun"),		CHILD(indexed, arenas_lrun)},
-	{NAME("nhchunks"),	CTL(arenas_nhchunks)},
+	{NAME("nhchunks"),	CTL_UINT(arenas_nhchunks)},
 	{NAME("hchunk"),	CHILD(indexed, arenas_hchunk)},
-	{NAME("extend"),	CTL(arenas_extend)}
+	{NAME("extend"),	CTL_UINT(arenas_extend)}
 };
 
 static const ctl_named_node_t	prof_node[] = {
-	{NAME("thread_active_init"), CTL(prof_thread_active_init)},
-	{NAME("active"),	CTL(prof_active)},
-	{NAME("dump"),		CTL(prof_dump)},
-	{NAME("reset"),		CTL(prof_reset)},
-	{NAME("interval"),	CTL(prof_interval)},
-	{NAME("lg_sample"),	CTL(lg_prof_sample)}
+	{NAME("thread_active_init"), CTL_BOOL(prof_thread_active_init)},
+	{NAME("active"),	CTL_BOOL(prof_active)},
+	{NAME("dump"),		CTL_STRP(prof_dump)},
+	{NAME("reset"),		CTL_SZ(prof_reset)},
+	{NAME("interval"),	CTL_U64(prof_interval)},
+	{NAME("lg_sample"),	CTL_SZ(lg_prof_sample)}
 };
 
 static const ctl_named_node_t stats_chunks_node[] = {
-	{NAME("current"),	CTL(stats_chunks_current)},
-	{NAME("total"),		CTL(stats_chunks_total)},
-	{NAME("high"),		CTL(stats_chunks_high)}
+	{NAME("current"),	CTL_SZ(stats_chunks_current)},
+	{NAME("total"),		CTL_U64(stats_chunks_total)},
+	{NAME("high"),		CTL_SZ(stats_chunks_high)}
 };
 
 static const ctl_named_node_t stats_arenas_i_small_node[] = {
-	{NAME("allocated"),	CTL(stats_arenas_i_small_allocated)},
-	{NAME("nmalloc"),	CTL(stats_arenas_i_small_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_small_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_small_nrequests)}
+	{NAME("allocated"),	CTL_SZ(stats_arenas_i_small_allocated)},
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_small_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_small_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_small_nrequests)}
 };
 
 static const ctl_named_node_t stats_arenas_i_large_node[] = {
-	{NAME("allocated"),	CTL(stats_arenas_i_large_allocated)},
-	{NAME("nmalloc"),	CTL(stats_arenas_i_large_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_large_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_large_nrequests)}
+	{NAME("allocated"),	CTL_SZ(stats_arenas_i_large_allocated)},
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_large_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_large_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_large_nrequests)}
 };
 
 static const ctl_named_node_t stats_arenas_i_huge_node[] = {
-	{NAME("allocated"),	CTL(stats_arenas_i_huge_allocated)},
-	{NAME("nmalloc"),	CTL(stats_arenas_i_huge_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_huge_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_huge_nrequests)}
+	{NAME("allocated"),	CTL_SZ(stats_arenas_i_huge_allocated)},
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_huge_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_huge_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_huge_nrequests)}
 };
 
 static const ctl_named_node_t stats_arenas_i_bins_j_node[] = {
-	{NAME("nmalloc"),	CTL(stats_arenas_i_bins_j_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_bins_j_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_bins_j_nrequests)},
-	{NAME("curregs"),	CTL(stats_arenas_i_bins_j_curregs)},
-	{NAME("nfills"),	CTL(stats_arenas_i_bins_j_nfills)},
-	{NAME("nflushes"),	CTL(stats_arenas_i_bins_j_nflushes)},
-	{NAME("nruns"),		CTL(stats_arenas_i_bins_j_nruns)},
-	{NAME("nreruns"),	CTL(stats_arenas_i_bins_j_nreruns)},
-	{NAME("curruns"),	CTL(stats_arenas_i_bins_j_curruns)}
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_bins_j_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_bins_j_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_bins_j_nrequests)},
+	{NAME("curregs"),	CTL_SZ(stats_arenas_i_bins_j_curregs)},
+	{NAME("nfills"),	CTL_U64(stats_arenas_i_bins_j_nfills)},
+	{NAME("nflushes"),	CTL_U64(stats_arenas_i_bins_j_nflushes)},
+	{NAME("nruns"),		CTL_U64(stats_arenas_i_bins_j_nruns)},
+	{NAME("nreruns"),	CTL_U64(stats_arenas_i_bins_j_nreruns)},
+	{NAME("curruns"),	CTL_SZ(stats_arenas_i_bins_j_curruns)}
 };
 static const ctl_named_node_t super_stats_arenas_i_bins_j_node[] = {
 	{NAME(""),		CHILD(named, stats_arenas_i_bins_j)}
@@ -396,10 +404,10 @@ static const ctl_indexed_node_t stats_arenas_i_bins_node[] = {
 };
 
 static const ctl_named_node_t stats_arenas_i_lruns_j_node[] = {
-	{NAME("nmalloc"),	CTL(stats_arenas_i_lruns_j_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_lruns_j_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_lruns_j_nrequests)},
-	{NAME("curruns"),	CTL(stats_arenas_i_lruns_j_curruns)}
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_lruns_j_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_lruns_j_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_lruns_j_nrequests)},
+	{NAME("curruns"),	CTL_SZ(stats_arenas_i_lruns_j_curruns)}
 };
 static const ctl_named_node_t super_stats_arenas_i_lruns_j_node[] = {
 	{NAME(""),		CHILD(named, stats_arenas_i_lruns_j)}
@@ -410,10 +418,10 @@ static const ctl_indexed_node_t stats_arenas_i_lruns_node[] = {
 };
 
 static const ctl_named_node_t stats_arenas_i_hchunks_j_node[] = {
-	{NAME("nmalloc"),	CTL(stats_arenas_i_hchunks_j_nmalloc)},
-	{NAME("ndalloc"),	CTL(stats_arenas_i_hchunks_j_ndalloc)},
-	{NAME("nrequests"),	CTL(stats_arenas_i_hchunks_j_nrequests)},
-	{NAME("curhchunks"),	CTL(stats_arenas_i_hchunks_j_curhchunks)}
+	{NAME("nmalloc"),	CTL_U64(stats_arenas_i_hchunks_j_nmalloc)},
+	{NAME("ndalloc"),	CTL_U64(stats_arenas_i_hchunks_j_ndalloc)},
+	{NAME("nrequests"),	CTL_U64(stats_arenas_i_hchunks_j_nrequests)},
+	{NAME("curhchunks"),	CTL_SZ(stats_arenas_i_hchunks_j_curhchunks)}
 };
 static const ctl_named_node_t super_stats_arenas_i_hchunks_j_node[] = {
 	{NAME(""),		CHILD(named, stats_arenas_i_hchunks_j)}
@@ -424,14 +432,14 @@ static const ctl_indexed_node_t stats_arenas_i_hchunks_node[] = {
 };
 
 static const ctl_named_node_t stats_arenas_i_node[] = {
-	{NAME("nthreads"),	CTL(stats_arenas_i_nthreads)},
-	{NAME("dss"),		CTL(stats_arenas_i_dss)},
-	{NAME("pactive"),	CTL(stats_arenas_i_pactive)},
-	{NAME("pdirty"),	CTL(stats_arenas_i_pdirty)},
-	{NAME("mapped"),	CTL(stats_arenas_i_mapped)},
-	{NAME("npurge"),	CTL(stats_arenas_i_npurge)},
-	{NAME("nmadvise"),	CTL(stats_arenas_i_nmadvise)},
-	{NAME("purged"),	CTL(stats_arenas_i_purged)},
+	{NAME("nthreads"),	CTL_UINT(stats_arenas_i_nthreads)},
+	{NAME("dss"),		CTL_STRP(stats_arenas_i_dss)},
+	{NAME("pactive"),	CTL_SZ(stats_arenas_i_pactive)},
+	{NAME("pdirty"),	CTL_SZ(stats_arenas_i_pdirty)},
+	{NAME("mapped"),	CTL_SZ(stats_arenas_i_mapped)},
+	{NAME("npurge"),	CTL_U64(stats_arenas_i_npurge)},
+	{NAME("nmadvise"),	CTL_U64(stats_arenas_i_nmadvise)},
+	{NAME("purged"),	CTL_U64(stats_arenas_i_purged)},
 	{NAME("small"),		CHILD(named, stats_arenas_i_small)},
 	{NAME("large"),		CHILD(named, stats_arenas_i_large)},
 	{NAME("huge"),		CHILD(named, stats_arenas_i_huge)},
@@ -449,16 +457,16 @@ static const ctl_indexed_node_t stats_arenas_node[] = {
 
 static const ctl_named_node_t stats_node[] = {
 	{NAME("cactive"),	CTL(stats_cactive)},
-	{NAME("allocated"),	CTL(stats_allocated)},
-	{NAME("active"),	CTL(stats_active)},
-	{NAME("mapped"),	CTL(stats_mapped)},
+	{NAME("allocated"),	CTL_SZ(stats_allocated)},
+	{NAME("active"),	CTL_SZ(stats_active)},
+	{NAME("mapped"),	CTL_SZ(stats_mapped)},
 	{NAME("chunks"),	CHILD(named, stats_chunks)},
 	{NAME("arenas"),	CHILD(indexed, stats_arenas)}
 };
 
 static const ctl_named_node_t	root_node[] = {
-	{NAME("version"),	CTL(version)},
-	{NAME("epoch"),		CTL(epoch)},
+	{NAME("version"),	CTL_STRP(version)},
+	{NAME("epoch"),		CTL_U64(epoch)},
 	{NAME("thread"),	CHILD(named, thread)},
 	{NAME("config"),	CHILD(named, config)},
 	{NAME("opt"),		CHILD(named, opt)},
@@ -475,6 +483,13 @@ static const ctl_named_node_t super_root_node[] = {
 #undef CHILD
 #undef CTL
 #undef INDEX
+#undef CTL_BOOL
+#undef CTL_STRP
+#undef CTL_SSZ
+#undef CTL_SZ
+#undef CTL_U32
+#undef CTL_U64
+#undef CTL_UINT
 
 /******************************************************************************/
 

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -442,6 +442,39 @@ TEST_BEGIN(test_introspect_next)
 }
 TEST_END
 
+TEST_BEGIN(test_introspect_kind)
+{
+	struct {
+		const char *ctl_name;
+		unsigned exp_kind;
+	} tcases[] = {
+		{ "epoch", MCTLTYPE_U64 },
+		{ "version", MCTLTYPE_STRP },
+		{ "opt.zero", MCTLTYPE_BOOL },
+		{ NULL, 0 }
+	};
+	size_t mib[6], kindsz, miblen;
+	unsigned kind, i;
+	int error;
+
+	kindsz = sizeof(kind);
+
+	for (i = 0; tcases[i].ctl_name != NULL; i++) {
+		miblen = sizeof(mib) / sizeof(mib[0]);
+		assert_d_eq(mallctlnametomib(tcases[i].ctl_name, mib, &miblen),
+		    0, "unexpected");
+
+		error = mallctl("introspect.kind", &kind, &kindsz, mib,
+		    miblen * sizeof(*mib));
+		assert_d_eq(error, 0, "%u: mallctl: %s", i, strerror(error));
+		assert_zu_eq(kindsz, sizeof(kind), "%u: unexpected wrong size",
+		    i);
+
+		assert_u_eq(kind, tcases[i].exp_kind, "%u: wrong ctl type", i);
+	}
+}
+TEST_END
+
 int
 main(void)
 {
@@ -465,5 +498,6 @@ main(void)
 	    test_arenas_hchunk_constants,
 	    test_arenas_extend,
 	    test_stats_arenas,
-	    test_introspect_next));
+	    test_introspect_next,
+	    test_introspect_kind));
 }

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -418,6 +418,30 @@ TEST_BEGIN(test_stats_arenas)
 }
 TEST_END
 
+TEST_BEGIN(test_introspect_next)
+{
+	size_t mib[6], miblen, lastlen, n;
+	int error;
+
+	n = lastlen = 0;
+
+	while (true) {
+		miblen = sizeof(mib);
+		error = mallctl("introspect.next", mib, &miblen, mib, lastlen);
+		if (error == ENOENT)
+			break;
+		assert_d_eq(error, 0, "mallctl: %s", strerror(error));
+		if (error)
+			break;
+
+		lastlen = miblen;
+		n++;
+	}
+
+	assert_zu_gt(n, 5, "mallctl next");
+}
+TEST_END
+
 int
 main(void)
 {
@@ -440,5 +464,6 @@ main(void)
 	    test_arenas_lrun_constants,
 	    test_arenas_hchunk_constants,
 	    test_arenas_extend,
-	    test_stats_arenas));
+	    test_stats_arenas,
+	    test_introspect_next));
 }

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -475,6 +475,40 @@ TEST_BEGIN(test_introspect_kind)
 }
 TEST_END
 
+TEST_BEGIN(test_introspect_name)
+{
+	const char *tcases[] = {
+		"epoch",
+		"opt.zero",
+		"thread.tcache.enabled",
+		"arena.0.chunk.dalloc",
+		NULL
+	};
+	const char **tcase;
+	char output[256];
+	size_t mib[6], outsz, miblen;
+	int error;
+
+	for (tcase = tcases; *tcase; tcase++) {
+		miblen = sizeof(mib) / sizeof(mib[0]);
+		assert_d_eq(mallctlnametomib(*tcase, mib, &miblen), 0,
+		    "unexpected");
+
+		outsz = sizeof(output);
+		error = mallctl("introspect.name", output, &outsz, mib,
+		    miblen * sizeof(*mib));
+		assert_d_eq(error, 0, "%lu: mallctl: %s", tcase - tcases,
+		    strerror(error));
+		if (error == 0) {
+			assert_str_eq(output, *tcase, "%lu: unexpected",
+			    tcase - tcases);
+			assert_zu_eq(outsz, strlen(*tcase) + 1,
+			    "%lu: unexpected wrong size", tcase - tcases);
+		}
+	}
+}
+TEST_END
+
 int
 main(void)
 {
@@ -499,5 +533,6 @@ main(void)
 	    test_arenas_extend,
 	    test_stats_arenas,
 	    test_introspect_next,
-	    test_introspect_kind));
+	    test_introspect_kind,
+	    test_introspect_name));
 }


### PR DESCRIPTION
In the spirit of FreeBSD sysctls, it is useful to have at least somewhat reliable programmatic access to the intended types of these sorts of tunables. To that end, this patch series:

* Adds type information to most `mallctl` nodes / oids
* Adds a special node to enumerate nodes (`introspect.next`) (like `sysctl.next` or magic MIB 0.2 on FreeBSD)
* Adds a special node to return type information (`introspect.kind`) (like `sysctl.oidfmt` or magic MIB 0.4)
* Adds a special node to return the name for a given MIB (`introspect.name`) (like `sysctl.name` or magic MIB 0.1)

Finally, I added simple program to explore the default configurations, `mallctl(1)`. [Here's a gist of some example output.](https://gist.github.com/cemeyer/dbc39bc7cef06fc7ba4a)