### PR TITLE
Fix support for the PGI compiler

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -155,7 +155,9 @@ static const bool config_cache_oblivious =
 #endif
 
 #include "jemalloc/internal/ph.h"
+#ifndef __PGI
 #define	RB_COMPACT
+#endif
 #include "jemalloc/internal/rb.h"
 #include "jemalloc/internal/qr.h"
 #include "jemalloc/internal/ql.h"

--- a/test/unit/math.c
+++ b/test/unit/math.c
@@ -5,6 +5,10 @@
 
 #include <float.h>
 
+#ifdef __PGI
+#undef INFINITY
+#endif
+
 #ifndef INFINITY
 #define	INFINITY (DBL_MAX + DBL_MAX)
 #endif


### PR DESCRIPTION
* Work around a weird pgi bug in test/unit/math.c

* Don't use compact red-black trees under pgi. I'm not sure if this is a
  red-black tree bug a pgi bug, but since most of the red-black trees seem to
  have been replaced with pairing-heaps I didn't investigate very hard.

* Note that this also relies on https://github.com/jemalloc/jemalloc/issues/390
  because pgi doesn't have support for TLS.

Passes `make check` with pgi 15.10.0 and 16.4.0 (-O and -O3)
