### PR TITLE
Add creating thread's Task ID ("tid") to the arena stats.

### DIFF
--- a/include/jemalloc/internal/arena.h
+++ b/include/jemalloc/internal/arena.h
@@ -272,6 +272,11 @@ struct arena_s {
 	unsigned		nthreads;
 
 	/*
+	 * The Task ID for the first thread to use this arena.
+	 */
+	int				tid;
+
+	/*
 	 * There are three classes of arena operations from a locking
 	 * perspective:
 	 * 1) Thread assignment (modifies nthreads) is protected by arenas_lock.

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -33,6 +33,7 @@ struct ctl_indexed_node_s {
 struct ctl_arena_stats_s {
 	bool			initialized;
 	unsigned		nthreads;
+	int				tid;
 	const char		*dss;
 	ssize_t			lg_dirty_mult;
 	size_t			pactive;

--- a/src/arena.c
+++ b/src/arena.c
@@ -2739,6 +2739,14 @@ arena_new(unsigned ind)
 
 	arena->ind = ind;
 	arena->nthreads = 0;
+
+#ifndef _WIN32
+	/* Save the creating thread's Task ID. */
+	arena->tid = syscall(SYS_gettid);
+#else
+	arena->tid = 0;
+#endif
+
 	if (malloc_mutex_init(&arena->lock))
 		return (NULL);
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -180,6 +180,7 @@ CTL_PROTO(stats_arenas_i_hchunks_j_nrequests)
 CTL_PROTO(stats_arenas_i_hchunks_j_curhchunks)
 INDEX_PROTO(stats_arenas_i_hchunks_j)
 CTL_PROTO(stats_arenas_i_nthreads)
+CTL_PROTO(stats_arenas_i_tid)
 CTL_PROTO(stats_arenas_i_dss)
 CTL_PROTO(stats_arenas_i_lg_dirty_mult)
 CTL_PROTO(stats_arenas_i_pactive)
@@ -443,6 +444,7 @@ static const ctl_indexed_node_t stats_arenas_i_hchunks_node[] = {
 
 static const ctl_named_node_t stats_arenas_i_node[] = {
 	{NAME("nthreads"),	CTL(stats_arenas_i_nthreads)},
+	{NAME("tid"),		CTL(stats_arenas_i_tid)},
 	{NAME("dss"),		CTL(stats_arenas_i_dss)},
 	{NAME("lg_dirty_mult"),	CTL(stats_arenas_i_lg_dirty_mult)},
 	{NAME("pactive"),	CTL(stats_arenas_i_pactive)},
@@ -629,6 +631,7 @@ ctl_arena_refresh(arena_t *arena, unsigned i)
 	ctl_arena_clear(astats);
 
 	sstats->nthreads += astats->nthreads;
+	sstats->tid = arena->tid;
 	if (config_stats) {
 		ctl_arena_stats_amerge(astats, arena);
 		/* Merge into sum stats as well. */
@@ -711,6 +714,10 @@ ctl_refresh(void)
 			ctl_stats.arenas[i].nthreads = arena_nbound(i);
 		else
 			ctl_stats.arenas[i].nthreads = 0;
+		if (tarenas[i] != NULL)
+			ctl_stats.arenas[i].tid = tarenas[i]->tid;
+		else
+			ctl_stats.arenas[i].tid = 0;
 	}
 
 	for (i = 0; i < ctl_stats.narenas; i++) {
@@ -2006,6 +2013,7 @@ CTL_RO_GEN(stats_arenas_i_dss, ctl_stats.arenas[mib[2]].dss, const char *)
 CTL_RO_GEN(stats_arenas_i_lg_dirty_mult, ctl_stats.arenas[mib[2]].lg_dirty_mult,
     ssize_t)
 CTL_RO_GEN(stats_arenas_i_nthreads, ctl_stats.arenas[mib[2]].nthreads, unsigned)
+CTL_RO_GEN(stats_arenas_i_tid, ctl_stats.arenas[mib[2]].tid, int)
 CTL_RO_GEN(stats_arenas_i_pactive, ctl_stats.arenas[mib[2]].pactive, size_t)
 CTL_RO_GEN(stats_arenas_i_pdirty, ctl_stats.arenas[mib[2]].pdirty, size_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_mapped,

--- a/src/stats.c
+++ b/src/stats.c
@@ -256,6 +256,7 @@ stats_arena_print(void (*write_cb)(void *, const char *), void *cbopaque,
     unsigned i, bool bins, bool large, bool huge)
 {
 	unsigned nthreads;
+	int tid;
 	const char *dss;
 	ssize_t lg_dirty_mult;
 	size_t page, pactive, pdirty, mapped;
@@ -273,6 +274,9 @@ stats_arena_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	CTL_M2_GET("stats.arenas.0.nthreads", i, &nthreads, unsigned);
 	malloc_cprintf(write_cb, cbopaque,
 	    "assigned threads: %u\n", nthreads);
+	CTL_M2_GET("stats.arenas.0.tid", i, &tid, int);
+	malloc_cprintf(write_cb, cbopaque,
+	    "tid: %u\n", tid);
 	CTL_M2_GET("stats.arenas.0.dss", i, &dss, const char *);
 	malloc_cprintf(write_cb, cbopaque, "dss allocation precedence: %s\n",
 	    dss);


### PR DESCRIPTION
Knowing the arena's creating Task ID can be very valuable when analyzing program memory usage.
(Especially when the TID <==> thread / run function mapping is already known by other means.)

Comments?