### PR TITLE
Fix a bug in __builtin_unreachable configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1095,7 +1095,7 @@ void foo (void) {
 		foo();
 	}
 ], [je_cv_gcc_builtin_unreachable])
-if test "x${je_cv_gcc_builtin_ffsl}" = "xyes" ; then
+if test "x${je_cv_gcc_builtin_unreachable}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [__builtin_unreachable])
 else
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort])


### PR DESCRIPTION
In 1167e9e, I accidentally tested `je_cv_gcc_builtin_ffsl` instead of
`je_cv_gcc_builtin_unreachable` (copy-paste error), which meant that
`JEMALLOC_INTERNAL_UNREACHABLE` was always getting defined as `abort` even if
`__builtin_unreachable` support was detected.