### PR TITLE
Support static linking of jemalloc with glibc

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -749,6 +749,15 @@ malloc_ncpus(void)
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 	result = si.dwNumberOfProcessors;
+#elif defined(JEMALLOC_GLIBC_MALLOC_HOOK)
+	/*
+	 * GLIBC's sysconf uses isspace().  GLIBC allocates for the first
+	 * time *before* setting up the isspace tables.
+	 * Therefore we need a different method to get the number of CPUs.
+	 */
+	cpu_set_t set;
+	pthread_getaffinity_np(pthread_self(), sizeof(set), &set);
+	result = CPU_COUNT(&set);
 #else
 	result = sysconf(_SC_NPROCESSORS_ONLN);
 #endif
@@ -1882,6 +1891,25 @@ JEMALLOC_EXPORT void *(*__realloc_hook)(void *ptr, size_t size) = je_realloc;
 JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
     je_memalign;
 # endif
+
+/*
+ * To enable static linking with glibc, the libc specific
+ * mallic interface must be implemented also, so none of
+ * glibc's malloc.o functions are added to the link
+ */
+#define ALIAS(je_fn)   __attribute__ ((alias (#je_fn), used))
+/* To force macro expansion of je_ prefix before stringification */
+#define PREALIAS(je_fn)  ALIAS(je_fn)
+void* __libc_malloc(size_t size)                      PREALIAS(je_malloc);
+void  __libc_free(void* ptr)                          PREALIAS(je_free);
+void* __libc_realloc(void* ptr, size_t size)          PREALIAS(je_realloc);
+void* __libc_calloc(size_t n, size_t size)            PREALIAS(je_calloc);
+void* __libc_memalign(size_t align, size_t s)         PREALIAS(je_memalign);
+void* __libc_valloc(size_t size)                      PREALIAS(je_valloc);
+int   __posix_memalign(void** r, size_t a, size_t s)  PREALIAS(je_posix_memalign);
+#undef PREALIAS
+#undef ALIAS
+
 #endif
 
 /*


### PR DESCRIPTION
glibc defines its malloc implementation with several weak and strong
symbols:

strong_alias (__libc_calloc, __calloc) weak_alias (__libc_calloc, calloc)
strong_alias (__libc_free, __cfree) weak_alias (__libc_free, cfree)
strong_alias (__libc_free, __free) strong_alias (__libc_free, free)
strong_alias (__libc_malloc, __malloc) strong_alias (__libc_malloc, malloc)

The issue is not with the weak symbols, but that other parts of glibc
depend on __libc_malloc explicitly.  Defining them in terms of jemalloc
API's allows the linker to drop glibc's malloc.o completely from the link,
and static linking no longer results in symbol collisions.

Another wrinkle: jemalloc during initialization calls sysconf to
get the number of CPU's.  GLIBC allocates for the first time before
setting up isspace (and other related) tables, which are used by
sysconf.  Instead, use the pthread API to get the number of
CPUs with GLIBC, which seems to work.

Fixes #442 
