### PR TITLE
Add a isblank definition for MSVC < 2013

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -52,6 +52,13 @@ typedef intptr_t ssize_t;
 #  define __func__ __FUNCTION__
 /* Disable warnings about deprecated system functions. */
 #  pragma warning(disable: 4996)
+#if _MSC_VER < 1800
+static int
+isblank(int c)
+{
+	return (c == '\t' || c == ' ');
+}
+#endif
 #else
 #  include <unistd.h>
 #endif


### PR DESCRIPTION
MSVC only got isblank in MSVC2013: http://msdn.microsoft.com/en-us/library/dn237255.aspx