### PR TITLE
Remove -Werror=declaration-after-statement.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -239,7 +239,6 @@ if test "x$GCC" = "xyes" ; then
     fi
   fi
   JE_CFLAGS_ADD([-Wall])
-  JE_CFLAGS_ADD([-Werror=declaration-after-statement])
   JE_CFLAGS_ADD([-Wshorten-64-to-32])
   JE_CFLAGS_ADD([-Wsign-compare])
   JE_CFLAGS_ADD([-pipe])


### PR DESCRIPTION
This will allow us to start moving declarations to first use, e.g. in #568.