### PR TITLE
Hotpatch out remaining fast-path option branches

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -89,6 +89,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/extent_mmap.c \
 	$(srcroot)src/hash.c \
 	$(srcroot)src/large.c \
+	$(srcroot)src/runtime_patch.c \
 	$(srcroot)src/mb.c \
 	$(srcroot)src/mutex.c \
 	$(srcroot)src/nstime.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1020,6 +1020,32 @@ if test "x$enable_cache_oblivious" = "x1" ; then
 fi
 AC_SUBST([enable_cache_oblivious])
 
+dnl Support runtime-patching of configuration branches
+AC_ARG_ENABLE([runtime-patching],
+  [AS_HELP_STRING([--disable-runtime-patching],
+                  [Disable support for runtime-patching of configuration branches])],
+[if test "x$enable_runtime_patching" = "xno" ; then
+  enable_runtime_patching="0"
+else
+  enable_runtime_patching="1"
+fi
+],
+[enable_runtime_patching="1"]
+)
+if test "x$enable_runtime_patching" = "x1" -a "x$GCC" = "xyes"; then
+  case "${host_cpu}" in
+    i686|x86_64)
+	AC_DEFINE([JEMALLOC_RUNTIME_PATCHING], [ ])
+	;;
+    *)
+	enable_runtime_patching="0"
+	;;
+  esac
+else
+  enable_runtime_patching="0"
+fi
+AC_SUBST([enable_runtime_patching])
+
 dnl ============================================================================
 dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.
 dnl One of those two functions should (theoretically) exist on all platforms
@@ -1757,4 +1783,5 @@ AC_MSG_RESULT([munmap             : ${enable_munmap}])
 AC_MSG_RESULT([lazy_lock          : ${enable_lazy_lock}])
 AC_MSG_RESULT([tls                : ${enable_tls}])
 AC_MSG_RESULT([cache-oblivious    : ${enable_cache_oblivious}])
+AC_MSG_RESULT([runtime-patching   : ${enable_runtime_patching}])
 AC_MSG_RESULT([===============================================================================])

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -343,6 +343,7 @@ typedef unsigned szind_t;
 #  define VARIABLE_ARRAY(type, name, count) type name[(count)]
 #endif
 
+#include "jemalloc/internal/runtime_patch.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/util.h"
 #include "jemalloc/internal/atomic.h"
@@ -373,6 +374,7 @@ typedef unsigned szind_t;
 /******************************************************************************/
 #define	JEMALLOC_H_STRUCTS
 
+#include "jemalloc/internal/runtime_patch.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/util.h"
 #include "jemalloc/internal/atomic.h"
@@ -464,6 +466,7 @@ void	jemalloc_prefork(void);
 void	jemalloc_postfork_parent(void);
 void	jemalloc_postfork_child(void);
 
+#include "jemalloc/internal/runtime_patch.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/util.h"
 #include "jemalloc/internal/atomic.h"
@@ -494,6 +497,7 @@ void	jemalloc_postfork_child(void);
 /******************************************************************************/
 #define	JEMALLOC_H_INLINES
 
+#include "jemalloc/internal/runtime_patch.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/util.h"
 #include "jemalloc/internal/atomic.h"

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -206,6 +206,12 @@
 #undef JEMALLOC_CACHE_OBLIVIOUS
 
 /*
+ * If defined, use runtime code modification to remove configuration branches
+ * from the hot path.
+ */
+#undef JEMALLOC_RUNTIME_PATCHING
+
+/*
  * Darwin (OS X) uses zones to work around Mach-O symbol override shortcomings.
  */
 #undef JEMALLOC_ZONE

