### PR TITLE
add openbsd support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,6 +283,11 @@ case "${host}" in
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	;;
+  *-*-openbsd*)
+	CFLAGS="$CFLAGS"
+	abi="elf"
+	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
+	;;
   *-*-linux*)
 	CFLAGS="$CFLAGS"
 	CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"


### PR DESCRIPTION
this patch add openbsd support to jemalloc.
tested under openbsd5.7 (current developpement version).
all tests pass (with patch from PR #187).

please note that some previous versions of jemalloc need `force_tls="0"` (version currently used by rustc in particular).