### PR TITLE
Use 'local-dynamic' TLS model for thread variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -421,13 +421,13 @@ SAVED_CFLAGS="${CFLAGS}"
 JE_CFLAGS_APPEND([-Werror])
 JE_COMPILABLE([tls_model attribute], [],
               [static __thread int
-               __attribute__((tls_model("initial-exec"), unused)) foo;
+               __attribute__((tls_model("local-dynamic"), unused)) foo;
                foo = 0;],
               [je_cv_tls_model])
 CFLAGS="${SAVED_CFLAGS}"
 if test "x${je_cv_tls_model}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_TLS_MODEL],
-            [__attribute__((tls_model("initial-exec")))])
+            [__attribute__((tls_model("local-dynamic")))])
 else
   AC_DEFINE([JEMALLOC_TLS_MODEL], [ ])
 fi


### PR DESCRIPTION
Since jemalloc can be compiled as a DSO (or statically linked into another DSO),
'local-dynamic' TLS model is a better choice. 'initial-exec' usage in DSO is
generally problematic, see for example: https://sourceware.org/ml/libc-alpha/2014-10/msg00134.html

This usage caused problems for Unreal Engine, too:
https://answers.unrealengine.com/questions/229646/crash-on-ue4editor-startup.html

In general it may be better to avoid specifying TLS model in the sources and rely on
-ftls-model= switch instead.