### PR TITLE
Avoid doing void pointer arithmetic in extent.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ if test "x$CFLAGS" = "x" ; then
     fi
     JE_CFLAGS_APPEND([-Wall])
     JE_CFLAGS_APPEND([-Werror=declaration-after-statement])
+    JE_CFLAGS_APPEND([-Wpointer-arith])
     JE_CFLAGS_APPEND([-Wshorten-64-to-32])
     JE_CFLAGS_APPEND([-Wsign-compare])
     JE_CFLAGS_APPEND([-pipe])

--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -224,22 +224,22 @@ JEMALLOC_INLINE void *
 extent_before_get(const extent_t *extent)
 {
 
-	return ((void *)(uintptr_t)extent->e_addr - PAGE);
+	return ((void *)((uintptr_t)extent->e_addr - PAGE));
 }
 
 JEMALLOC_INLINE void *
 extent_last_get(const extent_t *extent)
 {
 
-	return ((void *)(uintptr_t)extent->e_addr + extent_size_get(extent) -
-	    PAGE);
+	return ((void *)((uintptr_t)extent->e_addr + extent_size_get(extent) -
+	    PAGE));
 }
 
 JEMALLOC_INLINE void *
 extent_past_get(const extent_t *extent)
 {
 
-	return ((void *)(uintptr_t)extent->e_addr + extent_size_get(extent));
+	return ((void *)((uintptr_t)extent->e_addr + extent_size_get(extent)));
 }
 
 JEMALLOC_INLINE bool


### PR DESCRIPTION
Void pointer arithmetic isn't legal. There's a [gcc extension][1] that allows
it, but not all compilers support that extension. It looks like the uses in
extent.h could just have been typos though. This just adds parens so that the
math is done on a uintptr_t before casting the result back to (void *).

[1]: https://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html#Pointer-Arith