### PR TITLE
prevent allocs larger than PTRDIFF_MAX on Android

### DIFF
--- a/src/huge.c
+++ b/src/huge.c
@@ -61,6 +61,11 @@ huge_palloc(tsd_t *tsd, arena_t *arena, size_t size, size_t alignment,
 		return (NULL);
 	assert(usize >= chunksize);
 
+#ifdef __ANDROID__
+	if (usize > PTRDIFF_MAX)
+		return (NULL);
+#endif
+
 	/* Allocate an extent node with which to track the chunk. */
 	node = ipallocztm(tsd, CACHELINE_CEILING(sizeof(extent_node_t)),
 	    CACHELINE, false, tcache, true, arena);
@@ -290,6 +295,11 @@ huge_ralloc_no_move(void *ptr, size_t oldsize, size_t usize_min,
 	if (oldsize < chunksize || usize_max < chunksize)
 		return (true);
 
+#ifdef __ANDROID__
+	if (usize_max > PTRDIFF_MAX)
+		return (true);
+#endif
+
 	if (CHUNK_CEILING(usize_max) > CHUNK_CEILING(oldsize)) {
 		/* Attempt to expand the allocation in-place. */
 		if (!huge_ralloc_no_move_expand(ptr, oldsize, usize_max, zero))
@@ -334,6 +344,11 @@ huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t usize,
 {
 	void *ret;
 	size_t copysize;
+
+#ifdef __ANDROID__
+	if (usize > PTRDIFF_MAX)
+		return (NULL);
+#endif
 
 	/* Try to avoid moving the allocation. */
 	if (!huge_ralloc_no_move(ptr, oldsize, usize, usize, zero))


### PR DESCRIPTION
Android's Bionic libc now reports an out-of-memory error for allocations
larger than PTRDIFF_MAX in order to eliminate classes of potentially
exploitable bugs caused by signed overflow. Since jemalloc merges spans
of virtual memory (both for chunk recycling and in-place huge allocation
growth), it needs to cooperate with Bionic to fully enforce this.

This can be extended to other platforms if and when they decide to do
the same thing as musl and Bionic in this case. There's no need to
handle musl in jemalloc because it doesn't support replacing the malloc
implementation either via weak symbols or hooks like glibc.

Rationale from the Android commit message:

    make mmap fail on requests larger than PTRDIFF_MAX

    Allocations larger than PTRDIFF_MAX can be successfully created on
    32-bit with a 3:1 split, or in 32-bit processes running on 64-bit.

    Allowing these allocations to succeed is dangerous, as it introduces
    overflows for `end - start` and isn't compatible with APIs (mis)using
    ssize_t to report either the size or an error. POSIX is guilty of this,
    as are many other Android APIs. LLVM even considers the `ptr + size`
    case to be undefined, as all pointer arithmetic compiles down to signed
    operations and overflow is treated as undefined for standard C pointer
    arithmetic (GNU C `void *` arithmetic works differently).

    This also prevents dlmalloc from allocating > PTRDIFF_MAX as it doesn't
    merge mappings like jemalloc. A similar check will need to be added in
    jemalloc's code path for huge allocations.

    The musl libc implementation also performs this sanity check.

https://android-review.googlesource.com/#/c/170800/

GCC is also unable to handle `ptr + size` with `size > PTRDIFF_MAX`:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67999