### PR TITLE
ignore MALLOC_CONF in set{uid,gid,cap} binaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1108,6 +1108,24 @@ fi
 
 CPPFLAGS="$CPPFLAGS -D_REENTRANT"
 
+dnl Check if the GNU-specific secure_getenv function exists.
+AC_CHECK_FUNC([secure_getenv],
+              [have_secure_getenv="1"],
+              [have_secure_getenv="0"]
+             )
+if test "x$have_secure_getenv" = "x1" ; then
+  AC_DEFINE([JEMALLOC_HAVE_SECURE_GETENV], [ ])
+fi
+
+dnl Check if the Solaris/BSD issetugid function exists.
+AC_CHECK_FUNC([issetugid],
+              [have_issetugid="1"],
+              [have_issetugid="0"]
+             )
+if test "x$have_issetugid" = "x1" ; then
+  AC_DEFINE([JEMALLOC_HAVE_ISSETUGID], [ ])
+fi
+
 dnl Check whether the BSD-specific _malloc_thread_cleanup() exists.  If so, use
 dnl it rather than pthreads TSD cleanup functions to support cleanup during
 dnl thread exit, in order to avoid pthreads library recursion during

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -67,6 +67,16 @@
 #undef JEMALLOC_OSSPIN
 
 /*
+ * Defined if secure_getenv(3) is available.
+ */
+#undef JEMALLOC_HAVE_SECURE_GETENV
+
+/*
+ * Defined if issetugid(2) is available.
+ */
+#undef JEMALLOC_HAVE_ISSETUGID
+
+/*
  * Defined if _malloc_thread_cleanup() exists.  At least in the case of
  * FreeBSD, pthread_key_create() allocates, which if used during malloc
  * bootstrapping will cause recursion into the pthreads library.  Therefore, if

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -197,6 +197,23 @@ typedef struct {
 #  define UTRACE(a, b, c)
 #endif
 
+#ifndef JEMALLOC_HAVE_SECURE_GETENV
+#  ifndef JEMALLOC_HAVE_ISSETUGID
+static char *secure_getenv(const char *name) {
+
+	return getenv(name);
+}
+#  else
+static char *secure_getenv(const char *name) {
+
+	if (issetugid() == 0)
+		return getenv(name);
+	else
+		return NULL;
+}
+#  endif
+#endif
+
 /******************************************************************************/
 /*
  * Function prototypes for static functions that are referenced prior to
@@ -824,7 +841,7 @@ malloc_conf_init(void)
 #endif
 			    ;
 
-			if ((opts = getenv(envname)) != NULL) {
+			if ((opts = secure_getenv(envname)) != NULL) {
 				/*
 				 * Do nothing; opts is already initialized to
 				 * the value of the MALLOC_CONF environment


### PR DESCRIPTION
This eliminates the malloc tunables as tools for an attacker.

Closes #173
