### PR TITLE
Prof realloc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -179,6 +179,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_gdump.c \
 	$(srcroot)test/unit/prof_idump.c \
 	$(srcroot)test/unit/prof_reset.c \
+	$(srcroot)test/unit/prof_tctx.c \
 	$(srcroot)test/unit/prof_thread_name.c \
 	$(srcroot)test/unit/ql.c \
 	$(srcroot)test/unit/qr.c \

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -369,6 +369,7 @@ prof_boot0
 prof_boot1
 prof_boot2
 prof_bt_count
+prof_cnt_all
 prof_dump_header
 prof_dump_open
 prof_free

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -48,11 +48,12 @@ prof_tctx_t	*prof_lookup(tsd_t *tsd, prof_bt_t *bt);
 #ifdef JEMALLOC_JET
 size_t	prof_tdata_count(void);
 size_t	prof_bt_count(void);
-const prof_cnt_t *prof_cnt_all(void);
 typedef int (prof_dump_open_t)(bool, const char *);
 extern prof_dump_open_t *prof_dump_open;
 typedef bool (prof_dump_header_t)(tsdn_t *, bool, const prof_cnt_t *);
 extern prof_dump_header_t *prof_dump_header;
+void	prof_cnt_all(uint64_t *curobjs, uint64_t *curbytes,
+    uint64_t *accumobjs, uint64_t *accumbytes);
 #endif
 void	prof_idump(tsdn_t *tsdn);
 bool	prof_mdump(tsd_t *tsd, const char *filename);

--- a/src/arena.c
+++ b/src/arena.c
@@ -895,8 +895,8 @@ arena_destroy_retained(tsdn_t *tsdn, arena_t *arena)
 	 * own metadata structures, but if deallocation fails, that is the
 	 * application's decision/problem.  In practice, retained extents are
 	 * leaked here if !config_munmap unless the application provided custom
-	 * extent hooks, so best practice to either enable munmap (and avoid dss
-	 * for arenas to be destroyed), or provide custom extent hooks that
+	 * extent hooks, so best practice is to either enable munmap (and avoid
+	 * dss for arenas to be destroyed), or provide custom extent hooks that
 	 * either unmap retained extents or track them for later use.
 	 */
 	for (i = 0; i < sizeof(arena->extents_retained)/sizeof(extent_heap_t);

--- a/src/extent.c
+++ b/src/extent.c
@@ -1011,7 +1011,6 @@ extent_dalloc_default_impl(void *addr, size_t size)
 	return (true);
 }
 
-
 static bool
 extent_dalloc_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
     bool committed, unsigned arena_ind)

--- a/test/unit/prof_tctx.c
+++ b/test/unit/prof_tctx.c
@@ -1,0 +1,57 @@
+#include "test/jemalloc_test.h"
+
+#ifdef JEMALLOC_PROF
+const char *malloc_conf = "prof:true,lg_prof_sample:0";
+#endif
+
+TEST_BEGIN(test_prof_realloc)
+{
+	tsdn_t *tsdn;
+	int flags;
+	void *p, *q;
+	extent_t *extent_p, *extent_q;
+	prof_tctx_t *tctx_p, *tctx_q;
+	uint64_t curobjs_0, curobjs_1, curobjs_2, curobjs_3;
+
+	test_skip_if(!config_prof);
+
+	tsdn = tsdn_fetch();
+	flags = MALLOCX_TCACHE_NONE;
+
+	prof_cnt_all(&curobjs_0, NULL, NULL, NULL);
+	p = mallocx(1024, flags);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+	extent_p = iealloc(tsdn, p);
+	assert_ptr_not_null(extent_p, "Unexpected iealloc() failure");
+	tctx_p = prof_tctx_get(tsdn, extent_p, p);
+	assert_ptr_ne(tctx_p, (prof_tctx_t *)(uintptr_t)1U,
+	    "Expected valid tctx");
+	prof_cnt_all(&curobjs_1, NULL, NULL, NULL);
+	assert_u64_eq(curobjs_0 + 1, curobjs_1,
+	    "Allocation should have increased sample size");
+
+	q = rallocx(p, 2048, flags);
+	assert_ptr_ne(p, q, "Expected move");
+	assert_ptr_not_null(p, "Unexpected rmallocx() failure");
+	extent_q = iealloc(tsdn, q);
+	assert_ptr_not_null(extent_q, "Unexpected iealloc() failure");
+	tctx_q = prof_tctx_get(tsdn, extent_q, q);
+	assert_ptr_ne(tctx_q, (prof_tctx_t *)(uintptr_t)1U,
+	    "Expected valid tctx");
+	prof_cnt_all(&curobjs_2, NULL, NULL, NULL);
+	assert_u64_eq(curobjs_1, curobjs_2,
+	    "Reallocation should not have changed sample size");
+
+	dallocx(q, flags);
+	prof_cnt_all(&curobjs_3, NULL, NULL, NULL);
+	assert_u64_eq(curobjs_0, curobjs_3,
+	    "Sample size should have returned to base level");
+}
+TEST_END
+
+int
+main(void)
+{
+	return test(
+	    test_prof_realloc);
+}


### PR DESCRIPTION
This fixes #499, and does some refactoring of ```prof_dump()``` in order to allow the ```test_prof_realloc``` test.

Ignore all but the last two commits; the others are for other existing pull requests, and it appears I can't omit them from this pull request without rebasing to dev.