### PR TITLE
work around _FORTIFY_SOURCE false positive

### DIFF
--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -60,9 +60,11 @@
 #ifdef __GNUC__
 #	define likely(x)   __builtin_expect(!!(x), 1)
 #	define unlikely(x) __builtin_expect(!!(x), 0)
+#	define unreachable() __builtin_unreachable()
 #else
 #	define likely(x)   !!(x)
 #	define unlikely(x) !!(x)
+#	define unreachable()
 #endif
 
 /*
@@ -88,6 +90,7 @@
 		    __FILE__, __LINE__);				\
 		abort();						\
 	}								\
+	unreachable();							\
 } while (0)
 #endif
 


### PR DESCRIPTION
In builds with profiling disabled (default), the opt_prof_prefix array
has a one byte length as a micro-optimization. This will cause the usage
of write in the unused profiling code to be statically detected as a
buffer overflow by Bionic's _FORTIFY_SOURCE implementation as it tries
to detect read overflows in addition to write overflows.