### PR TITLE
Fix second definition of malloc_conf

### DIFF
--- a/test/integration/mallocx.c
+++ b/test/integration/mallocx.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf = "junk:false";
-#endif
-
 static unsigned
 get_nsizes_impl(const char *cmd)
 {
@@ -225,7 +221,9 @@ TEST_END
 int
 main(void)
 {
-
+#ifdef JEMALLOC_FILL
+  malloc_conf = "junk:false";
+#endif
 	return (test(
 	    test_overflow,
 	    test_oom,

--- a/test/integration/xallocx.c
+++ b/test/integration/xallocx.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf = "junk:false";
-#endif
-
 /*
  * Use a separate arena for xallocx() extension/contraction tests so that
  * internal allocation e.g. by heap profiling can't interpose allocations where
@@ -397,7 +393,9 @@ TEST_END
 int
 main(void)
 {
-
+#ifdef JEMALLOC_FILL
+  malloc_conf = "junk:false";
+#endif
 	return (test(
 	    test_same_size,
 	    test_extra_no_move,


### PR DESCRIPTION
Second definition causes the compiler to complain about malloc_conf (je_malloc_conf)
  redefinition and/or inconsistent linkage. I believe the intention was
  simply to change the existing config so it can take effect.