### PR TITLE
Pairing heap

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -95,6 +95,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/mutex.c \
 	$(srcroot)src/nstime.c \
 	$(srcroot)src/pages.c \
+	$(srcroot)src/ph.c \
 	$(srcroot)src/prng.c \
 	$(srcroot)src/prof.c \
 	$(srcroot)src/quarantine.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -148,6 +148,7 @@ TESTS_UNIT := $(srcroot)test/unit/atomic.c \
 	$(srcroot)test/unit/math.c \
 	$(srcroot)test/unit/mq.c \
 	$(srcroot)test/unit/mtx.c \
+	$(srcroot)test/unit/ph.c \
 	$(srcroot)test/unit/prng.c \
 	$(srcroot)test/unit/prof_accum.c \
 	$(srcroot)test/unit/prof_active.c \

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -371,6 +371,7 @@ typedef unsigned szind_t;
 #include "jemalloc/internal/tsd.h"
 #include "jemalloc/internal/mb.h"
 #include "jemalloc/internal/extent.h"
+#include "jemalloc/internal/ph.h"
 #include "jemalloc/internal/arena.h"
 #include "jemalloc/internal/bitmap.h"
 #include "jemalloc/internal/base.h"
@@ -401,6 +402,7 @@ typedef unsigned szind_t;
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/mb.h"
 #include "jemalloc/internal/bitmap.h"
+#include "jemalloc/internal/ph.h"
 #define	JEMALLOC_ARENA_STRUCTS_A
 #include "jemalloc/internal/arena.h"
 #undef JEMALLOC_ARENA_STRUCTS_A
@@ -494,6 +496,7 @@ void	jemalloc_postfork_child(void);
 #include "jemalloc/internal/mb.h"
 #include "jemalloc/internal/bitmap.h"
 #include "jemalloc/internal/extent.h"
+#include "jemalloc/internal/ph.h"
 #include "jemalloc/internal/arena.h"
 #include "jemalloc/internal/base.h"
 #include "jemalloc/internal/rtree.h"
@@ -525,6 +528,7 @@ void	jemalloc_postfork_child(void);
 #include "jemalloc/internal/tsd.h"
 #include "jemalloc/internal/mb.h"
 #include "jemalloc/internal/extent.h"
+#include "jemalloc/internal/ph.h"
 #include "jemalloc/internal/base.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/pages.h"