--- a/include/jemalloc/internal/runtime_patch.h
+++ b/include/jemalloc/internal/runtime_patch.h
@@ -1,0 +1,106 @@
+#ifdef JEMALLOC_H_TYPES
+
+#if	defined(JEMALLOC_RUNTIME_PATCHING) && \
+	defined(__x86_64__) && \
+	(__GNUC__ > 4 || (__GNUC_MINOR__ >= 5 && __GNUC__ == 4))
+#  define X86_64_PATCHING
+#endif
+
+typedef struct jmp_desc_s jmp_desc_t;
+
+#endif /* JEMALLOC_H_TYPES */
+/******************************************************************************/
+#ifdef JEMALLOC_H_STRUCTS
+
+enum PATCH_OPTIONS {
+  MALLOC_SLOW = 0,
+  OPT_PROF = 1,
+};
+
+struct jmp_desc_s {
+        intptr_t option;
+	void *jump_from;
+	void *jump_to;
+} __attribute__((packed));
+
+#endif /* JEMALLOC_H_STRUCTS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_EXTERNS
+
+#ifdef X86_64_PATCHING
+void malloc_patch_option(intptr_t key, bool* option);
+#endif
+
+#endif /* JEMALLOC_H_EXTERNS */
+/******************************************************************************/
+#ifdef JEMALLOC_H_INLINES
+
+#ifdef X86_64_PATCHING
+
+/* Must *always* be inlined */
+#define PATCH_FUNC_OFF(key)						\
+  JEMALLOC_ALWAYS_INLINE_C JEMALLOC_ATTR(unused) bool			\
+malloc_##key##_default_off(bool* option) {				\
+  asm goto (								\
+	    /* 8-byte noop, enough space for a 32-bit jmp later */	\
+	    "0: .byte 0x0f,0x1f,0x84,0x00,0x00,0x00,0x00,0x00;"		\
+	    /* Save key in jmp_table for later patching */		\
+	    ".pushsection jmp_table, \"a\";"				\
+	    ".quad %c0, 0b, %l1;"					\
+	    ".popsection"						\
+	    : : "i" (key) : : foo);					\
+  return false;								\
+  if (0) {								\
+  foo:									\
+    return true;							\
+  }									\
+}
+
+#define PATCH_FUNC_ON(key)						\
+  JEMALLOC_ALWAYS_INLINE_C JEMALLOC_ATTR(unused) bool			\
+  malloc_##key##_default_on(bool* option) {				\
+    asm goto (								\
+      /* 32bit jmp */							\
+      "0: .byte 0xe9 \n\t"						\
+              /* relative jmp address */				\
+	      ".long %l1 - 0b - 5\n\t"					\
+	      ".byte 0x00\n\t"						\
+	      ".byte 0x00\n\t"						\
+	      ".byte 0x00\n\t"						\
+              /* Save key in jmp_table for later patching */		\
+	      ".pushsection jmp_table, \"a\";"				\
+	      ".quad %c0, 0b, %l1;"					\
+	      ".popsection"						\
+	      : : "i" (key) : : foo);					\
+    return false;							\
+    if (0) {								\
+    foo:								\
+      return true;							\
+    }									\
+}
+
+#else /* X86_64_PATCHING */
+
+/* Always inline these, even in debug mode, for clarity */
+JEMALLOC_ALWAYS_INLINE_C void JEMALLOC_ATTR(unused)
+malloc_patch_option(intptr_t key, bool* option) {}
+
+#define PATCH_FUNC_OFF(key)					\
+  JEMALLOC_ALWAYS_INLINE_C bool JEMALLOC_ATTR(unused)		\
+  malloc_##key##_default_off(bool* option) {			\
+    return *option;						\
+  }
+
+#define PATCH_FUNC_ON(key)					\
+  JEMALLOC_ALWAYS_INLINE_C bool JEMALLOC_ATTR(unused)		\
+  malloc_##key##_default_on(bool* option) {			\
+    return *option;						\
+  }
+
+#endif /* X86_64_PATCHING */
+
+PATCH_FUNC_OFF(OPT_PROF)
+PATCH_FUNC_ON(MALLOC_SLOW)
+
+#endif /* JEMALLOC_H_INLINES */
+/******************************************************************************/

--- a/src/prof.c
+++ b/src/prof.c
@@ -2021,6 +2021,7 @@ prof_active_set(tsdn_t *tsdn, bool active)
 	malloc_mutex_lock(tsdn, &prof_active_mtx);
 	prof_active_old = prof_active;
 	prof_active = active;
