### PR TITLE
Enable -Wsign-compare warnings.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,7 @@ if test "x$CFLAGS" = "x" ; then
     JE_CFLAGS_APPEND([-Wall])
     JE_CFLAGS_APPEND([-Werror=declaration-after-statement])
     JE_CFLAGS_APPEND([-Wshorten-64-to-32])
+    JE_CFLAGS_APPEND([-Wsign-compare])
     JE_CFLAGS_APPEND([-pipe])
     JE_CFLAGS_APPEND([-g3])
   elif test "x$je_cv_msvc" = "xyes" ; then


### PR DESCRIPTION
Warn about comparisons between signed and unsigned integers. Mozilla enables -Wsign-compare for all C/C++ code in Gecko, including jemalloc and other third-party libraries. jemalloc does not have any -Wsign-compare warnings with clang on OS X, gcc on Linux, or gcc for Android.

gcc's -Wall enables -Wsign-compare for C++, but not C. clang's -Wall does not enable -Wsign-compare. Both clang and gcc enable -Wsign-compare for C and C++ as part of -Wextra.