### PR TITLE
Fix gdump locking

### DIFF
--- a/include/jemalloc/internal/chunk.h
+++ b/include/jemalloc/internal/chunk.h
@@ -52,8 +52,8 @@ chunk_hooks_t	chunk_hooks_get(tsdn_t *tsdn, arena_t *arena);
 chunk_hooks_t	chunk_hooks_set(tsdn_t *tsdn, arena_t *arena,
     const chunk_hooks_t *chunk_hooks);
 
-bool	chunk_register(tsdn_t *tsdn, const void *chunk,
-    const extent_node_t *node);
+bool	chunk_register(const void *chunk, const extent_node_t *node,
+    bool *gdump);
 void	chunk_deregister(const void *chunk, const extent_node_t *node);
 void	*chunk_alloc_base(size_t size);
 void	*chunk_alloc_cache(tsdn_t *tsdn, arena_t *arena,

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -612,14 +612,14 @@ valgrind_freelike_block
 valgrind_make_mem_defined
 valgrind_make_mem_noaccess
 valgrind_make_mem_undefined
-witness_assert_lockless
+witness_assert_lock_depth
 witness_assert_not_owner
 witness_assert_owner
 witness_fork_cleanup
 witness_init
 witness_lock
 witness_lock_error
-witness_lockless_error
+witness_lock_depth_error
 witness_not_owner_error
 witness_owner
 witness_owner_error

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -141,7 +141,7 @@ chunk_hooks_assure_initialized(tsdn_t *tsdn, arena_t *arena,
 }
 
 bool
-chunk_register(tsdn_t *tsdn, const void *chunk, const extent_node_t *node)
+chunk_register(const void *chunk, const extent_node_t *node, bool *gdump)
 {
 
 	assert(extent_node_addr_get(node) == chunk);
@@ -160,8 +160,7 @@ chunk_register(tsdn_t *tsdn, const void *chunk, const extent_node_t *node)
 			 */
 			high = atomic_read_z(&highchunks);
 		}
-		if (cur > high && prof_gdump_get_unlocked())
-			prof_gdump(tsdn);
+		*gdump = (cur > high && prof_gdump_get_unlocked());
 	}
 
 	return (false);

--- a/src/huge.c
+++ b/src/huge.c
@@ -15,20 +15,20 @@ huge_node_get(const void *ptr)
 }
 
 static bool
-huge_node_set(tsdn_t *tsdn, const void *ptr, extent_node_t *node)
+huge_node_set(tsdn_t *tsdn, const void *ptr, extent_node_t *node, bool *gdump)
 {
 
 	assert(extent_node_addr_get(node) == ptr);
 	assert(!extent_node_achunk_get(node));
-	return (chunk_register(tsdn, ptr, node));
+	return (chunk_register(ptr, node, gdump));
 }
 
 static void
-huge_node_reset(tsdn_t *tsdn, const void *ptr, extent_node_t *node)
+huge_node_reset(tsdn_t *tsdn, const void *ptr, extent_node_t *node, bool *gdump)
 {
 	bool err;
 
-	err = huge_node_set(tsdn, ptr, node);
+	err = huge_node_set(tsdn, ptr, node, gdump);
 	assert(!err);
 }
 
@@ -57,11 +57,12 @@ huge_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize, size_t alignment,
 	arena_t *iarena;
 	extent_node_t *node;
 	size_t sn;
-	bool is_zeroed;
+	bool is_zeroed, gdump;
 
 	/* Allocate one or more contiguous chunks for this request. */
 
 	assert(!tsdn_null(tsdn) || arena != NULL);
+	witness_assert_lock_depth(tsdn, 0); /* prof_gdump() requirement. */
 
 	ausize = sa2u(usize, alignment);
 	if (unlikely(ausize == 0 || ausize > HUGE_MAXCLASS))
@@ -91,11 +92,13 @@ huge_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize, size_t alignment,
 
 	extent_node_init(node, arena, ret, usize, sn, is_zeroed, true);
 
