### PR TITLE
Make pages_purge reduce the resident set size on Windows and OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -262,7 +262,7 @@ case "${host}" in
   *-*-darwin* | *-*-ios*)
 	CFLAGS="$CFLAGS"
 	abi="macho"
-	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
+	AC_DEFINE([JEMALLOC_PURGE_USE_MMAP], [ ])
 	RPATH=""
 	LD_PRELOAD_VAR="DYLD_INSERT_LIBRARIES"
 	so="dylib"

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -198,12 +198,14 @@
  *   madvise(..., MADV_DONTNEED) : On Linux, this immediately discards pages,
  *                                 such that new pages will be demand-zeroed if
  *                                 the address region is later touched.
- *   madvise(..., MADV_FREE) : On FreeBSD and Darwin, this marks pages as being
- *                             unused, such that they will be discarded rather
- *                             than swapped out.
+ *   madvise(..., MADV_FREE) : On FreeBSD, this marks pages as being unused,
+ *                             such that they will be discarded rather than
+ *                             swapped out.
+ *   mmap(..., MAP_FIXED | ...) : On Darwin, this immediately discards pages.
  */
 #undef JEMALLOC_PURGE_MADVISE_DONTNEED
 #undef JEMALLOC_PURGE_MADVISE_FREE
+#undef JEMALLOC_PURGE_USE_MMAP
 
 /* Define if operating system has alloca.h header. */
 #undef JEMALLOC_HAS_ALLOCA_H

--- a/src/chunk_mmap.c
+++ b/src/chunk_mmap.c
@@ -119,8 +119,14 @@ pages_purge(void *addr, size_t length)
 	bool unzeroed;
 
 #ifdef _WIN32
-	VirtualAlloc(addr, length, MEM_RESET, PAGE_READWRITE);
-	unzeroed = true;
+	VirtualFree(addr, length, MEM_DECOMMIT);
+	VirtualAlloc(addr, length, MEM_COMMIT, PAGE_READWRITE);
+	unzeroed = false;
+#elif defined(JEMALLOC_PURGE_USE_MMAP)
+	void *new_addr = mmap(addr, length, PROT_READ | PROT_WRITE,
+	                      MAP_FIXED | MAP_PRIVATE | MAP_ANON, -1, 0);
+	assert(new_addr == addr);
+	unzeroed = false;
 #elif defined(JEMALLOC_HAVE_MADVISE)
 #  ifdef JEMALLOC_PURGE_MADVISE_DONTNEED
 #    define JEMALLOC_MADV_PURGE MADV_DONTNEED


### PR DESCRIPTION
On long lived processes which do many allocations and deallocations, it is
customary to end up in a situation where the amount of allocated memory is
rather low, but the number of chunks in use is rather high.

In that case, on Windows and OSX, the memory that once was used is still
committed by the OS and the resident set size ends up being closer to the
size of the chunks allocated than to the remaining allocations, creating the
impression that the process is using more memory than it actually is.

A few notes:
- This kind of mimics what we end up doing on Linux with MADV_DONTNEED.
- I don't know what MADV_FREE actually does on FreeBSD and other OSes it's used on. AFAIK, OSX doesn't use that part of FreeBSD, and delegates memory management to mach, so the behavior on OSX is possibly different.
- AFAICT from Firefox benchmarks, this doesn't seem to affect performance on either OSX or Windows, but I don't have results for the full range of benchmarks on Windows yet.
- I can understand that not all applications using jemalloc would want to pay the price for these purges. Maybe this is something that would need a pref?
- In mozjemalloc, the way we currently handle this is actually more convoluted:
  - On Windows, we MEM_DECOMMIT, but only MEM_COMMIT when the pages are going to be used again. This is actually something that would be nice to do in jemalloc3 as well, because AIUI, as long as some address space is MEM_COMMITted, its size is reserved in the page file, and it would be better to keep that low despite the long-term fragmentation. Thoughts?
  - On OSX, we use MADV_FREE, keep track of the madvised pages, and actively purge them afterwards via an explicit call to a jemalloc_purge_freed_pages function. Considering the lack of performance impact, I don't think we need something like this in jemalloc3 (although, we still do have a jemalloc_purge_freed_pages compatibility function in Firefox that uses mallctl to trigger arena.*.purge)