### PR TITLE
Reuse previously computed value

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -122,8 +122,10 @@ static void
 zone_free_definite_size(malloc_zone_t *zone, void *ptr, size_t size)
 {
 
-	if (ivsalloc(ptr, config_prof) != 0) {
-		assert(ivsalloc(ptr, config_prof) == size);
+	size_t alloc_size;
+	alloc_size = ivsalloc(ptr, config_prof);
+	if (alloc_size != 0) {
+		assert(alloc_size == size);
 		je_free(ptr);
 		return;
 	}


### PR DESCRIPTION
These two `ivsalloc()` calls are identical and should yield the same result. There's no need for two identical calls. It's better to cache and reuse the value instead of recomputing it. Should the assert fire it's more convenient to see the value immediately. Also the new code makes a single call both with asserts present (debug builds) and asserts removed (non-debug builds) which makes it more predictable in case of some "impossible" bugs.