### PR TITLE
Readme.txt error for building in the Windows

### DIFF
--- a/msvc/ReadMe.txt
+++ b/msvc/ReadMe.txt
@@ -17,7 +17,7 @@ How to build jemalloc for Windows
    (note: x86/x64 doesn't matter at this point)
 
 5. Generate header files:
-   sh -c "./autogen.sh CC=cl --enable-lazy-lock=no"
+   sh -c "./autogen.sh" CC=cl --enable-lazy-lock=no
 
 6. Now the project can be opened and built in Visual Studio:
    msvc\jemalloc_vc2015.sln


### PR DESCRIPTION
The command can't work using sh -C sh -c "./autogen.sh CC=cl --enable-lazy-lock=no". 
Change the position of the colon, the command of autogen work.