### PR TITLE
Implement stats.bookkeeping.

### DIFF
--- a/include/jemalloc/internal/base.h
+++ b/include/jemalloc/internal/base.h
@@ -9,6 +9,10 @@
 /******************************************************************************/
 #ifdef JEMALLOC_H_EXTERNS
 
+/* base_mtx is exported to protect base_allocated */
+extern malloc_mutex_t	base_mtx;
+extern size_t base_allocated;
+
 void	*base_alloc(size_t size);
 void	*base_calloc(size_t number, size_t size);
 extent_node_t *base_node_alloc(void);

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -52,6 +52,7 @@ struct ctl_arena_stats_s {
 struct ctl_stats_s {
 	size_t			allocated;
 	size_t			active;
+	size_t			bookkeeping;
 	size_t			mapped;
 	struct {
 		size_t		current;	/* stats_chunks.curchunks */

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -397,6 +397,9 @@ extern size_t const	index2size_tab[NSIZES];
  */
 extern uint8_t const	size2index_tab[];
 
+extern malloc_mutex_t a0_mtx;
+extern size_t a0_allocated;
+
 arena_t	*a0get(void);
 void	*a0malloc(size_t size);
 void	*a0calloc(size_t num, size_t size);

--- a/include/jemalloc/internal/quarantine.h
+++ b/include/jemalloc/internal/quarantine.h
@@ -29,6 +29,10 @@ struct quarantine_s {
 /******************************************************************************/
 #ifdef JEMALLOC_H_EXTERNS
 
+extern malloc_mutex_t quarantine_allocated_mtx;
+extern size_t quarantine_allocated;
+
+bool	quarantine_boot(void);
 void	quarantine_alloc_hook_work(tsd_t *tsd);
 void	quarantine(tsd_t *tsd, void *ptr);
 void	quarantine_cleanup(tsd_t *tsd);

--- a/src/base.c
+++ b/src/base.c
@@ -4,7 +4,7 @@
 /******************************************************************************/
 /* Data. */
 
-static malloc_mutex_t	base_mtx;
+malloc_mutex_t	base_mtx;
 
 /*
  * Current pages that are being used for internal memory allocations.  These
@@ -15,6 +15,8 @@ static void		*base_pages;
 static void		*base_next_addr;
 static void		*base_past_addr; /* Addr immediately past base_pages. */
 static extent_node_t	*base_nodes;
+
+size_t base_allocated;
 
 /******************************************************************************/
 
@@ -54,6 +56,8 @@ base_alloc(size_t size)
 	/* Allocate. */
 	ret = base_next_addr;
 	base_next_addr = (void *)((uintptr_t)base_next_addr + csize);
+	if (config_stats)
+		base_allocated += csize;
 	malloc_mutex_unlock(&base_mtx);
 	JEMALLOC_VALGRIND_MAKE_MEM_UNDEFINED(ret, csize);
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -720,6 +720,21 @@ ctl_refresh(void)
 		malloc_mutex_lock(&a0_mtx);
 		ctl_stats.bookkeeping += a0_allocated;
 		malloc_mutex_unlock(&a0_mtx);
+
+		if (config_tcache) {
+			for (i = 0; i < ctl_stats.narenas; i++) {
+				arena_t *arena = tarenas[i];
+				if (arena != NULL) {
+					tcache_t *tcache;
+
+					malloc_mutex_lock(&arena->lock);
+					ql_foreach(tcache, &arena->tcache_ql, link) {
+						ctl_stats.bookkeeping += isalloc(tcache, false);
+					}
+					malloc_mutex_unlock(&arena->lock);
+				}
+			}
+		}
 	}
 
 	ctl_epoch++;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -735,6 +735,12 @@ ctl_refresh(void)
 				}
 			}
 		}
+
+		if (opt_quarantine) {
+			malloc_mutex_lock(&quarantine_allocated_mtx);
+			ctl_stats.bookkeeping += quarantine_allocated;
+			malloc_mutex_unlock(&quarantine_allocated_mtx);
+		}
 	}
 
 	ctl_epoch++;

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1111,6 +1111,11 @@ malloc_init_hard(void)
 
 	arena_boot();
 
+	if (opt_quarantine && quarantine_boot()) {
+		malloc_mutex_unlock(&init_lock);
+		return (true);
+	}
+
 	if (config_tcache && tcache_boot()) {
 		malloc_mutex_unlock(&init_lock);
 		return (true);


### PR DESCRIPTION
This is a first and crude attempt at issue #163, but hopefully it's on the right track.

This attempts to account for:
    - All base allocations, including arena headers;
    - All chunk headers;
    - Extent nodes used for huge allocations;
    - All allocations performed via `a0{m,c}alloc`.

This leaves missing:
    - Allocations of `tcache_t`;
    - Allocations of `quarantine_t`;
    - Allocations made for heap profiling.

Thoughts?