### PR TITLE
Add support for time-based purging

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,8 +85,8 @@ C_SRCS := $(srcroot)src/jemalloc.c $(srcroot)src/arena.c \
 	$(srcroot)src/extent.c $(srcroot)src/hash.c $(srcroot)src/huge.c \
 	$(srcroot)src/mb.c $(srcroot)src/mutex.c $(srcroot)src/pages.c \
 	$(srcroot)src/prof.c $(srcroot)src/quarantine.c $(srcroot)src/rtree.c \
-	$(srcroot)src/stats.c $(srcroot)src/tcache.c $(srcroot)src/util.c \
-	$(srcroot)src/tsd.c
+	$(srcroot)src/stats.c $(srcroot)src/tcache.c $(srcroot)src/time.c \
+	$(srcroot)src/tsd.c $(srcroot)src/util.c
 ifeq ($(enable_valgrind), 1)
 C_SRCS += $(srcroot)src/valgrind.c
 endif
@@ -143,6 +143,7 @@ TESTS_UNIT := $(srcroot)test/unit/atomic.c \
 	$(srcroot)test/unit/SFMT.c \
 	$(srcroot)test/unit/size_classes.c \
 	$(srcroot)test/unit/stats.c \
+	$(srcroot)test/unit/time.c \
 	$(srcroot)test/unit/tsd.c \
 	$(srcroot)test/unit/util.c \
 	$(srcroot)test/unit/zero.c

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -959,6 +959,45 @@ for (i = 0; i < nbins; i++) {
         for related dynamic control options.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="opt.dirty_exp_time">
+        <term>
+          <mallctl>opt.dirty_exp_time</mallctl>
+          (<type>size_t</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>In addition to having control on the amount of dirty
+        pages via <link
+        linkend="opt.lg_dirty_mult"><mallctl>opt.lg_dirty_mult</mallctl></link>,
+        this provides a way to specify the maximum time in milliseconds a dirty
+        page is allowed to exist before being returned to kernel by
+        <citerefentry><refentrytitle>madvise</refentrytitle>
+        <manvolnum>2</manvolnum></citerefentry> or a similar system call. The
+        default expiration time for dirty pages is 2000 milliseconds. If <link
+        linkend="opt.async_purge"><mallctl>opt.async_purge</mallctl></link> is
+        true, <link
+        linkend="arena.i.purge_old"><mallctl>arena.&lt;i&gt;.purge_old</mallctl></link>
+        must be called periodcally to enforce this constraint. See <link
+        linkend="arenas.dirty_exp_time"><mallctl>arenas.dirty_exp_time</mallctl></link>
+        and <link
+        linkend="arena.i.dirty_exp_time"><mallctl>arena.&lt;i&gt;.dirty_exp_time</mallctl></link>
+        for related dynamic control options.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="opt.async_purge">
+        <term>
+          <mallctl>opt.async_purge</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Enable/disable internal dirty page purging based on <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>.
+        If set to true, jemalloc will not automatically purge expired dirty
+        pages and it is application's responsibility to call <link
+        linkend="arena.i.purge_old"><mallctl>arena.&lt;i&gt;.purge_old</mallctl></link>
+        periodcally to enforce the expiration time limit. This value is set to
+        false by default.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="opt.stats_print">
         <term>
           <mallctl>opt.stats_print</mallctl>
@@ -1495,6 +1534,20 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         </para></listitem>
       </varlistentry>
 
+      <varlistentry id="arena.i.dirty_exp_time">
+        <term>
+          <mallctl>arena.&lt;i&gt;.dirty_exp_time</mallctl>
+          (<type>size_t</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Current per-arena setting of <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>.
+        Each time this interface is set and the max time is decreased, pages are
+        synchronously purged as necessary to impose the new limit. See <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>
+        for additional information.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="arena.i.dss">
         <term>
           <mallctl>arena.&lt;i&gt;.dss</mallctl>
@@ -1754,6 +1807,21 @@ typedef struct {
         linkend="arena.i.lg_dirty_mult"><mallctl>arena.&lt;i&gt;.lg_dirty_mult</mallctl></link>
         during arena creation.  See <link
         linkend="opt.lg_dirty_mult"><mallctl>opt.lg_dirty_mult</mallctl></link>
+        for additional information.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="arenas.dirty_exp_time">
+        <term>
+          <mallctl>arenas.dirty_exp_time</mallctl>
+          (<type>size_t</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Current default per-arena setting of <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>,
+        used to initialize <link
+        linkend="arena.i.dirty_exp_time"><mallctl>arena.&lt;i&gt;.dirty_exp_time</mallctl></link>
+        during arena creation.  See <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>
         for additional information.</para></listitem>
       </varlistentry>
 
@@ -2098,6 +2166,18 @@ typedef struct {
         <listitem><para>Minimum ratio (log base 2) of active to dirty pages.
         See <link
         linkend="opt.lg_dirty_mult"><mallctl>opt.lg_dirty_mult</mallctl></link>
+        for details.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.dirty_exp_time">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.dirty_exp_time</mallctl>
+          (<type>size_t</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Maximum time in milliseconds dirty pages are allowed to
+        exist. See <link
+        linkend="opt.dirty_exp_time"><mallctl>opt.dirty_exp_time</mallctl></link>
         for details.</para></listitem>
       </varlistentry>
 

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -35,6 +35,7 @@ struct ctl_arena_stats_s {
 	unsigned		nthreads;
 	const char		*dss;
 	ssize_t			lg_dirty_mult;
+	uint64_t		dirty_exp_time;
 	size_t			pactive;
 	size_t			pdirty;
 	arena_stats_t		astats;

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -378,6 +378,7 @@ typedef unsigned szind_t;
 #include "jemalloc/internal/hash.h"
 #include "jemalloc/internal/quarantine.h"
 #include "jemalloc/internal/prof.h"
+#include "jemalloc/internal/time.h"
 
 #undef JEMALLOC_H_TYPES
 /******************************************************************************/
@@ -491,6 +492,7 @@ void	jemalloc_postfork_child(void);
 #include "jemalloc/internal/quarantine.h"
 #include "jemalloc/internal/prof.h"
 #include "jemalloc/internal/tsd.h"
+#include "jemalloc/internal/time.h"
 
 #undef JEMALLOC_H_EXTERNS
 /******************************************************************************/

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -304,7 +304,7 @@ malloc_mutex_unlock
 malloc_printf
 malloc_snprintf
 malloc_strtoumax
-malloc_time_get
+malloc_time_get_ns
 malloc_tsd_boot0
 malloc_tsd_boot1
 malloc_tsd_cleanup_register

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -25,6 +25,10 @@ arena_dalloc_junk_small
 arena_dalloc_large
 arena_dalloc_large_junked_locked
 arena_dalloc_small
+arena_dirty_exp_time_default_get
+arena_dirty_exp_time_default_set
+arena_dirty_exp_time_get
+arena_dirty_exp_time_set
 arena_dss_prec_get
 arena_dss_prec_set
 arena_get
@@ -88,7 +92,9 @@ arena_quarantine_junk_small
 arena_ralloc
 arena_ralloc_junk_large
 arena_ralloc_no_move
+arena_rd_to_marker
 arena_rd_to_miscelm
+arena_rdelm_is_marker
 arena_redzone_corruption
 arena_run_regind
 arena_run_to_miscelm
@@ -298,6 +304,7 @@ malloc_mutex_unlock
 malloc_printf
 malloc_snprintf
 malloc_strtoumax
+malloc_time_get
 malloc_tsd_boot0
 malloc_tsd_boot1
 malloc_tsd_cleanup_register

--- a/include/jemalloc/internal/time.h
+++ b/include/jemalloc/internal/time.h
@@ -1,0 +1,23 @@
+/******************************************************************************/
+#ifdef JEMALLOC_H_TYPES
+
+#define	NANOSECONDS_PER_SECOND		KQU(1000000000)
+
+#define	NANOSECONDS_PER_MILLISECOND	KQU(1000000)
+
+#endif /* JEMALLOC_H_TYPES */
+/******************************************************************************/
+#ifdef JEMALLOC_H_STRUCTS
+
+#endif /* JEMALLOC_H_STRUCTS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_EXTERNS
+
+uint64_t	malloc_time_get(void);
+
+#endif /* JEMALLOC_H_EXTERNS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_INLINES
+
+#endif /* JEMALLOC_H_INLINES */
+/******************************************************************************/

--- a/include/jemalloc/internal/time.h
+++ b/include/jemalloc/internal/time.h
@@ -13,7 +13,7 @@
 /******************************************************************************/
 #ifdef JEMALLOC_H_EXTERNS
 
-uint64_t	malloc_time_get(void);
+uint64_t	malloc_time_get_ns(void);
 
 #endif /* JEMALLOC_H_EXTERNS */
 /******************************************************************************/

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1058,7 +1058,8 @@ malloc_conf_init(void)
 			    -1, (sizeof(size_t) << 3) - 1)
 			CONF_HANDLE_BOOL(opt_async_purge, "async_purge", true)
 			CONF_HANDLE_SIZE_T(opt_dirty_exp_time, "dirty_exp_time",
-			    0, SIZE_T_MAX, false)
+			    0, UINT32_MAX, false)
+			opt_dirty_exp_time *= NANOSECONDS_PER_MILLISECOND;
 			CONF_HANDLE_BOOL(opt_stats_print, "stats_print", true)
 			if (config_fill) {
 				if (CONF_MATCH("junk")) {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1056,6 +1056,9 @@ malloc_conf_init(void)
 			    SIZE_T_MAX, false)
 			CONF_HANDLE_SSIZE_T(opt_lg_dirty_mult, "lg_dirty_mult",
 			    -1, (sizeof(size_t) << 3) - 1)
+			CONF_HANDLE_BOOL(opt_async_purge, "async_purge", true)
+			CONF_HANDLE_SIZE_T(opt_dirty_exp_time, "dirty_exp_time",
+			    0, SIZE_T_MAX, false)
 			CONF_HANDLE_BOOL(opt_stats_print, "stats_print", true)
 			if (config_fill) {
 				if (CONF_MATCH("junk")) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -259,6 +259,7 @@ stats_arena_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	unsigned nthreads;
 	const char *dss;
 	ssize_t lg_dirty_mult;
+	uint64_t dirty_exp_time;
 	size_t page, pactive, pdirty, mapped;
 	size_t metadata_mapped, metadata_allocated;
 	uint64_t npurge, nmadvise, purged;
@@ -286,6 +287,11 @@ stats_arena_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		malloc_cprintf(write_cb, cbopaque,
 		    "min active:dirty page ratio: N/A\n");
 	}
+	CTL_M2_GET("stats.arenas.0.dirty_exp_time", i, &dirty_exp_time,
+	    uint64_t);
+	malloc_cprintf(write_cb, cbopaque,
+	    "dirty page expiration time: %"PRIu64" nanoseconds\n",
+	    dirty_exp_time);
 	CTL_M2_GET("stats.arenas.0.pactive", i, &pactive, size_t);
 	CTL_M2_GET("stats.arenas.0.pdirty", i, &pdirty, size_t);
 	CTL_M2_GET("stats.arenas.0.npurge", i, &npurge, uint64_t);
@@ -426,11 +432,13 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		bool bv;
 		unsigned uv;
 		ssize_t ssv;
-		size_t sv, bsz, ssz, sssz, cpsz;
+		uint64_t u64v;
+		size_t sv, bsz, ssz, sssz, u64sz, cpsz;
 
 		bsz = sizeof(bool);
 		ssz = sizeof(size_t);
 		sssz = sizeof(ssize_t);
+		u64sz = sizeof(uint64_t);
 		cpsz = sizeof(const char *);
 
 		CTL_GET("version", &cpv, const char *);
@@ -472,6 +480,15 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 			    ssv, ssv2);					\
 		}							\
 }
+#define	OPT_WRITE_UINT64_T_MUTABLE(n, m) {				\
+		uint64_t u64v2;						\
+		if (je_mallctl("opt."#n, &u64v, &u64sz, NULL, 0) == 0 &&\
+		    je_mallctl(#m, &u64v2, &u64sz, NULL, 0) == 0) {	\
+			malloc_cprintf(write_cb, cbopaque,		\
+			    "  opt."#n": %"PRIu64" ("#m": %"PRIu64")\n",\
+			    u64v, u64v2);				\
+		}							\
+}
 #define	OPT_WRITE_CHAR_P(n)						\
 		if (je_mallctl("opt."#n, &cpv, &cpsz, NULL, 0) == 0) {	\
 			malloc_cprintf(write_cb, cbopaque,		\
@@ -485,6 +502,8 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		OPT_WRITE_CHAR_P(dss)
 		OPT_WRITE_SIZE_T(narenas)
 		OPT_WRITE_SSIZE_T_MUTABLE(lg_dirty_mult, arenas.lg_dirty_mult)
+		OPT_WRITE_UINT64_T_MUTABLE(dirty_exp_time,
+		    arenas.dirty_exp_time)
 		OPT_WRITE_BOOL(stats_print)
 		OPT_WRITE_CHAR_P(junk)
 		OPT_WRITE_SIZE_T(quarantine)
@@ -537,6 +556,10 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 			malloc_cprintf(write_cb, cbopaque,
 			    "Min active:dirty page ratio per arena: N/A\n");
 		}
+		CTL_GET("arenas.dirty_exp_time", &u64v, uint64_t);
+		malloc_cprintf(write_cb, cbopaque,
+		    "Dirty page expiration time : %"PRIu64" nanoseconds\n",
+		    u64v);
 		if (je_mallctl("arenas.tcache_max", &sv, &ssz, NULL, 0) == 0) {
 			malloc_cprintf(write_cb, cbopaque,
 			    "Maximum thread-cached size class: %zu\n", sv);

--- a/src/time.c
+++ b/src/time.c
@@ -1,0 +1,20 @@
+#include "jemalloc/internal/jemalloc_internal.h"
+
+/******************************************************************************/
+
+uint64_t
+malloc_time_get(void)
+{
+#ifndef _WIN32
+	struct timespec now;
+#endif
+	int ret;
+
+#ifndef _WIN32
+	ret = clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
+	if (likely(ret == 0))
+		return (now.tv_sec * NANOSECONDS_PER_SECOND + now.tv_nsec);
+#endif
+
+	return (0);
+}

--- a/src/time.c
+++ b/src/time.c
@@ -1,20 +1,27 @@
 #include "jemalloc/internal/jemalloc_internal.h"
 
+#ifndef _WIN32
+#include <time.h>
+#endif
+
 /******************************************************************************/
 
 uint64_t
-malloc_time_get(void)
+malloc_time_get_ns(void)
 {
 #ifndef _WIN32
 	struct timespec now;
 #endif
-	int ret;
+	uint64_t ret = 0;
 
 #ifndef _WIN32
-	ret = clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
-	if (likely(ret == 0))
-		return (now.tv_sec * NANOSECONDS_PER_SECOND + now.tv_nsec);
+#ifdef CLOCK_MONOTONIC_COARSE
+	if (likely(clock_gettime(CLOCK_MONOTONIC_COARSE, &now) == 0))
+#else
+	if (likely(clock_gettime(CLOCK_MONOTONIC, &now) == 0))
+#endif
+		ret = now.tv_sec * NANOSECONDS_PER_SECOND + now.tv_nsec;
 #endif
 
-	return (0);
+	return (ret);
 }

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -389,7 +389,8 @@ TEST_BEGIN(test_arena_i_dirty_exp_time)
 
 	assert_d_eq(mallctl("arena.0.dirty_exp_time", &orig_dirty_exp_time, &sz,
 	    NULL, 0), 0, "Unexpected mallctl() failure");
-	assert_u64_eq(orig_dirty_exp_time, DIRTY_EXP_TIME_DEFAULT,
+	assert_u64_eq(orig_dirty_exp_time, DIRTY_EXP_TIME_DEFAULT /
+	    NANOSECONDS_PER_MILLISECOND,
 	    "Unexpected orig arena.0.dirty_exp_time");
 
 	dirty_exp_time = 1234567;
@@ -546,7 +547,8 @@ TEST_BEGIN(test_arenas_dirty_exp_time)
 
 	assert_d_eq(mallctl("arenas.dirty_exp_time", &orig_dirty_exp_time,
 	    &szu64, NULL, 0), 0, "Unexpected mallctl() failure");
-	assert_u64_eq(orig_dirty_exp_time, DIRTY_EXP_TIME_DEFAULT,
+	assert_u64_eq(orig_dirty_exp_time, DIRTY_EXP_TIME_DEFAULT /
+	    NANOSECONDS_PER_MILLISECOND,
 	    "Unexpected orig arenas.dirty_exp_time");
 
 	dirty_exp_time = 7654321;

--- a/test/unit/time.c
+++ b/test/unit/time.c
@@ -1,0 +1,32 @@
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_basic_get)
+{
+	uint64_t now = malloc_time_get();
+
+	assert_u64_gt(now, 0, "Unexpected time: now=0");
+}
+TEST_END
+
+TEST_BEGIN(test_monotonic)
+{
+	uint64_t prev = malloc_time_get();
+	uint64_t now;
+	int i;
+
+	for (i = 0; i < 1000000; i++) {
+		now = malloc_time_get();
+		assert_u64_ge(now, prev, "malloc_time_get() is not monotonic");
+		prev = now;
+	}
+}
+TEST_END
+
+int
+main(void)
+{
+
+	return (test(
+	    test_basic_get,
+	    test_monotonic));
+}

--- a/test/unit/time.c
+++ b/test/unit/time.c
@@ -2,7 +2,7 @@
 
 TEST_BEGIN(test_basic_get)
 {
-	uint64_t now = malloc_time_get();
+	uint64_t now = malloc_time_get_ns();
 
 	assert_u64_gt(now, 0, "Unexpected time: now=0");
 }
@@ -10,13 +10,14 @@ TEST_END
 
 TEST_BEGIN(test_monotonic)
 {
-	uint64_t prev = malloc_time_get();
+	uint64_t prev = malloc_time_get_ns();
 	uint64_t now;
 	int i;
 
 	for (i = 0; i < 1000000; i++) {
-		now = malloc_time_get();
-		assert_u64_ge(now, prev, "malloc_time_get() is not monotonic");
+		now = malloc_time_get_ns();
+		assert_u64_ge(now, prev,
+		    "malloc_time_get_ns() is not monotonic");
 		prev = now;
 	}
 }


### PR DESCRIPTION
This allows application to specify an expiration time for dirty pages. If
dirty_exp_time is not 0, jemalloc will purge dirty pages that are older than the
specified time. The action is triggered each time a dirty run is deallocated.

If async_purge=true, jemalloc itself will not do purging automatically.
Application needs to call mallctl("arena.<i>.purge_old") periodically (probably
from an extra thread) to impose the limit on expiration time. The default
async_purge is false.