### PR TITLE
Handle race in stats_arena_bins_print

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -133,8 +133,16 @@ stats_arena_bins_print(void (*write_cb)(void *, const char *), void *cbopaque,
 			availregs = nregs * curslabs;
 			milli = (availregs != 0) ? (1000 * curregs) / availregs
 			    : 1000;
-			assert(milli <= 1000);
-			if (milli < 10) {
+
+			if (milli > 1000) {
+				/*
+				 * Race detected: the counters were read in
+				 * separate mallctl calls and concurrent
+				 * operations happened in between. In this case
+				 * no meaningful utilization can be computed.
+				 */
+				malloc_snprintf(util, sizeof(util), " race");
+			} else if (milli < 10) {
 				malloc_snprintf(util, sizeof(util),
 				    "0.00%zu", milli);
 			} else if (milli < 100) {
@@ -144,6 +152,7 @@ stats_arena_bins_print(void (*write_cb)(void *, const char *), void *cbopaque,
 				malloc_snprintf(util, sizeof(util), "0.%zu",
 				    milli);
 			} else {
+				assert(milli == 1000);
 				malloc_snprintf(util, sizeof(util), "1");
 			}
 


### PR DESCRIPTION
When multiple threads calling stats_print, race could happen as we read the
counters in separate mallctl calls. The removed assertion could fail when there
are other operations happening at the same time. For simplicity, assume a safe
bound when race is detected instead of retrying.

This should resolve #591.