### PR TITLE
Make opt.lg_dirty_mult work as documented

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -850,6 +850,7 @@ arena_maybe_purge(arena_t *arena)
 	if (opt_lg_dirty_mult < 0)
 		return;
 	threshold = (arena->nactive >> opt_lg_dirty_mult);
+	threshold = threshold < chunk_npages ? chunk_npages : threshold;
 	/*
 	 * Don't purge unless the number of purgeable pages exceeds the
 	 * threshold.
@@ -893,6 +894,7 @@ arena_compute_npurge(arena_t *arena, bool all)
 	 */
 	if (!all) {
 		size_t threshold = (arena->nactive >> opt_lg_dirty_mult);
+		threshold = threshold < chunk_npages ? chunk_npages : threshold;
 
 		npurge = arena->ndirty - threshold;
 	} else


### PR DESCRIPTION
The documentation for opt.lg_dirty_mult says:
    Per-arena minimum ratio (log base 2) of active to dirty
    pages.  Some dirty unused pages may be allowed to accumulate,
    within the limit set by the ratio (or one chunk worth of dirty
    pages, whichever is greater) (...)

The restriction in parentheses currently doesn't happen. This makes
jemalloc aggressively madvise(), which in turns increases the amount
of page faults significantly.

For instance, this resulted in several(!) hundred(!) milliseconds
startup regression on Firefox for Android.

This may require further tweaking, but starting with actually doing
what the documentation says is a good start.