### PR TITLE
Fix lots of --disable-stats issues

### DIFF
--- a/include/jemalloc/internal/ctl_structs.h
+++ b/include/jemalloc/internal/ctl_structs.h
@@ -22,18 +22,6 @@ struct ctl_indexed_node_s {
 };
 
 struct ctl_arena_stats_s {
-	unsigned		arena_ind;
-	bool			initialized;
-	ql_elm(ctl_arena_stats_t)	destroyed_link;
-
-	unsigned		nthreads;
-	const char		*dss;
-	ssize_t			decay_time;
-	size_t			pactive;
-	size_t			pdirty;
-
-	/* The remainder are only populated if config_stats is true. */
-
 	arena_stats_t		astats;
 
 	/* Aggregate stats for small size classes, based on bin stats. */
@@ -47,22 +35,42 @@ struct ctl_arena_stats_s {
 };
 
 struct ctl_stats_s {
-	uint64_t		epoch;
 	size_t			allocated;
 	size_t			active;
 	size_t			metadata;
 	size_t			resident;
 	size_t			mapped;
 	size_t			retained;
+};
+
+struct ctl_arena_s {
+	unsigned		arena_ind;
+	bool			initialized;
+	ql_elm(ctl_arena_t)	destroyed_link;
+
+	/* Basic stats, supported even if !config_stats. */
+	unsigned		nthreads;
+	const char		*dss;
+	ssize_t			decay_time;
+	size_t			pactive;
+	size_t			pdirty;
+
+	/* NULL if !config_stats. */
+	ctl_arena_stats_t	*astats;
+};
+
+struct ctl_arenas_s {
+	uint64_t		epoch;
 	unsigned		narenas;
-	ql_head(ctl_arena_stats_t)	destroyed;
+	ql_head(ctl_arena_t)	destroyed;
+
 	/*
-	 * Element 0 contains merged stats for extant arenas (accessed via
-	 * MALLCTL_ARENAS_ALL), element 1 contains merged stats for destroyed
-	 * arenas (accessed via MALLCTL_ARENAS_DESTROYED), and the remaining
-	 * MALLOCX_ARENA_MAX+1 elements correspond to arenas.
+	 * Element 0 corresponds to merged stats for extant arenas (accessed via
+	 * MALLCTL_ARENAS_ALL), element 1 corresponds to merged stats for
+	 * destroyed arenas (accessed via MALLCTL_ARENAS_DESTROYED), and the
+	 * remaining MALLOCX_ARENA_MAX+1 elements correspond to arenas.
 	 */
-	ctl_arena_stats_t	*arenas[MALLOCX_ARENA_MAX + 3];
+	ctl_arena_t		*arenas[MALLOCX_ARENA_MAX + 3];
 };
 
 #endif /* JEMALLOC_INTERNAL_CTL_STRUCTS_H */

--- a/include/jemalloc/internal/ctl_types.h
+++ b/include/jemalloc/internal/ctl_types.h
@@ -6,5 +6,7 @@ typedef struct ctl_named_node_s ctl_named_node_t;
 typedef struct ctl_indexed_node_s ctl_indexed_node_t;
 typedef struct ctl_arena_stats_s ctl_arena_stats_t;
 typedef struct ctl_stats_s ctl_stats_t;
+typedef struct ctl_arena_s ctl_arena_t;
+typedef struct ctl_arenas_s ctl_arenas_t;
 
 #endif /* JEMALLOC_INTERNAL_CTL_TYPES_H */

--- a/src/extent.c
+++ b/src/extent.c
@@ -820,9 +820,11 @@ extent_alloc_retained(tsdn_t *tsdn, arena_t *arena,
 	extent = extent_recycle(tsdn, arena, r_extent_hooks,
 	    arena->extents_retained, false, false, new_addr, usize, pad,
 	    alignment, zero, commit, slab);
-	if (extent != NULL && config_stats) {
-		size_t size = usize + pad;
-		arena->stats.retained -= size;
+	if (extent != NULL) {
+		if (config_stats) {
+			size_t size = usize + pad;
+			arena->stats.retained -= size;
+		}
 		if (config_prof)
 			extent_gprof_add(tsdn, extent);
 	}

--- a/test/unit/base.c
+++ b/test/unit/base.c
@@ -33,16 +33,20 @@ TEST_BEGIN(test_base_hooks_default)
 	tsdn = tsdn_fetch();
 	base = base_new(tsdn, 0, (extent_hooks_t *)&extent_hooks_default);
 
-	base_stats_get(tsdn, base, &allocated0, &resident, &mapped);
-	assert_zu_ge(allocated0, sizeof(base_t),
-	    "Base header should count as allocated");
+	if (config_stats) {
+		base_stats_get(tsdn, base, &allocated0, &resident, &mapped);
+		assert_zu_ge(allocated0, sizeof(base_t),
+		    "Base header should count as allocated");
+	}
 
 	assert_ptr_not_null(base_alloc(tsdn, base, 42, 1),
 	    "Unexpected base_alloc() failure");
 
-	base_stats_get(tsdn, base, &allocated1, &resident, &mapped);
-	assert_zu_ge(allocated1 - allocated0, 42,
-	    "At least 42 bytes were allocated by base_alloc()");
+	if (config_stats) {
+		base_stats_get(tsdn, base, &allocated1, &resident, &mapped);
+		assert_zu_ge(allocated1 - allocated0, 42,
+		    "At least 42 bytes were allocated by base_alloc()");
+	}
 
 	base_delete(base);
 }
@@ -67,16 +71,20 @@ TEST_BEGIN(test_base_hooks_null)
 	base = base_new(tsdn, 0, &hooks);
 	assert_ptr_not_null(base, "Unexpected base_new() failure");
 
-	base_stats_get(tsdn, base, &allocated0, &resident, &mapped);
-	assert_zu_ge(allocated0, sizeof(base_t),
-	    "Base header should count as allocated");
+	if (config_stats) {
+		base_stats_get(tsdn, base, &allocated0, &resident, &mapped);
+		assert_zu_ge(allocated0, sizeof(base_t),
+		    "Base header should count as allocated");
+	}
 
 	assert_ptr_not_null(base_alloc(tsdn, base, 42, 1),
 	    "Unexpected base_alloc() failure");
 
-	base_stats_get(tsdn, base, &allocated1, &resident, &mapped);
-	assert_zu_ge(allocated1 - allocated0, 42,
-	    "At least 42 bytes were allocated by base_alloc()");
+	if (config_stats) {
+		base_stats_get(tsdn, base, &allocated1, &resident, &mapped);
+		assert_zu_ge(allocated1 - allocated0, 42,
+		    "At least 42 bytes were allocated by base_alloc()");
+	}
 
 	base_delete(base);
 


### PR DESCRIPTION
While testing #569, I tried ```--disable-stats``` and hit a huge set of regressions and new bugs.  This diff fixes all those revealed by the tests.

We definitely need to add some more travis-CI configurations (at least ```--enable-debug```, ```--disable-stats``` and ```--disable-tcache```).