### PR TITLE
Fix build problems on Solaris (index_t already defined)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1555,6 +1555,15 @@ if test "x${je_cv_pthread_mutex_adaptive_np}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP], [ ])
 fi
 
+JE_COMPILABLE([index_t present in sys/types.h], [
+#include <sys/types.h>
+], [
+  index_t index = 0;
+], [je_system_index_t])
+if test "x${je_system_index_t}" = "xyes" ; then
+  AC_DEFINE([JEMALLOC_HAVE_SYSTEM_INDEX_T], [ ])
+fi
+
 dnl ============================================================================
 dnl Check for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -183,8 +183,10 @@ static const bool config_cache_oblivious =
 
 #include "jemalloc/internal/jemalloc_internal_macros.h"
 
+#ifndef JEMALLOC_HAVE_SYSTEM_INDEX_T
 /* Size class index type. */
 typedef unsigned index_t;
+#endif
 
 /*
  * Flags bits:

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -253,6 +253,9 @@
 /* Adaptive mutex support in pthreads. */
 #undef JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP
 
+/* index_t defined on the target system in sys/types.h */
+#undef JEMALLOC_HAVE_SYSTEM_INDEX_T
+
 /*
  * If defined, jemalloc symbols are not exported (doesn't work when
  * JEMALLOC_PREFIX is not defined).


### PR DESCRIPTION
I tried building jemalloc on SmartOS, but it failed to compile due to the fact that index_t is defined in sys/types.h with a different type.

in sys/types.h it is a short, and now we're trying to define it as an unsigned integer.

All unit tests pass with this change.