+	malloc_patch_option(PROF_ACTIVE, &prof_active);
 	malloc_mutex_unlock(tsdn, &prof_active_mtx);
 	return (prof_active_old);
 }
@@ -2208,6 +2209,7 @@ prof_boot2(tsdn_t *tsdn)
 		lg_prof_sample = opt_lg_prof_sample;
 
 		prof_active = opt_prof_active;
+		malloc_patch_option(PROF_ACTIVE, &prof_active);
 		if (malloc_mutex_init(&prof_active_mtx, "prof_active",
 		    WITNESS_RANK_PROF_ACTIVE))
 			return (true);

--- a/src/runtime_patch.c
+++ b/src/runtime_patch.c
@@ -1,0 +1,71 @@
+#include "jemalloc/internal/jemalloc_internal.h"
+
+#ifdef X86_64_PATCHING
+
+static void unprotect(void *addr, size_t len, int flags) {
+        intptr_t start = (intptr_t)PAGE_ADDR2BASE(addr);
+        if (mprotect((void *) start, len + (intptr_t)addr - start, flags)) {
+		perror("mprotect");
+		abort();
+	}
+}
+
+#define JMP_INSTR_LEN 5
+
+void malloc_patch_option(intptr_t key, bool* option) {
+	extern jmp_desc_t __start_jmp_table[], __stop_jmp_table[];
+	jmp_desc_t *desc;
+	int64_t offset;
+	int32_t offset32;
+	unsigned long *dest;
+	char jmp[8];
+	void *newp;
+
+	int patched = 0;
+
+	/* Search for jmps to modify.  Note that because of inlining,
+	 * multiple addresses may be found */
+	for (desc = __start_jmp_table; desc < __stop_jmp_table; desc++) {
+		if (desc->option != key)
+			continue;
+		patched++;
+		offset = (desc->jump_to - desc->jump_from) - JMP_INSTR_LEN;
+		if ((offset > INT32_MAX) || (offset < INT32_MIN)) {
+			/* We only saved room for a 32-bit jmp.  Hard fail */
+			malloc_printf("offset too big: %lx\n", offset);
+			abort();
+		}
+
+		offset32 = offset;
+		dest = desc->jump_from;
+		newp = jmp;
+		if (*option) {
+			/* 32-bit jmp */
+			jmp[0] = 0xe9;
+			memcpy(jmp+1, &offset32, 4);
+			jmp[5] = 0x00;
+			jmp[6] = 0x00;
+			jmp[7] = 0x00;
+		} else {
+			/* 8-byte nop */
+			jmp[0] = 0x0f;
+			jmp[1] = 0x1f;
+			jmp[2] = 0x84;
+			jmp[3] = 0x00;
+			jmp[4] = 0x00;
+			jmp[5] = 0x00;
+			jmp[6] = 0x00;
+			jmp[7] = 0x00;
+		}
+		/* Write.  Since this is 8 bytes, it is atomic on x86_64.
+		 * Concurrently running threads may still take the previous
+		 * path for a short while until icache flushes.
+		 */
+		unprotect(dest, 8, PROT_READ | PROT_EXEC | PROT_WRITE);
+		*dest = *(unsigned long*)newp;
+		unprotect(dest, 8, PROT_READ | PROT_EXEC);
+	}
+	assert(patched > 0);
+}
+
+#endif


### PR DESCRIPTION
commit f4a0f32 sped up the fast-path substantially, but we still have
an init check (slow_path), and a prof / prof_active check.  Using
dynamic runtime code patching, we can remove all of them.

This depends on asm goto in gcc, and static global addresses, so optimize
mode is also required.  Code is provided for x86_64 only, but
the same technique should work on most arches.

Note that although we patch the option, currently running threads
may still take the old branch for a while until the cache flushes,
so this is only an optimization.

Testing:

In microbenchmarks, this is a 2% cpu improvement.  It's so small it is hard
to tell in production though.  By comparison, sized-deallocations are 10% cpu
in a microbenchmark.

linux's perf utility was used to view currently executing asm.  Used mallctl
to flip prof_active on/off, checked that it appeared to be working correctly.

Tested building in debug / opt mode, but don't have anything else besides
x86_64 to check that the compile options are correct.
