### PR TITLE
[wip] Per-arena 'lg_dirty_mult' not under stats

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -15,6 +15,15 @@
 	xmallctlbymib(mib, miblen, v, &sz, NULL, 0);			\
 } while (0)
 
+#define	CTL_I2_GET(n, v, t) do {					\
+	size_t mib[6];							\
+	size_t miblen = sizeof(mib) / sizeof(size_t);			\
+	size_t sz = sizeof(t);						\
+	xmallctlnametomib(n, mib, &miblen);				\
+	mib[1] = i;							\
+	xmallctlbymib(mib, miblen, v, &sz, NULL, 0);			\
+} while (0)
+
 #define	CTL_J_GET(n, v, t) do {						\
 	size_t mib[6];							\
 	size_t miblen = sizeof(mib) / sizeof(size_t);			\
@@ -283,7 +292,7 @@ stats_arena_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	CTL_I_GET("stats.arenas.0.dss", &dss, const char *);
 	malloc_cprintf(write_cb, cbopaque, "dss allocation precedence: %s\n",
 	    dss);
-	CTL_I_GET("stats.arenas.0.lg_dirty_mult", &lg_dirty_mult, ssize_t);
+	CTL_I2_GET("arena.0.lg_dirty_mult", &lg_dirty_mult, ssize_t);
 	if (lg_dirty_mult >= 0) {
 		malloc_cprintf(write_cb, cbopaque,
 		    "Min active:dirty page ratio: %u:1\n",


### PR DESCRIPTION
Fix incorrect reference of arena.<N>.lg_dirty_mult - it is not under
'stats', and the index in the mib is at index 1 not 2.