--- a/include/jemalloc/internal/ph.h
+++ b/include/jemalloc/internal/ph.h
@@ -1,0 +1,238 @@
+/*
+ * A Pairing Heap implementation.
+ *
+ * "The Pairing Heap: A New Form of Self-Adjusting Heap"
+ * https://www.cs.cmu.edu/~sleator/papers/pairing-heaps.pdf
+ *
+ * With auxiliary list, described in a follow on paper
+ *
+ * "Pairing Heaps: Experiments and Analysis"
+ * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.106.2988&rep=rep1&type=pdf
+ *
+ * Where search/nsearch/last are not needed, ph.h outperforms rb.h by ~7x fewer
+ * cpu cycles, and ~4x fewer memory references.
+ *
+ * Tagging parent/prev pointers on the next list was also described in the
+ * original paper, such that only two pointers are needed.  This is not
+ * implemented here, as it substantially increases the memory references
+ * needed when ph_remove is called, almost overshadowing the other performance
+ * gains.
+ */
+#ifdef JEMALLOC_H_TYPES
+
+typedef struct ph_node_s ph_node_t;
+typedef struct ph_heap_s ph_heap_t;
+
+#endif /* JEMALLOC_H_TYPES */
+/******************************************************************************/
+#ifdef JEMALLOC_H_STRUCTS
+
+struct ph_node_s {
+  ph_node_t *subheaps;
+  ph_node_t *parent;
+  ph_node_t *next;
+  ph_node_t *prev;
+};
+
+struct ph_heap_s {
+  ph_node_t *root;
+};
+
+#endif /* JEMALLOC_H_STRUCTS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_EXTERNS
+
+#endif /* JEMALLOC_H_EXTERNS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_INLINES
+
+#ifndef JEMALLOC_ENABLE_INLINE
+
+ph_node_t *ph_merge(ph_node_t *heap1, ph_node_t *heap2);
+ph_node_t *ph_merge_pairs(ph_node_t *subheaps);
+void ph_merge_aux_list(ph_heap_t *l);
+void ph_new(ph_heap_t *n);
+ph_node_t *ph_first(ph_heap_t *l);
+void ph_insert( ph_heap_t *l, ph_node_t *n);
+ph_node_t *ph_remove_first(ph_heap_t *l);
+void ph_remove(ph_heap_t *l, ph_node_t *n);
+
+#endif
+
+#if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_PH_C_))
+
+/* Helper routines ************************************************************/
+
+JEMALLOC_INLINE ph_node_t *
+ph_merge(ph_node_t *heap1, ph_node_t *heap2) {
+	if (heap1 == NULL)
+		return (heap2);
+	else if(heap2 == NULL)
+		return (heap1);
+	/* Optional: user-settable comparison function */
+	else if (heap1 < heap2) {
+		heap2->parent = heap1;
+		heap2->prev = NULL;
+		heap2->next = heap1->subheaps;
+		if (heap1->subheaps)
+			heap1->subheaps->prev = heap2;
+		heap1->subheaps = heap2;
+		return (heap1);
+	} else {
+		heap1->parent = heap2;
+		heap1->prev = NULL;
+		heap1->next = heap2->subheaps;
+		if (heap2->subheaps)
+			heap2->subheaps->prev = heap1;
+		heap2->subheaps = heap1;
+		return (heap2);
+	}
+}
+
+JEMALLOC_INLINE ph_node_t *
+ph_merge_pairs(ph_node_t *subheaps) {
+	if (!subheaps)
+		return (NULL);
+	else if (subheaps->next == NULL)
+		return (subheaps);
+	else {
+		ph_node_t *l0 = subheaps;
+		ph_node_t *l1 = l0->next;
+		ph_node_t *lrest = l1->next;
+
+		if (lrest)
+			lrest->prev = NULL;
+		l1->next = NULL;
+		l1->prev = NULL;
+		l0->next = NULL;
+		l0->prev = NULL;
+		return (ph_merge(ph_merge(l0, l1), ph_merge_pairs(lrest)));
+	}
+}
+
+/*
+ * Merge the aux list in to the root node.
+ */
+JEMALLOC_INLINE void
+ph_merge_aux_list(ph_heap_t *l) {
+	if (!l->root)
+		return;
+	if (l->root->next) {
+		ph_node_t *l0 = l->root->next;
+		ph_node_t *l1 = l0->next;
+		ph_node_t *lrest = NULL;
+
+		/* Multipass merge */
+		while(l1) {
+			lrest = l1->next;
+			if (lrest)
+				lrest->prev = NULL;
+			l1->next = NULL;
+			l1->prev = NULL;
+			l0->next = NULL;
+			l0->prev = NULL;
+			l0 = ph_merge(l0, l1);
+			l1 = lrest;
+		}
+		l->root->next = NULL;
+		l->root = ph_merge(l->root, l0);
+	}
+}
+
+/* User API *******************************************************************/
+
+JEMALLOC_INLINE void
+ph_new(ph_heap_t *n) {
+	memset(n, 0, sizeof(ph_heap_t));
+}
+
+JEMALLOC_INLINE ph_node_t *
+ph_first(ph_heap_t *l) {
+	/*
+	 * For the cost of an extra pointer, a l->min could be stored
+	 * instead of merging the aux list here.  Current users always
+	 * call ph_remove(l, ph_first(l)) though, and the aux list
+	 * must always be merged for delete of the min node anyway.
+	 */
+	ph_merge_aux_list(l);
+	return (l->root);
+}
+
+JEMALLOC_INLINE void
+ph_insert(ph_heap_t *l, ph_node_t *n) {
+	memset(n, 0, sizeof(ph_node_t));
+
+	/*
+	 * Non-aux list insert:
+	 *
+	 * l->root = ph_merge(l->root, n);
+	 *
+	 * Aux list insert:
+	 */
+	if(!l->root)
+		l->root = n;
+	else {
+		n->next = l->root->next;
+		if (l->root->next)
+			l->root->next->prev = n;
+		n->prev = l->root;
+		l->root->next = n;
+	}
+}
+
+JEMALLOC_INLINE ph_node_t *
+ph_remove_first(ph_heap_t *l) {
+	ph_node_t *ret;
+	ph_merge_aux_list(l);
+	if (!l->root)
+		return (NULL);
+
+	ret = l->root;
+
+	l->root = ph_merge_pairs(l->root->subheaps);
+
+	return (ret);
+}
+
+JEMALLOC_INLINE void
+ph_remove(ph_heap_t *l, ph_node_t *n) {
+	ph_node_t *replace;
+
+	/* We can delete from aux list without merging it, but we need
+	   to merge if we are dealing with the root node */
+	if (l->root == n) {
+		ph_merge_aux_list(l);
+		if (l->root == n) {
+			ph_remove_first(l);
+			return;
+		}
+	}
+
+	/* Find a possible replacement node, and link to parent */
+	replace = ph_merge_pairs(n->subheaps);
+	if (n->parent != NULL && n->parent->subheaps == n) {
+		if (replace)
+			n->parent->subheaps = replace;
+		else
+			n->parent->subheaps = n->next;
+	}
+	/* Set next/prev for sibling linked list */
+	if (replace) {
+		replace->parent = n->parent;
+		replace->prev = n->prev;
+		if (n->prev)
+			n->prev->next = replace;
+		replace->next = n->next;
+		if (n->next)
+			n->next->prev = replace;
+	} else {
+		if (n->prev)
+			n->prev->next = n->next;
+		if (n->next)
+			n->next->prev = n->prev;
+	}
+}
+#endif
+
+#endif /* JEMALLOC_H_INLINES */
+/******************************************************************************/

