### PR TITLE
prevent allocations larger than PTRDIFF_MAX

### DIFF
--- a/src/huge.c
+++ b/src/huge.c
@@ -34,6 +34,10 @@ huge_palloc(tsd_t *tsd, arena_t *arena, size_t usize, size_t alignment,
 	extent_node_t *node;
 	bool is_zeroed;
 
+	/* Prevent allocations where pointer arithmetic can be undefined. */
+	if (usize > PTRDIFF_MAX)
+		return (NULL);
+
 	/* Allocate one or more contiguous chunks for this request. */
 
 	/* Allocate an extent node with which to track the chunk. */
@@ -295,6 +299,17 @@ huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
 {
 	void *ret;
 	size_t copysize;
+	size_t usize;
+
+	usize = s2u(size);
+	if (usize == 0) {
+		/* size_t overflow. */
+		return (NULL);
+	}
+
+	/* Prevent allocations where pointer arithmetic can be undefined. */
+	if (usize > PTRDIFF_MAX)
+		return (NULL);
 
 	/* Try to avoid moving the allocation. */
 	if (!huge_ralloc_no_move(ptr, oldsize, size, extra, zero))


### PR DESCRIPTION
In practice, this only has an impact on 32-bit processes in environments
where it's possible to allocate over half of the address space. It wipes
out a few subtle classes of undefined behavior from pointer arithmetic
without a performance hit.

The musl C library has adopted this solution to the problem already. The
alternative is pervasively checking the size against PTRDIFF_MAX in the
code asking the allocator for buffers. It seems like the burden should
be on the allocator instead because it can be solved in one place.

For example, the following C program compiled as i386 will succeed on
x86_64, but is not actually well-defined:

    #include <stdio.h>
    #include <stdlib.h>

    const size_t size = 3000000000U;

    int main(void) {
        char *ptr = malloc(size);
        if (!ptr) return 1;
        char *end = ptr + size;
        printf("%p\n", ptr);
        printf("%p\n", end);
        printf("%p\n", end - ptr);
        return 0;
    }

The C standard is not entirely clear if the `ptr + size` operation here
is undefined. It is clear that `end - ptr` is undefined because it
causes a ptrdiff_t overflow which is explicily UB.

LLVM interprets the standard as defining all pointer arithmetic in terms
of ptrdiff_t so both operations cause undefined overflows. The LLVM IR
(clang -S -emit-llvm) is clearly undefined, and the understanding of the
LLVM developers is that this is correct per the standard:

    %8 = getelementptr inbounds i8* %7, i32 -1294967296

http://llvm.org/releases/3.5.0/docs/LangRef.html#id181

Since jemalloc moved to `(uintptr_t)ptr + size`, it does not appear to
hit this issue itself. It would hit it with `(char *)ptr + size` though.