### PR TITLE
Remove JEMALLOC_ALLOC_SIZE annotations on functions not returning poi…

### DIFF
--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -13,7 +13,7 @@ JEMALLOC_EXPORT void	*@je_@calloc(size_t num, size_t size) JEMALLOC_CXX_THROW
     JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE2(1, 2) JEMALLOC_NOTHROW;
 JEMALLOC_EXPORT int	@je_@posix_memalign(void **memptr, size_t alignment,
     size_t size) JEMALLOC_CXX_THROW JEMALLOC_ATTR(nonnull(1))
-    JEMALLOC_ALLOC_SIZE(2) JEMALLOC_NOTHROW;
+    JEMALLOC_NOTHROW;
 JEMALLOC_EXPORT void	*@je_@aligned_alloc(size_t alignment, size_t size)
     JEMALLOC_CXX_THROW JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE(2)
     JEMALLOC_NOTHROW;
@@ -27,7 +27,7 @@ JEMALLOC_EXPORT void	*@je_@mallocx(size_t size, int flags)
 JEMALLOC_EXPORT void	*@je_@rallocx(void *ptr, size_t size, int flags)
     JEMALLOC_ALLOC_SIZE(2) JEMALLOC_NOTHROW;
 JEMALLOC_EXPORT size_t	@je_@xallocx(void *ptr, size_t size, size_t extra,
-    int flags) JEMALLOC_ALLOC_SIZE(2) JEMALLOC_NOTHROW;
+    int flags) JEMALLOC_NOTHROW;
 JEMALLOC_EXPORT size_t	@je_@sallocx(const void *ptr, int flags)
     JEMALLOC_ATTR(pure) JEMALLOC_NOTHROW;
 JEMALLOC_EXPORT void	@je_@dallocx(void *ptr, int flags) JEMALLOC_NOTHROW;

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1531,7 +1531,7 @@ label_oom:
 }
 
 JEMALLOC_EXPORT int
-JEMALLOC_ATTR(nonnull(1)) JEMALLOC_ALLOC_SIZE(2) JEMALLOC_NOTHROW
+JEMALLOC_ATTR(nonnull(1)) JEMALLOC_NOTHROW
 je_posix_memalign(void **memptr, size_t alignment, size_t size)
 {
 	int ret = imemalign(memptr, alignment, size, sizeof(void *));
@@ -2277,7 +2277,7 @@ ixallocx_prof(tsd_t *tsd, void *ptr, size_t old_usize, size_t size,
 }
 
 JEMALLOC_EXPORT size_t
-JEMALLOC_ALLOC_SIZE(2) JEMALLOC_NOTHROW
+JEMALLOC_NOTHROW
 je_xallocx(void *ptr, size_t size, size_t extra, int flags)
 {
 	tsd_t *tsd;


### PR DESCRIPTION
…nters

As per gcc documentation:
  The alloc_size attribute is used to tell the compiler that the function
  return value points to memory (...)

This resolves #245.