### PR TITLE
Add tree destruction function and test

### DIFF
--- a/include/jemalloc/internal/rb.h
+++ b/include/jemalloc/internal/rb.h
@@ -183,7 +183,10 @@ a_prefix##iter(a_rbt_type *rbtree, a_type *start, a_type *(*cb)(	\
   a_rbt_type *, a_type *, void *), void *arg);				\
 a_attr a_type *								\
 a_prefix##reverse_iter(a_rbt_type *rbtree, a_type *start,		\
-  a_type *(*cb)(a_rbt_type *, a_type *, void *), void *arg);
+  a_type *(*cb)(a_rbt_type *, a_type *, void *), void *arg);		\
+a_attr void								\
+a_prefix##destroy(a_rbt_type *rbtree, void (*cb)(a_type *, void *),	\
+  void *arg);
 
 /*
  * The rb_gen() macro generates a type-specific red-black tree implementation,
@@ -312,6 +315,20 @@ a_prefix##reverse_iter(a_rbt_type *rbtree, a_type *start,		\
  *         arg  : Opaque pointer passed to cb().
  *       Ret: NULL if iteration completed, or the non-NULL callback return value
  *            that caused termination of the iteration.
+ *
+ *   static void
+ *   ex_destroy(ex_t *tree, void (*cb)(ex_node_t *, void *), void *arg);
+ *       Description: Iterate over the tree with post-order traversal, remove
+ *                    each node, and run the callback if non-null. This is
+ *                    used for destroying a tree without paying the cost to
+ *                    rebalance it. The tree must not be otherwise altered
+ *                    during traversal.
+ *       Args:
+ *         tree: Pointer to an initialized red-black tree object.
+ *         cb  : Callback function, which, if non-null, is called for each node
+ *               during iteration. There is no way to stop iteration once it has
+ *               begun.
+ *         arg : Opaque pointer passed to cb().
  */
 #define	rb_gen(a_attr, a_prefix, a_rbt_type, a_type, a_field, a_cmp)	\
 a_attr void								\
@@ -976,6 +993,28 @@ a_prefix##reverse_iter(a_rbt_type *rbtree, a_type *start,		\
 	ret = NULL;							\
     }									\
     return (ret);							\
+}									\
+a_attr void								\
+a_prefix##destroy_recurse(a_rbt_type *rbtree, a_type *node, void (*cb)(	\
+  a_type *, void *), void *arg) {					\
+    if (node == &rbtree->rbt_nil) {					\
+	return;								\
+    }									\
+    a_prefix##destroy_recurse(rbtree, rbtn_left_get(a_type, a_field,	\
+      node), cb, arg);							\
+    rbtn_left_set(a_type, a_field, (node), &rbtree->rbt_nil);		\
+    a_prefix##destroy_recurse(rbtree, rbtn_right_get(a_type, a_field,	\
+      node), cb, arg);							\
+    rbtn_right_set(a_type, a_field, (node), &rbtree->rbt_nil);		\
+    if (cb) {								\
+	cb(node, arg);							\
+    }									\
+}									\
+a_attr void								\
+a_prefix##destroy(a_rbt_type *rbtree, void (*cb)(a_type *, void *),	\
+  void *arg) {								\
+    a_prefix##destroy_recurse(rbtree, rbtree->rbt_root, cb, arg);	\
+    rbtree->rbt_root = &rbtree->rbt_nil;				\
 }
 
 #endif /* RB_H_ */

--- a/test/unit/rb.c
+++ b/test/unit/rb.c
@@ -212,6 +212,15 @@ remove_reverse_iterate_cb(tree_t *tree, node_t *node, void *data)
 	return (ret);
 }
 
+static void
+destroy_cb(node_t *node, void *data)
+{
+	unsigned *nnodes = (unsigned *)data;
+
+	assert_u_gt(*nnodes, 0, "Destruction removed too many nodes");
+	(*nnodes)--;
+}
+
 TEST_BEGIN(test_rb_random)
 {
 #define	NNODES 25
@@ -278,7 +287,7 @@ TEST_BEGIN(test_rb_random)
 			}
 
 			/* Remove nodes. */
-			switch (i % 4) {
+			switch (i % 5) {
 			case 0:
 				for (k = 0; k < j; k++)
 					node_remove(&tree, &nodes[k], j - k);
@@ -313,6 +322,12 @@ TEST_BEGIN(test_rb_random)
 				} while (start != NULL);
 				assert_u_eq(nnodes, 0,
 				    "Removal terminated early");
+				break;
+			} case 4: {
+				unsigned nnodes = j;
+				tree_destroy(&tree, destroy_cb, &nnodes);
+				assert_u_eq(nnodes, 0,
+				    "Destruction terminated early");
 				break;
 			} default:
 				not_reached();


### PR DESCRIPTION
Iterating over the tree with post-order traversal to remove and process nodes avoids the cost of re-balancing when destroying the tree.