### PR TITLE
Fix __builtin_unreachable configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1118,6 +1118,9 @@ AC_SUBST([enable_cache_oblivious])
 
 
 
+dnl optimization level can impact whether __builtin_unreachable works
+SAVED_CFLAGS="${CFLAGS}"
+JE_CFLAGS_APPEND(["${EXTRA_CFLAGS}"])
 JE_COMPILABLE([a program using __builtin_unreachable], [
 void foo (void) {
   __builtin_unreachable();
@@ -1132,6 +1135,7 @@ if test "x${je_cv_gcc_builtin_unreachable}" = "xyes" ; then
 else
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort])
 fi
+CFLAGS="${SAVED_CFLAGS}"
 
 dnl ============================================================================
 dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.


### PR DESCRIPTION
__builtin_unreachable causes link errors with osx+gnu, but only at -O1 or higher.
If EXTRA_CFLAGS contain an optimization level it needs to be added to CFLAGS
for the __builtin_unreachable check.

EXTRA_CFLAGS used to be set for all configure tests, but that was changed with
af0e28f