### PR TITLE
Don't depend on stdbool.h for jemalloc.h

### DIFF
--- a/include/jemalloc/internal/chunk.h
+++ b/include/jemalloc/internal/chunk.h
@@ -46,9 +46,9 @@ void	*chunk_alloc_arena(chunk_alloc_t *chunk_alloc,
     chunk_dalloc_t *chunk_dalloc, unsigned arena_ind, void *new_addr,
     size_t size, size_t alignment, bool *zero);
 void	*chunk_alloc_default(void *new_addr, size_t size, size_t alignment,
-    bool *zero, unsigned arena_ind);
+    int *zero, unsigned arena_ind);
 void	chunk_unmap(void *chunk, size_t size);
-bool	chunk_dalloc_default(void *chunk, size_t size, unsigned arena_ind);
+int	chunk_dalloc_default(void *chunk, size_t size, unsigned arena_ind);
 bool	chunk_boot(void);
 void	chunk_prefork(void);
 void	chunk_postfork_parent(void);

--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <limits.h>
 #include <strings.h>

--- a/include/jemalloc/jemalloc_typedefs.h.in
+++ b/include/jemalloc/jemalloc_typedefs.h.in
@@ -1,2 +1,2 @@
-typedef void *(chunk_alloc_t)(void *, size_t, size_t, bool *, unsigned);
-typedef bool (chunk_dalloc_t)(void *, size_t, unsigned);
+typedef void *(chunk_alloc_t)(void *, size_t, size_t, int *, unsigned);
+typedef int (chunk_dalloc_t)(void *, size_t, unsigned);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -238,7 +238,7 @@ chunk_alloc_arena(chunk_alloc_t *chunk_alloc, chunk_dalloc_t *chunk_dalloc,
 {
 	void *ret;
 
-	ret = chunk_alloc(new_addr, size, alignment, zero, arena_ind);
+	ret = chunk_alloc(new_addr, size, alignment, (int *) zero, arena_ind);
 	if (ret != NULL && chunk_register(ret, size, false)) {
 		chunk_dalloc(ret, size, arena_ind);
 		ret = NULL;
@@ -249,7 +249,7 @@ chunk_alloc_arena(chunk_alloc_t *chunk_alloc, chunk_dalloc_t *chunk_dalloc,
 
 /* Default arena chunk allocation routine in the absence of user override. */
 void *
-chunk_alloc_default(void *new_addr, size_t size, size_t alignment, bool *zero,
+chunk_alloc_default(void *new_addr, size_t size, size_t alignment, int *zero,
     unsigned arena_ind)
 {
 	arena_t *arena;
@@ -261,7 +261,7 @@ chunk_alloc_default(void *new_addr, size_t size, size_t alignment, bool *zero,
 	 */
 	assert(arena != NULL);
 
-	return (chunk_alloc_core(new_addr, size, alignment, false, zero,
+	return (chunk_alloc_core(new_addr, size, alignment, false, (bool *) zero,
 	    arena->dss_prec));
 }
 
@@ -389,12 +389,12 @@ chunk_dalloc_core(void *chunk, size_t size)
 }
 
 /* Default arena chunk deallocation routine in the absence of user override. */
-bool
+int
 chunk_dalloc_default(void *chunk, size_t size, unsigned arena_ind)
 {
 
 	chunk_dalloc_core(chunk, size);
-	return (false);
+	return 0;
 }
 
 bool

--- a/test/integration/chunk.c
+++ b/test/integration/chunk.c
@@ -3,7 +3,7 @@
 chunk_alloc_t *old_alloc;
 chunk_dalloc_t *old_dalloc;
 
-bool
+int
 chunk_dalloc(void *chunk, size_t size, unsigned arena_ind)
 {
 
@@ -11,7 +11,7 @@ chunk_dalloc(void *chunk, size_t size, unsigned arena_ind)
 }
 
 void *
-chunk_alloc(void *new_addr, size_t size, size_t alignment, bool *zero,
+chunk_alloc(void *new_addr, size_t size, size_t alignment, int *zero,
     unsigned arena_ind)
 {
 


### PR DESCRIPTION
stdbool.h was only added in MSVC2013, so for MSVC2010/2012 we'd either need to export our stdbool.h, or eliminate `bool` from installed headers -- which is what I did here.

This patch will simply replace all externally-visible uses of `bool` with `int`, and cast appropriately (I believe the cast is always valid, but couldn't find confirmation or refutation of that, sadly).
