### PR TITLE
Fix stack corruption in unit test and uninitialized var warning

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -2458,6 +2458,7 @@ arena_malloc_large(tsd_t *tsd, arena_t *arena, szind_t binind, bool zero)
 		arena->stats.lstats[index].nrequests++;
 		arena->stats.lstats[index].curruns++;
 	}
+  idump = false;
 	if (config_prof)
 		idump = arena_prof_accum_locked(arena, usize);
 	malloc_mutex_unlock(&arena->lock);

--- a/test/unit/hash.c
+++ b/test/unit/hash.c
@@ -63,15 +63,16 @@ hash_variant_string(hash_variant_t variant)
 static void
 hash_variant_verify_key(hash_variant_t variant, uint8_t *key)
 {
-	const int hashbytes = hash_variant_bits(variant) / 8;
-	VARIABLE_ARRAY(uint8_t, hashes, hashbytes * 256);
+	const size_t hashbytes = hash_variant_bits(variant) / 8;
+  const size_t hashes_size = hashbytes * 256U;
+  VARIABLE_ARRAY(uint8_t, hashes, hashes_size);
 	VARIABLE_ARRAY(uint8_t, final, hashbytes);
 	unsigned i;
 	uint32_t computed, expected;
 
 	memset(key, 0, KEY_SIZE);
-	memset(hashes, 0, sizeof(hashes));
-	memset(final, 0, sizeof(final));
+  memset(hashes, 0, hashes_size);
+  memset(final, 0, hashbytes);
 
 	/*
 	 * Hash keys of the form {0}, {0,1}, {0,1,2}, ..., {0,1,...,255} as the


### PR DESCRIPTION
  Stack corruption happens in x64 bit in hash unit test.
  `memset()` makes use of the `sizeof(ptr)` not an array since
  on Windows `VARIABLE_ARRAY` is `alloced` and the result is a ptr
  which is 8 bytes on x64 and that is bigger than 32-bit hash.
  This corrupts the stack.
  Warning in arena.c issued by MSVC 13 Release is questionable
  but breaks the build.