### PR TITLE
Support Debian GNU/kFreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,7 +384,7 @@ case "${host}" in
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	;;
-  *-*-linux*)
+  *-*-linux* | *-*-kfreebsd*)
 	CFLAGS="$CFLAGS"
 	CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
 	abi="elf"


### PR DESCRIPTION
Handles kFreeBSD exactly like Linux since they both use GNU libc.

"make check" passes on my kFreeBSD server (64-bit).
