### PR TITLE
Allow forcing an VM overcommit setting

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -242,6 +242,16 @@
 #undef JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY
 
 /*
+ * Options for forcing an overcommit setting.
+ * This can be used if the overcommit setting from
+ * the target OS is known and static.
+ * Using this is benefitial since some overhead
+ * from querying sysctl or proc/sys can be avoided.
+ */
+#undef JEMALLOC_FORCE_VM_OVERCOMMIT
+#undef JEMALLOC_FORCE_NO_VM_OVERCOMMIT
+
+/*
  * Methods for purging unused pages differ between operating systems.
  *
  *   madvise(..., MADV_DONTNEED) : On Linux, this immediately discards pages,


### PR DESCRIPTION
Sometimes the overcommit setting from the OS
is known and static.
In this case, we can allow forcing the setting
to one value in order to avoid the lookup in
/proc/sys or sysfs.
This is useful because having to look up
in /proc/sys or sysfs creates an overheaad.

Signed-off-by: Alex Naidis alex.naidis@linux.com