-	if (huge_node_set(tsdn, ret, node)) {
+	if (huge_node_set(tsdn, ret, node, &gdump)) {
 		arena_chunk_dalloc_huge(tsdn, arena, ret, usize, sn);
 		idalloctm(tsdn, node, NULL, true, true);
 		return (NULL);
 	}
+	if (config_prof && opt_prof && gdump)
+		prof_gdump(tsdn);
 
 	/* Insert node into huge. */
 	malloc_mutex_lock(tsdn, &arena->huge_mtx);
@@ -144,7 +147,9 @@ huge_ralloc_no_move_similar(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	extent_node_t *node;
 	arena_t *arena;
 	chunk_hooks_t chunk_hooks = CHUNK_HOOKS_INITIALIZER;
-	bool pre_zeroed, post_zeroed;
+	bool pre_zeroed, post_zeroed, gdump;
+
+	witness_assert_lock_depth(tsdn, 0); /* prof_gdump() requirement. */
 
 	/* Increase usize to incorporate extra. */
 	for (usize = usize_min; usize < usize_max && (usize_next = s2u(usize+1))
@@ -178,10 +183,13 @@ huge_ralloc_no_move_similar(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	huge_node_unset(ptr, node);
 	assert(extent_node_size_get(node) != usize);
 	extent_node_size_set(node, usize);
-	huge_node_reset(tsdn, ptr, node);
+	huge_node_reset(tsdn, ptr, node, &gdump);
 	/* Update zeroed. */
 	extent_node_zeroed_set(node, post_zeroed);
 	malloc_mutex_unlock(tsdn, &arena->huge_mtx);
+	/* gdump without any locks held. */
+	if (config_prof && opt_prof && gdump)
+		prof_gdump(tsdn);
 
 	arena_chunk_ralloc_huge_similar(tsdn, arena, ptr, oldsize, usize);
 
@@ -207,7 +215,7 @@ huge_ralloc_no_move_shrink(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	arena_t *arena;
 	chunk_hooks_t chunk_hooks;
 	size_t cdiff;
-	bool pre_zeroed, post_zeroed;
+	bool pre_zeroed, post_zeroed, gdump;
 
 	node = huge_node_get(ptr);
 	arena = extent_node_arena_get(node);
@@ -215,6 +223,7 @@ huge_ralloc_no_move_shrink(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	chunk_hooks = chunk_hooks_get(tsdn, arena);
 
 	assert(oldsize > usize);
+	witness_assert_lock_depth(tsdn, 0); /* prof_gdump() requirement. */
 
 	/* Split excess chunks. */
 	cdiff = CHUNK_CEILING(oldsize) - CHUNK_CEILING(usize);
@@ -241,10 +250,13 @@ huge_ralloc_no_move_shrink(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	/* Update the size of the huge allocation. */
 	huge_node_unset(ptr, node);
 	extent_node_size_set(node, usize);
-	huge_node_reset(tsdn, ptr, node);
+	huge_node_reset(tsdn, ptr, node, &gdump);
 	/* Update zeroed. */
 	extent_node_zeroed_set(node, post_zeroed);
 	malloc_mutex_unlock(tsdn, &arena->huge_mtx);
+	/* gdump without any locks held. */
+	if (config_prof && opt_prof && gdump)
+		prof_gdump(tsdn);
 
 	/* Zap the excess chunks. */
 	arena_chunk_ralloc_huge_shrink(tsdn, arena, ptr, oldsize, usize,
@@ -258,13 +270,15 @@ huge_ralloc_no_move_expand(tsdn_t *tsdn, void *ptr, size_t oldsize,
     size_t usize, bool zero) {
 	extent_node_t *node;
 	arena_t *arena;
-	bool is_zeroed_subchunk, is_zeroed_chunk;
+	bool is_zeroed_subchunk, is_zeroed_chunk, gdump;
 
 	node = huge_node_get(ptr);
 	arena = extent_node_arena_get(node);
 	malloc_mutex_lock(tsdn, &arena->huge_mtx);
 	is_zeroed_subchunk = extent_node_zeroed_get(node);
 	malloc_mutex_unlock(tsdn, &arena->huge_mtx);
+
+	witness_assert_lock_depth(tsdn, 0); /* prof_gdump() requirement. */
 
 	/*
 	 * Use is_zeroed_chunk to detect whether the trailing memory is zeroed,
@@ -280,8 +294,11 @@ huge_ralloc_no_move_expand(tsdn_t *tsdn, void *ptr, size_t oldsize,
 	extent_node_size_set(node, usize);
 	extent_node_zeroed_set(node, extent_node_zeroed_get(node) &&
 	    is_zeroed_chunk);
-	huge_node_reset(tsdn, ptr, node);
+	huge_node_reset(tsdn, ptr, node, &gdump);
 	malloc_mutex_unlock(tsdn, &arena->huge_mtx);
+	/* gdump without any locks held. */
+	if (config_prof && opt_prof && gdump)
+		prof_gdump(tsdn);
 
 	if (zero || (config_fill && unlikely(opt_zero))) {
 		if (!is_zeroed_subchunk) {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1581,7 +1581,7 @@ ialloc_body(size_t size, bool zero, tsdn_t **tsdn, size_t *usize,
 
 	tsd = tsd_fetch();
 	*tsdn = tsd_tsdn(tsd);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	ind = size2index(size);
 	if (unlikely(ind >= NSIZES))
@@ -1619,7 +1619,7 @@ ialloc_post_check(void *ret, tsdn_t *tsdn, size_t usize, const char *func,
 		assert(usize == isalloc(tsdn, ret, config_prof));
 		*tsd_thread_allocatedp_get(tsdn_tsd(tsdn)) += usize;
 	}
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 }
 
 JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
@@ -1704,7 +1704,7 @@ imemalign(void **memptr, size_t alignment, size_t size, size_t min_alignment)
 		goto label_oom;
 	}
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	if (size == 0)
 		size = 1;
 
@@ -1745,7 +1745,7 @@ label_return:
 	UTRACE(0, size, result);
 	JEMALLOC_VALGRIND_MALLOC(result != NULL, tsd_tsdn(tsd), result, usize,
 	    false);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (ret);
 label_oom:
 	assert(result == NULL);
@@ -1755,7 +1755,7 @@ label_oom:
 		abort();
 	}
 	ret = ENOMEM;
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	goto label_return;
 }
 
@@ -1873,7 +1873,7 @@ ifree(tsd_t *tsd, void *ptr, tcache_t *tcache, bool slow_path)
 	size_t usize;
 	UNUSED size_t rzsize JEMALLOC_CC_SILENCE_INIT(0);
 
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	assert(ptr != NULL);
 	assert(malloc_initialized() || IS_INITIALIZER);
@@ -1901,7 +1901,7 @@ isfree(tsd_t *tsd, void *ptr, size_t usize, tcache_t *tcache, bool slow_path)
 {
 	UNUSED size_t rzsize JEMALLOC_CC_SILENCE_INIT(0);
 
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	assert(ptr != NULL);
 	assert(malloc_initialized() || IS_INITIALIZER);
@@ -1947,7 +1947,7 @@ je_realloc(void *ptr, size_t size)
 		malloc_thread_init();
 		tsd = tsd_fetch();
 
-		witness_assert_lockless(tsd_tsdn(tsd));
+		witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 		old_usize = isalloc(tsd_tsdn(tsd), ptr, config_prof);
 		if (config_valgrind && unlikely(in_valgrind)) {
@@ -1994,7 +1994,7 @@ je_realloc(void *ptr, size_t size)
 	UTRACE(ptr, size, ret);
 	JEMALLOC_VALGRIND_REALLOC(maybe, tsdn, ret, usize, maybe, ptr,
 	    old_usize, old_rzsize, maybe, false);
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (ret);
 }
 
@@ -2005,12 +2005,12 @@ je_free(void *ptr)
 	UTRACE(ptr, 0, 0);
 	if (likely(ptr != NULL)) {
 		tsd_t *tsd = tsd_fetch();
-		witness_assert_lockless(tsd_tsdn(tsd));
+		witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 		if (likely(!malloc_slow))
 			ifree(tsd, ptr, tcache_get(tsd, false), false);
 		else
 			ifree(tsd, ptr, tcache_get(tsd, false), true);
-		witness_assert_lockless(tsd_tsdn(tsd));
+		witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	}
 }
 
@@ -2239,7 +2239,7 @@ imallocx_body(size_t size, int flags, tsdn_t **tsdn, size_t *usize,
 
 	tsd = tsd_fetch();
 	*tsdn = tsd_tsdn(tsd);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	if (likely(flags == 0)) {
 		szind_t ind = size2index(size);
@@ -2374,7 +2374,7 @@ je_rallocx(void *ptr, size_t size, int flags)
 	assert(malloc_initialized() || IS_INITIALIZER);
 	malloc_thread_init();
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	if (unlikely((flags & MALLOCX_ARENA_MASK) != 0)) {
 		unsigned arena_ind = MALLOCX_ARENA_GET(flags);
@@ -2421,7 +2421,7 @@ je_rallocx(void *ptr, size_t size, int flags)
 	UTRACE(ptr, size, p);
 	JEMALLOC_VALGRIND_REALLOC(maybe, tsd_tsdn(tsd), p, usize, no, ptr,
 	    old_usize, old_rzsize, no, zero);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (p);
 label_oom:
 	if (config_xmalloc && unlikely(opt_xmalloc)) {
@@ -2429,7 +2429,7 @@ label_oom:
 		abort();
 	}
 	UTRACE(ptr, size, 0);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (NULL);
 }
 
@@ -2525,7 +2525,7 @@ je_xallocx(void *ptr, size_t size, size_t extra, int flags)
 	assert(malloc_initialized() || IS_INITIALIZER);
 	malloc_thread_init();
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	old_usize = isalloc(tsd_tsdn(tsd), ptr, config_prof);
 
@@ -2566,7 +2566,7 @@ je_xallocx(void *ptr, size_t size, size_t extra, int flags)
 	    old_usize, old_rzsize, no, zero);
 label_not_resized:
 	UTRACE(ptr, size, ptr);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (usize);
 }
 
@@ -2581,14 +2581,14 @@ je_sallocx(const void *ptr, int flags)
 	malloc_thread_init();
 
 	tsdn = tsdn_fetch();
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 
 	if (config_ivsalloc)
 		usize = ivsalloc(tsdn, ptr, config_prof);
 	else
 		usize = isalloc(tsdn, ptr, config_prof);
 
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (usize);
 }
 
@@ -2602,7 +2602,7 @@ je_dallocx(void *ptr, int flags)
 	assert(malloc_initialized() || IS_INITIALIZER);
 
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	if (unlikely((flags & MALLOCX_TCACHE_MASK) != 0)) {
 		if ((flags & MALLOCX_TCACHE_MASK) == MALLOCX_TCACHE_NONE)
 			tcache = NULL;
@@ -2616,7 +2616,7 @@ je_dallocx(void *ptr, int flags)
 		ifree(tsd, ptr, tcache, false);
 	else
 		ifree(tsd, ptr, tcache, true);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 }
 
 JEMALLOC_ALWAYS_INLINE_C size_t
@@ -2624,13 +2624,13 @@ inallocx(tsdn_t *tsdn, size_t size, int flags)
 {
 	size_t usize;
 
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 
 	if (likely((flags & MALLOCX_LG_ALIGN_MASK) == 0))
 		usize = s2u(size);
 	else
 		usize = sa2u(size, MALLOCX_ALIGN_GET_SPECIFIED(flags));
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (usize);
 }
 
@@ -2647,7 +2647,7 @@ je_sdallocx(void *ptr, size_t size, int flags)
 	usize = inallocx(tsd_tsdn(tsd), size, flags);
 	assert(usize == isalloc(tsd_tsdn(tsd), ptr, config_prof));
 
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	if (unlikely((flags & MALLOCX_TCACHE_MASK) != 0)) {
 		if ((flags & MALLOCX_TCACHE_MASK) == MALLOCX_TCACHE_NONE)
 			tcache = NULL;
@@ -2661,7 +2661,7 @@ je_sdallocx(void *ptr, size_t size, int flags)
 		isfree(tsd, ptr, usize, tcache, false);
 	else
 		isfree(tsd, ptr, usize, tcache, true);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 }
 
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW
@@ -2677,13 +2677,13 @@ je_nallocx(size_t size, int flags)
 		return (0);
 
 	tsdn = tsdn_fetch();
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 
 	usize = inallocx(tsdn, size, flags);
 	if (unlikely(usize > HUGE_MAXCLASS))
 		return (0);
 
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (usize);
 }
 
@@ -2698,9 +2698,9 @@ je_mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp,
 		return (EAGAIN);
 
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	ret = ctl_byname(tsd, name, oldp, oldlenp, newp, newlen);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (ret);
 }
 
@@ -2714,9 +2714,9 @@ je_mallctlnametomib(const char *name, size_t *mibp, size_t *miblenp)
 		return (EAGAIN);
 
 	tsdn = tsdn_fetch();
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	ret = ctl_nametomib(tsdn, name, mibp, miblenp);
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (ret);
 }
 
@@ -2731,9 +2731,9 @@ je_mallctlbymib(const size_t *mib, size_t miblen, void *oldp, size_t *oldlenp,
 		return (EAGAIN);
 
 	tsd = tsd_fetch();
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	ret = ctl_bymib(tsd, mib, miblen, oldp, oldlenp, newp, newlen);
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 	return (ret);
 }
 
@@ -2744,9 +2744,9 @@ je_malloc_stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	tsdn_t *tsdn;
 
 	tsdn = tsdn_fetch();
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	stats_print(write_cb, cbopaque, opts);
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 }
 
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW
@@ -2759,14 +2759,14 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr)
 	malloc_thread_init();
 
 	tsdn = tsdn_fetch();
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 
 	if (config_ivsalloc)
 		ret = ivsalloc(tsdn, ptr, config_prof);
 	else
 		ret = (ptr == NULL) ? 0 : isalloc(tsdn, ptr, config_prof);
 
-	witness_assert_lockless(tsdn);
+	witness_assert_lock_depth(tsdn, 0);
 	return (ret);
 }
 

--- a/src/witness.c
+++ b/src/witness.c
@@ -71,15 +71,16 @@ witness_not_owner_error_t *witness_not_owner_error =
 #endif
 
 #ifdef JEMALLOC_JET
-#undef witness_lockless_error
-#define	witness_lockless_error JEMALLOC_N(n_witness_lockless_error)
+#undef witness_lock_depth_error
+#define	witness_lock_depth_error JEMALLOC_N(n_witness_lock_depth_error)
 #endif
 void
-witness_lockless_error(const witness_list_t *witnesses)
+witness_lock_depth_error(const witness_list_t *witnesses, unsigned depth)
 {
 	witness_t *w;
 
-	malloc_printf("<jemalloc>: Should not own any locks:");
+	malloc_printf("<jemalloc>: Should own %u lock%s:", depth, (depth != 1) ?
+	    "s" : "");
 	ql_foreach(w, witnesses, link) {
 		malloc_printf(" %s(%u)", w->name, w->rank);
 	}
@@ -87,17 +88,17 @@ witness_lockless_error(const witness_list_t *witnesses)
 	abort();
 }
 #ifdef JEMALLOC_JET
-#undef witness_lockless_error
-#define	witness_lockless_error JEMALLOC_N(witness_lockless_error)
-witness_lockless_error_t *witness_lockless_error =
-    JEMALLOC_N(n_witness_lockless_error);
+#undef witness_lock_depth_error
+#define	witness_lock_depth_error JEMALLOC_N(witness_lock_depth_error)
+witness_lock_depth_error_t *witness_lock_depth_error =
+    JEMALLOC_N(n_witness_lock_depth_error);
 #endif
 
 void
 witnesses_cleanup(tsd_t *tsd)
 {
 
-	witness_assert_lockless(tsd_tsdn(tsd));
+	witness_assert_lock_depth(tsd_tsdn(tsd), 0);
 
 	/* Do nothing. */
 }


### PR DESCRIPTION
This fix is based on rc-4.5.0.  A similar fix is required for the dev branch.