### PR TITLE
Use the correct type for opt.junk when printing stats.

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -461,7 +461,7 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		OPT_WRITE_SIZE_T(narenas)
 		OPT_WRITE_SSIZE_T(lg_dirty_mult)
 		OPT_WRITE_BOOL(stats_print)
-		OPT_WRITE_BOOL(junk)
+		OPT_WRITE_CHAR_P(junk)
 		OPT_WRITE_SIZE_T(quarantine)
 		OPT_WRITE_BOOL(redzone)
 		OPT_WRITE_BOOL(zero)


### PR DESCRIPTION
2c5cb613dfbdf58f88152321b63e60c58cd23972 changed `opt.junk` to be a string instead of a bool, but that change wasn't reflected in `stats_print`. Thanks @glandium for reporting this.