### PR TITLE
add missing check for new_addr chunk size

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -82,7 +82,7 @@ chunk_recycle(arena_t *arena, extent_tree_t *chunks_szad,
 	malloc_mutex_lock(&arena->chunks_mtx);
 	node = (new_addr != NULL) ? extent_tree_ad_search(chunks_ad, &key) :
 	    extent_tree_szad_nsearch(chunks_szad, &key);
-	if (node == NULL) {
+	if (node == NULL || (new_addr != NULL && node->size < size)) {
 		malloc_mutex_unlock(&arena->chunks_mtx);
 		return (NULL);
 	}


### PR DESCRIPTION
8ddc93293cd8370870f221225ef1e013fbff6d65 switched this to over using the
address tree in order to avoid false negatives, so it now needs to check
that the size of the free extent is large enough to satisfy the request.