--- a/src/arena.c
+++ b/src/arena.c
@@ -199,7 +199,7 @@ run_quantize_ceil(size_t size)
 run_quantize_t *run_quantize_ceil = JEMALLOC_N(run_quantize_ceil_impl);
 #endif
 
-static arena_run_tree_t *
+static ph_heap_t *
 arena_runs_avail_get(arena_t *arena, szind_t ind)
 {
 
@@ -217,8 +217,8 @@ arena_avail_insert(arena_t *arena, arena_chunk_t *chunk, size_t pageind,
 	    arena_miscelm_get(chunk, pageind))));
 	assert(npages == (arena_mapbits_unallocated_size_get(chunk, pageind) >>
 	    LG_PAGE));
-	arena_run_tree_insert(arena_runs_avail_get(arena, ind),
-	    arena_miscelm_get(chunk, pageind));
+	ph_insert(arena_runs_avail_get(arena, ind),
+	    &arena_miscelm_get(chunk, pageind)->avail.ph_link);
 }
 
 static void
@@ -229,8 +229,8 @@ arena_avail_remove(arena_t *arena, arena_chunk_t *chunk, size_t pageind,
 	    arena_miscelm_get(chunk, pageind))));
 	assert(npages == (arena_mapbits_unallocated_size_get(chunk, pageind) >>
 	    LG_PAGE));
-	arena_run_tree_remove(arena_runs_avail_get(arena, ind),
-	    arena_miscelm_get(chunk, pageind));
+	ph_remove(arena_runs_avail_get(arena, ind),
+	    &arena_miscelm_get(chunk, pageind)->avail.ph_link);
 }
 
 static void
@@ -245,8 +245,8 @@ arena_run_dirty_insert(arena_t *arena, arena_chunk_t *chunk, size_t pageind,
 	assert(arena_mapbits_dirty_get(chunk, pageind+npages-1) ==
 	    CHUNK_MAP_DIRTY);
 
-	qr_new(&miscelm->rd, rd_link);
-	qr_meld(&arena->runs_dirty, &miscelm->rd, rd_link);
+	qr_new(&miscelm->avail.rd, rd_link);
+	qr_meld(&arena->runs_dirty, &miscelm->avail.rd, rd_link);
 	arena->ndirty += npages;
 }
 
@@ -262,7 +262,7 @@ arena_run_dirty_remove(arena_t *arena, arena_chunk_t *chunk, size_t pageind,
 	assert(arena_mapbits_dirty_get(chunk, pageind+npages-1) ==
 	    CHUNK_MAP_DIRTY);
 
-	qr_remove(&miscelm->rd, rd_link);
+	qr_remove(&miscelm->avail.rd, rd_link);
 	assert(arena->ndirty >= npages);
 	arena->ndirty -= npages;
 }
