### PR TITLE
OpenBSD don't support TLS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,13 @@ case "${host}" in
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	;;
-  *-*-openbsd*|*-*-bitrig*)
+  *-*-openbsd*)
+	CFLAGS="$CFLAGS"
+	abi="elf"
+	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
+	force_tls="0"
+	;;
+  *-*-bitrig*)
 	CFLAGS="$CFLAGS"
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])


### PR DESCRIPTION
under some compiler (gcc 4.8.4 in particular), the auto-detection of TLS
don't work properly.

force tls to be disabled for openbsd only (so split openbsd and bitrig).

the testsuite pass under gcc (4.8.4) and gcc (4.2.1)

this PR resolve issue #223