### PR TITLE
Take into account the install suffix that jemalloc was built with in the...

### DIFF
--- a/jemalloc.pc.in
+++ b/jemalloc.pc.in
@@ -2,10 +2,11 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+install_suffix=@install_suffix@
 
 Name: jemalloc
 Description: A general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support.
 URL: http://www.canonware.com/jemalloc
 Version: @jemalloc_version@
 Cflags: -I${includedir}
-Libs: -L${libdir} -ljemalloc
+Libs: -L${libdir} -ljemalloc${install_suffix}


### PR DESCRIPTION
... pkg-config file.

If jemalloc is installed with an install-suffix, pkg-install fails to find it. Fix the pkg-config file to find the library correctly.

Signed-off-by: Abhishek Kulkarni <adkulkar@umail.iu.edu>