@@ -1079,9 +1079,9 @@ arena_run_first_best_fit(arena_t *arena, size_t size)
 
 	ind = size2index(run_quantize_ceil(size));
 	for (i = ind; i < runs_avail_nclasses + runs_avail_bias; i++) {
-		arena_chunk_map_misc_t *miscelm = arena_run_tree_first(
-		    arena_runs_avail_get(arena, i));
-		if (miscelm != NULL)
+		ph_node_t *node = ph_first(arena_runs_avail_get(arena, i));
+		arena_chunk_map_misc_t *miscelm = arena_ph_to_miscelm(node);
+		if (node != NULL)
 			return (&miscelm->run);
 	}
 
@@ -3379,7 +3379,7 @@ arena_new(unsigned ind)
 	arena->ndirty = 0;
 
 	for(i = 0; i < runs_avail_nclasses; i++)
-		arena_run_tree_new(&arena->runs_avail[i]);
+		ph_new(&arena->runs_avail[i]);
 	qr_new(&arena->runs_dirty, rd_link);
 	qr_new(&arena->chunks_cache, cc_link);
 

--- a/test/unit/ph.c
+++ b/test/unit/ph.c
@@ -1,0 +1,92 @@
+#include "test/jemalloc_test.h"
+
+typedef struct node_s node_t;
+
+struct node_s {
+	ph_node_t link;
+};
+
+TEST_BEGIN(test_ph_empty)
+{
+	ph_heap_t tree;
+
+	ph_new(&tree);
+
+	assert_ptr_null(ph_first(&tree), "Unexpected node");
+}
+TEST_END
+
+TEST_BEGIN(test_ph_random)
+{
+#define	NNODES 25
+#define	NBAGS 250
+#define	SEED 42
+	sfmt_t *sfmt;
+	uint64_t bag[NNODES];
+	ph_heap_t tree;
+	node_t nodes[NNODES];
+	unsigned i, j, k;
+
+	sfmt = init_gen_rand(SEED);
+	for (i = 0; i < NBAGS; i++) {
+		switch (i) {
+		case 0:
+			/* Insert in order. */
+			for (j = 0; j < NNODES; j++)
+				bag[j] = j;
+			break;
+		case 1:
+			/* Insert in reverse order. */
+			for (j = 0; j < NNODES; j++)
+				bag[j] = NNODES - j - 1;
+			break;
+		default:
+			for (j = 0; j < NNODES; j++)
+				bag[j] = gen_rand64_range(sfmt, NNODES);
+		}
+
+		for (j = 1; j <= NNODES; j++) {
+			/* Initialize tree and nodes. */
+			ph_new(&tree);
+
+			/* Insert nodes. */
+			for (k = 0; k < j; k++) {
+				ph_insert(&tree, &nodes[k].link);
+
+				assert_ptr_not_null(ph_first(&tree),
+				    "Tree should not be empty");
+			}
+
+			/* Remove nodes. */
+			switch (i % 2) {
+			case 0:
+				for (k = 0; k < j; k++)
+					ph_remove(&tree, &nodes[k].link);
+				break;
+			case 1:
+				for (k = j; k > 0; k--)
+					ph_remove(&tree, &nodes[k-1].link);
+				break;
+			default:
+				not_reached();
+			}
+
+			assert_ptr_null(ph_first(&tree),
+				    "Tree should not be empty");
+		}
+	}
+	fini_gen_rand(sfmt);
+#undef NNODES
+#undef NBAGS
+#undef SEED
+}
+TEST_END
+
+int
+main(void)
+{
+
+	return (test(
+	    test_ph_empty,
+	    test_ph_random));
+}


### PR DESCRIPTION
Even after recent improvements to arena's runs_avail tree, it still looks like it is extremely hot.  Since we've separated the concerns of address and size, and no longer use nsearch(), we can drop in a heap implementation instead for O(1) insertions and O(logn) deletes.

I experimented with a handful of other datastructures (skiplist, array-based heaps, the old rb.h with parent pointers, aux list or no, tagged parent pointers, etc), but a twopass pairing heap with aux list ended up being fastest so far.  

Benchmarked by hacking up a version of rb_bench to only test insert/delete/first.  Pairing heaps were ~7x faster by cycles, ~4x fewer memory loads.

Tested similarly with rb_test, and also canaried in prod - didn't see any leaks or crashes.  Canary showed 1% cpu improvement, 2% tail latency improvement.