### PR TITLE
Prefer object-dir includes over source-dir includes.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ abs_srcroot := @abs_srcroot@
 abs_objroot := @abs_objroot@
 
 # Build parameters.
-CPPFLAGS := @CPPFLAGS@ -I$(srcroot)include -I$(objroot)include
+CPPFLAGS := @CPPFLAGS@ -I$(objroot)include -I$(srcroot)include
 CFLAGS := @CFLAGS@
 LDFLAGS := @LDFLAGS@
 EXTRA_LDFLAGS := @EXTRA_LDFLAGS@


### PR DESCRIPTION
 When building out-ouf-source, we need to use object-dir include files
because they contain the generated macros, rather than the ones in
source-dir.