### PR TITLE
huge_node_locked don't have to unlock huge_mtx

### DIFF
--- a/src/huge.c
+++ b/src/huge.c
@@ -83,7 +83,6 @@ huge_node_locked(const void *ptr)
 	node = extent_tree_ad_search(&huge, &key);
 	assert(node != NULL);
 	assert(node->addr == ptr);
-	malloc_mutex_unlock(&huge_mtx);
 
 	return (node);
 }


### PR DESCRIPTION
in src/huge.c, after each call of huge_node_locked(), huge_mtx is
already unlocked. don't unlock it twice (it is a undefined behaviour).

under openbsd, the undefined behaviour is to call `abort()`.