### PR TITLE
je_srallocx function

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -154,6 +154,7 @@ TESTS_INTEGRATION := $(srcroot)test/integration/aligned_alloc.c \
 	$(srcroot)test/integration/overflow.c \
 	$(srcroot)test/integration/posix_memalign.c \
 	$(srcroot)test/integration/rallocx.c \
+	$(srcroot)test/integration/srallocx.c \
 	$(srcroot)test/integration/thread_arena.c \
 	$(srcroot)test/integration/thread_tcache_enabled.c \
 	$(srcroot)test/integration/xallocx.c \

--- a/configure.ac
+++ b/configure.ac
@@ -492,7 +492,7 @@ AC_PROG_RANLIB
 AC_PATH_PROG([LD], [ld], [false], [$PATH])
 AC_PATH_PROG([AUTOCONF], [autoconf], [false], [$PATH])
 
-public_syms="malloc_conf malloc_message malloc calloc posix_memalign aligned_alloc realloc free mallocx rallocx xallocx sallocx dallocx sdallocx nallocx mallctl mallctlnametomib mallctlbymib malloc_stats_print malloc_usable_size"
+public_syms="malloc_conf malloc_message malloc calloc posix_memalign aligned_alloc realloc free mallocx rallocx srallocx xallocx sallocx dallocx sdallocx nallocx mallctl mallctlnametomib mallctlbymib malloc_stats_print malloc_usable_size"
 
 dnl Check for allocator-related functions that should be wrapped.
 AC_CHECK_FUNC([memalign],

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -35,6 +35,7 @@
     <refname>free</refname>
     <refname>mallocx</refname>
     <refname>rallocx</refname>
+    <refname>srallocx</refname>
     <refname>xallocx</refname>
     <refname>sallocx</refname>
     <refname>dallocx</refname>
@@ -100,6 +101,14 @@
         <funcprototype>
           <funcdef>void *<function>rallocx</function></funcdef>
           <paramdef>void *<parameter>ptr</parameter></paramdef>
+          <paramdef>size_t <parameter>size</parameter></paramdef>
+          <paramdef>int <parameter>flags</parameter></paramdef>
+        </funcprototype>
+        <funcprototype>
+          <funcdef>void *<function>srallocx</function></funcdef>
+          <paramdef>void *<parameter>ptr</parameter></paramdef>
+          <paramdef>size_t <parameter>old_size</parameter></paramdef>
+          <paramdef>size_t <parameter>old_size_used</parameter></paramdef>
           <paramdef>size_t <parameter>size</parameter></paramdef>
           <paramdef>int <parameter>flags</parameter></paramdef>
         </funcprototype>
@@ -232,6 +241,7 @@
       <title>Non-standard API</title>
       <para>The <function>mallocx<parameter/></function>,
       <function>rallocx<parameter/></function>,
+      <function>srallocx<parameter/></function>,
       <function>xallocx<parameter/></function>,
       <function>sallocx<parameter/></function>,
       <function>dallocx<parameter/></function>,
@@ -320,6 +330,12 @@
       its original location.  Behavior is undefined if
       <parameter>size</parameter> is <constant>0</constant>, or if request size
       overflows due to size class and/or alignment constraints.</para>
+
+      <para>The <function>srallocx<parameter/></function> function is a
+      sized version of <function>rallocx<parameter/></function> function and has two more
+      parameters: <parameter>old_size</parameter> for size of previosly allocated
+      memory, and <parameter>old_size_used</parameter> for number of bytes to be
+      copied during reallocation.</para>
 
       <para>The <function>xallocx<parameter/></function> function resizes the
       allocation at <parameter>ptr</parameter> in place to be at least
@@ -556,8 +572,8 @@ for (i = 0; i < nbins; i++) {
     allocating.</para>
 
     <para>The <function>realloc<parameter/></function>,
-    <function>rallocx<parameter/></function>, and
-    <function>xallocx<parameter/></function> functions may resize allocations
+    <function>rallocx<parameter/></function>, <function>srallocx<parameter/></function>
+    and <function>xallocx<parameter/></function> functions may resize allocations
     without moving them under limited circumstances.  Unlike the
     <function>*allocx<parameter/></function> API, the standard API does not
     officially round up the usable size of an allocation to the nearest size
@@ -1054,8 +1070,8 @@ for (i = 0; i < nbins; i++) {
         <listitem><para>Zero filling enabled/disabled.  If enabled, each byte
         of uninitialized allocated memory will be initialized to 0.  Note that
         this initialization only happens once for each byte, so
-        <function>realloc<parameter/></function> and
-        <function>rallocx<parameter/></function> calls do not zero memory that
+        <function>realloc<parameter/></function>, <function>rallocx<parameter/></function>
+        and <function>srallocx<parameter/></function> calls do not zero memory that
         was previously allocated.  This is intended for debugging and will
         impact performance negatively.  This option is disabled by default.
         </para></listitem>
@@ -2637,8 +2653,9 @@ typedef struct {
     </refsect2>
     <refsect2>
       <title>Non-standard API</title>
-      <para>The <function>mallocx<parameter/></function> and
-      <function>rallocx<parameter/></function> functions return a pointer to
+      <para>The <function>mallocx<parameter/></function>,
+      <function>rallocx<parameter/></function>
+      and <function>srallocx<parameter/></function> functions return a pointer to
       the allocated memory if successful; otherwise a <constant>NULL</constant>
       pointer is returned to indicate insufficient contiguous memory was
       available to service the allocation request.  </para>

--- a/include/jemalloc/internal/arena.h
+++ b/include/jemalloc/internal/arena.h
@@ -487,8 +487,9 @@ extern arena_ralloc_junk_large_t *arena_ralloc_junk_large;
 #endif
 bool	arena_ralloc_no_move(void *ptr, size_t oldsize, size_t size,
     size_t extra, bool zero);
-void	*arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize,
-    size_t size, size_t alignment, bool zero, tcache_t *tcache);
+void	*arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr,
+	size_t oldsize, size_t oldsize_used,
+	size_t size, size_t alignment, bool zero, tcache_t *tcache);
 dss_prec_t	arena_dss_prec_get(arena_t *arena);
 bool	arena_dss_prec_set(arena_t *arena, dss_prec_t dss_prec);
 ssize_t	arena_lg_dirty_mult_default_get(void);

--- a/include/jemalloc/internal/huge.h
+++ b/include/jemalloc/internal/huge.h
@@ -15,7 +15,8 @@ void	*huge_palloc(tsd_t *tsd, arena_t *arena, size_t size, size_t alignment,
     bool zero, tcache_t *tcache);
 bool	huge_ralloc_no_move(void *ptr, size_t oldsize, size_t usize_min,
     size_t usize_max, bool zero);
-void	*huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize,
+void	*huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr,
+	size_t oldsize, size_t oldsize_used,
     size_t usize, size_t alignment, bool zero, tcache_t *tcache);
 #ifdef JEMALLOC_JET
 typedef void (huge_dalloc_junk_t)(void *, size_t);

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -1083,8 +1083,8 @@ iralloct_realign(tsd_t *tsd, void *ptr, size_t oldsize, size_t size,
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-iralloct(tsd_t *tsd, void *ptr, size_t oldsize, size_t size, size_t alignment,
-    bool zero, tcache_t *tcache, arena_t *arena)
+iralloct(tsd_t *tsd, void *ptr, size_t oldsize, size_t oldsize_used, size_t size,
+	size_t alignment, bool zero, tcache_t *tcache, arena_t *arena)
 {
 
 	assert(ptr != NULL);
@@ -1100,16 +1100,16 @@ iralloct(tsd_t *tsd, void *ptr, size_t oldsize, size_t size, size_t alignment,
 		    zero, tcache, arena));
 	}
 
-	return (arena_ralloc(tsd, arena, ptr, oldsize, size, alignment, zero,
-	    tcache));
+	return (arena_ralloc(tsd, arena, ptr, oldsize, oldsize_used, size,
+		alignment, zero, tcache));
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-iralloc(tsd_t *tsd, void *ptr, size_t oldsize, size_t size, size_t alignment,
-    bool zero)
+iralloc(tsd_t *tsd, void *ptr, size_t oldsize, size_t oldsize_used, size_t size,
+	size_t alignment, bool zero)
 {
 
-	return (iralloct(tsd, ptr, oldsize, size, alignment, zero,
+	return (iralloct(tsd, ptr, oldsize, oldsize_used, size, alignment, zero,
 	    tcache_get(tsd, true), NULL));
 }
 

--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -31,6 +31,9 @@ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
 JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
     void JEMALLOC_NOTHROW	*@je_@rallocx(void *ptr, size_t size,
     int flags) JEMALLOC_ALLOC_SIZE(2);
+JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+    void JEMALLOC_NOTHROW	*@je_@srallocx(void *ptr, size_t old_size,
+    size_t used_size, size_t size, int flags) JEMALLOC_ALLOC_SIZE(4);
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@xallocx(void *ptr, size_t size,
     size_t extra, int flags);
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@sallocx(const void *ptr,

--- a/src/arena.c
+++ b/src/arena.c
@@ -2851,8 +2851,8 @@ arena_ralloc_move_helper(tsd_t *tsd, arena_t *arena, size_t usize,
 }
 
 void *
-arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
-    size_t alignment, bool zero, tcache_t *tcache)
+arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t oldsize_used,
+	size_t size, size_t alignment, bool zero, tcache_t *tcache)
 {
 	void *ret;
 	size_t usize;
@@ -2883,13 +2883,13 @@ arena_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t size,
 		 * ipalloc()/arena_malloc().
 		 */
 
-		copysize = (usize < oldsize) ? usize : oldsize;
+		copysize = (usize < oldsize_used) ? usize : oldsize_used;
 		JEMALLOC_VALGRIND_MAKE_MEM_UNDEFINED(ret, copysize);
 		memcpy(ret, ptr, copysize);
 		isqalloc(tsd, ptr, oldsize, tcache);
 	} else {
-		ret = huge_ralloc(tsd, arena, ptr, oldsize, usize, alignment,
-		    zero, tcache);
+		ret = huge_ralloc(tsd, arena, ptr, oldsize, oldsize_used,
+			usize, alignment, zero, tcache);
 	}
 	return (ret);
 }

--- a/src/huge.c
+++ b/src/huge.c
@@ -329,8 +329,9 @@ huge_ralloc_move_helper(tsd_t *tsd, arena_t *arena, size_t usize,
 }
 
 void *
-huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t usize,
-    size_t alignment, bool zero, tcache_t *tcache)
+huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr,
+	size_t oldsize, size_t oldsize_used,
+	size_t usize, size_t alignment, bool zero, tcache_t *tcache)
 {
 	void *ret;
 	size_t copysize;
@@ -349,7 +350,7 @@ huge_ralloc(tsd_t *tsd, arena_t *arena, void *ptr, size_t oldsize, size_t usize,
 	if (ret == NULL)
 		return (NULL);
 
-	copysize = (usize < oldsize) ? usize : oldsize;
+	copysize = (usize < oldsize_used) ? usize : oldsize_used;
 	memcpy(ret, ptr, copysize);
 	isqalloc(tsd, ptr, oldsize, tcache);
 	return (ret);

--- a/test/integration/srallocx.c
+++ b/test/integration/srallocx.c
@@ -1,0 +1,67 @@
+#include "test/jemalloc_test.h"
+
+
+/* Generate random printable ASCII char */
+static char random_char(size_t pos) {
+	return (char) ('!' + ((pos * 17) % ('~' - '!' + 1)));
+}
+
+
+static void test_for_size(size_t first_alloc_size, size_t realloc_size) {
+	void *p;
+	void *q;
+
+	size_t used_size = first_alloc_size / 2;
+
+	p = mallocx(first_alloc_size, 0);
+	assert_ptr_not_null(p, "mallocx() unexpectedly failed");
+
+	for (size_t i = 0; i < first_alloc_size; ++i) {
+		((char*) p)[i] = random_char(i);
+	}
+
+	q = srallocx(p, first_alloc_size, used_size, realloc_size, 0);
+	assert_ptr_not_null(q, "srallocx() unexpectedly failed");
+	assert_ptr_ne(p, q, "should reallocate with changed addr for following checks");
+
+	for (size_t i = 0; i < used_size; ++i) {
+		assert_c_eq(random_char(i), ((char*) q)[i], "data is copied in srallocx()");
+	}
+
+/*
+ * not running this part of test under valgrind
+ * because if srallocx works properly, this code reads
+ * uninitialized memory
+ */
+#ifndef JEMALLOC_VALGRIND
+	for (size_t i = used_size; ; ++i) {
+		if (i == first_alloc_size) {
+			assert_not_reached("either all data copied"
+				" or random memory contained expected sequence");
+		}
+
+		if (random_char(i) != ((char*) q)[i]) {
+			// found byte that is not copied by srallocx
+			break;
+		}
+	}
+#endif
+
+	sdallocx(q, realloc_size, 0);
+}
+
+
+TEST_BEGIN(test_basic)
+{
+	test_for_size(100, 1000);
+	test_for_size(100, 10000000);
+	test_for_size(1000000, 2000000);
+}
+TEST_END
+
+int
+main(void)
+{
+	return (test(
+		test_basic));
+}


### PR DESCRIPTION
Similar to `je_rallocx` function, but with two more parameters:
* allocated size (to avoid call to `isalloc`)
* used data size (to avoid copying more than necessary to the new region)

Closes #298