### PR TITLE
Simplify/optimize rtree

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -189,6 +189,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/size_classes.c \
 	$(srcroot)test/unit/slab.c \
 	$(srcroot)test/unit/smoothstep.c \
+	$(srcroot)test/unit/spin.c \
 	$(srcroot)test/unit/stats.c \
 	$(srcroot)test/unit/stats_print.c \
 	$(srcroot)test/unit/ticker.c \

--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,74 @@ case "${host_cpu}" in
 esac
 AC_DEFINE_UNQUOTED([CPU_SPINWAIT], [$CPU_SPINWAIT])
 
+case "${host_cpu}" in
+  aarch64)
+    AC_MSG_CHECKING([number of significant virtual address bits])
+    LG_VADDR=48
+    AC_MSG_RESULT([$LG_VADDR])
+    ;;
+  x86_64)
+    AC_CACHE_CHECK([number of significant virtual address bits],
+                   [je_cv_lg_vaddr],
+                   AC_RUN_IFELSE([AC_LANG_PROGRAM(
+[[
+#include <stdio.h>
+#ifdef _WIN32
+#include <limits.h>
+#include <intrin.h>
+typedef unsigned __int32 uint32_t;
+#else
+#include <stdint.h>
+#endif
+]], [[
+	uint32_t r[[4]];
+	uint32_t eax_in = 0x80000008U;
+#ifdef _WIN32
+	__cpuid((int *)r, (int)eax_in);
+#else
+	asm volatile ("cpuid"
+	    : "=a" (r[[0]]), "=b" (r[[1]]), "=c" (r[[2]]), "=d" (r[[3]])
+	    : "a" (eax_in), "c" (0)
+	);
+#endif
+	uint32_t eax_out = r[[0]];
+	uint32_t vaddr = ((eax_out & 0x0000ff00U) >> 8);
+	FILE *f = fopen("conftest.out", "w");
+	if (f == NULL) {
+		return 1;
+	}
+	fprintf(f, "%u", vaddr);
+	fclose(f);
+	return 0;
+]])],
+                   [je_cv_lg_vaddr=`cat conftest.out`],
+                   [je_cv_lg_vaddr=error],
+                   [je_cv_lg_vaddr=57]))
+    if test "x${je_cv_lg_vaddr}" != "x" ; then
+      LG_VADDR="${je_cv_lg_vaddr}"
+    fi
+    if test "x${LG_VADDR}" != "xerror" ; then
+      AC_DEFINE_UNQUOTED([LG_VADDR], [$LG_VADDR])
+    else
+      AC_MSG_ERROR([cannot determine number of significant virtual address bits])
+    fi
+    ;;
+  *)
+    AC_MSG_CHECKING([number of significant virtual address bits])
+    if test "x${LG_SIZEOF_PTR}" = "x3" ; then
+      LG_VADDR=64
+    elif test "x${LG_SIZEOF_PTR}" = "x2" ; then
+      LG_VADDR=32
+    elif test "x${LG_SIZEOF_PTR}" = "xLG_SIZEOF_PTR_WIN" ; then
+      LG_VADDR="(1U << (LG_SIZEOF_PTR_WIN+3))"
+    else
+      AC_MSG_ERROR([Unsupported lg(pointer size): ${LG_SIZEOF_PTR}])
+    fi
+    AC_MSG_RESULT([$LG_VADDR])
+    ;;
+esac
+AC_DEFINE_UNQUOTED([LG_VADDR], [$LG_VADDR])
+
 LD_PRELOAD_VAR="LD_PRELOAD"
 so="so"
 importlib="${so}"

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -22,6 +22,13 @@
  */
 #undef CPU_SPINWAIT
 
+/*
+ * Number of significant bits in virtual addresses.  This may be less than the
+ * total number of bits in a pointer, e.g. on x64, for which the uppermost 16
+ * bits are the same as bit 47.
+ */
+#undef LG_VADDR
+
 /* Defined if C11 atomics are available. */
 #undef JEMALLOC_C11ATOMICS
 

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -419,7 +419,6 @@ rtree_child_read
 rtree_child_read_hard
 rtree_child_tryread
 rtree_clear
-rtree_ctx_start_level
 rtree_delete
 rtree_elm_acquire
 rtree_elm_lookup
@@ -431,6 +430,7 @@ rtree_elm_witness_acquire
 rtree_elm_witness_release
 rtree_elm_write
 rtree_elm_write_acquired
+rtree_leafkey
 rtree_new
 rtree_node_alloc
 rtree_node_dalloc

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -415,9 +415,6 @@ prof_thread_name_get
 prof_thread_name_set
 psz2ind
 psz2u
-rtree_child_read
-rtree_child_read_hard
-rtree_child_tryread
 rtree_clear
 rtree_delete
 rtree_elm_acquire
@@ -435,13 +432,8 @@ rtree_leafkey
 rtree_new
 rtree_node_alloc
 rtree_node_dalloc
-rtree_node_valid
 rtree_read
-rtree_start_level
 rtree_subkey
-rtree_subtree_read
-rtree_subtree_read_hard
-rtree_subtree_tryread
 rtree_write
 s2u
 s2u_compute

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -422,6 +422,7 @@ rtree_clear
 rtree_delete
 rtree_elm_acquire
 rtree_elm_lookup
+rtree_elm_lookup_hard
 rtree_elm_read
 rtree_elm_read_acquired
 rtree_elm_release

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -445,7 +445,6 @@ size2index_compute
 size2index_lookup
 size2index_tab
 spin_adaptive
-spin_init
 stats_print
 tcache_alloc_easy
 tcache_alloc_large

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -7,19 +7,15 @@ typedef rtree_elm_t *(rtree_node_alloc_t)(tsdn_t *, rtree_t *, size_t);
 extern rtree_node_alloc_t *rtree_node_alloc;
 typedef void (rtree_node_dalloc_t)(tsdn_t *, rtree_t *, rtree_elm_t *);
 extern rtree_node_dalloc_t *rtree_node_dalloc;
-void	rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
+void rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
 #endif
-rtree_elm_t	*rtree_subtree_read_hard(tsdn_t *tsdn, rtree_t *rtree,
-    unsigned level);
-rtree_elm_t	*rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree,
-    rtree_elm_t *elm, unsigned level);
 rtree_elm_t *rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
     rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
-void	rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
     uintptr_t key, const rtree_elm_t *elm);
-void	rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,
     const rtree_elm_t *elm);
-void	rtree_elm_witness_release(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_release(tsdn_t *tsdn, const rtree_t *rtree,
     const rtree_elm_t *elm);
 
 #endif /* JEMALLOC_INTERNAL_RTREE_EXTERNS_H */

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -1,7 +1,29 @@
 #ifndef JEMALLOC_INTERNAL_RTREE_EXTERNS_H
 #define JEMALLOC_INTERNAL_RTREE_EXTERNS_H
 
-bool rtree_new(rtree_t *rtree, unsigned bits);
+/*
+ * Split the bits into one to three partitions depending on number of
+ * significant bits.  It the number of bits does not divide evenly into the
+ * number of levels, place one remainder bit per level starting at the leaf
+ * level.
+ */
+static const rtree_level_t rtree_levels[] = {
+#if RTREE_NSB <= 10
+	{RTREE_NSB, RTREE_NHIB + RTREE_NSB}
+#elif RTREE_NSB <= 36
+	{RTREE_NSB/2, RTREE_NHIB + RTREE_NSB/2},
+	{RTREE_NSB/2 + RTREE_NSB%2, RTREE_NHIB + RTREE_NSB}
+#elif RTREE_NSB <= 52
+	{RTREE_NSB/3, RTREE_NHIB + RTREE_NSB/3},
+	{RTREE_NSB/3 + RTREE_NSB%3/2,
+	    RTREE_NHIB + RTREE_NSB/3*2 + RTREE_NSB%3/2},
+	{RTREE_NSB/3 + RTREE_NSB%3 - RTREE_NSB%3/2, RTREE_NHIB + RTREE_NSB}
+#else
+#  error Unsupported number of significant virtual address bits
+#endif
+};
+
+bool rtree_new(rtree_t *rtree);
 #ifdef JEMALLOC_JET
 typedef rtree_elm_t *(rtree_node_alloc_t)(tsdn_t *, rtree_t *, size_t);
 extern rtree_node_alloc_t *rtree_node_alloc;

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -13,6 +13,8 @@ rtree_elm_t	*rtree_subtree_read_hard(tsdn_t *tsdn, rtree_t *rtree,
     unsigned level);
 rtree_elm_t	*rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree,
     rtree_elm_t *elm, unsigned level);
+rtree_elm_t *rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
+    rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
 void	rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
     uintptr_t key, const rtree_elm_t *elm);
 void	rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -2,8 +2,8 @@
 #define JEMALLOC_INTERNAL_RTREE_INLINES_H
 
 #ifndef JEMALLOC_ENABLE_INLINE
-uintptr_t rtree_leafkey(rtree_t *rtree, uintptr_t key);
-uintptr_t rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level);
+uintptr_t rtree_leafkey(uintptr_t key);
+uintptr_t rtree_subkey(uintptr_t key, unsigned level);
 extent_t *rtree_elm_read(rtree_elm_t *elm, bool dependent);
 void rtree_elm_write(rtree_elm_t *elm, const extent_t *extent);
 rtree_elm_t *rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree,
@@ -25,21 +25,21 @@ void rtree_clear(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_RTREE_C_))
 JEMALLOC_ALWAYS_INLINE uintptr_t
-rtree_leafkey(rtree_t *rtree, uintptr_t key) {
+rtree_leafkey(uintptr_t key) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
-	unsigned cumbits = (rtree->levels[rtree->height-1].cumbits -
-	    rtree->levels[rtree->height-1].bits);
+	unsigned cumbits = (rtree_levels[RTREE_HEIGHT-1].cumbits -
+	    rtree_levels[RTREE_HEIGHT-1].bits);
 	unsigned maskbits = ptrbits - cumbits;
 	uintptr_t mask = ~((ZU(1) << maskbits) - 1);
 	return (key & mask);
 }
 
 JEMALLOC_ALWAYS_INLINE uintptr_t
-rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level) {
+rtree_subkey(uintptr_t key, unsigned level) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
-	unsigned cumbits = rtree->levels[level].cumbits;
+	unsigned cumbits = rtree_levels[level].cumbits;
 	unsigned shiftbits = ptrbits - cumbits;
-	unsigned maskbits = rtree->levels[level].bits;
+	unsigned maskbits = rtree_levels[level].bits;
 	unsigned mask = (ZU(1) << maskbits) - 1;
 	return ((key >> shiftbits) & mask);
 }
@@ -82,7 +82,7 @@ rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 	assert(!dependent || !init_missing);
 
 	if (likely(key != 0)) {
-		uintptr_t leafkey = rtree_leafkey(rtree, key);
+		uintptr_t leafkey = rtree_leafkey(key);
 #define RTREE_CACHE_CHECK(i) do {					\
 		if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {	\
 			rtree_elm_t *leaf = rtree_ctx->cache[i].leaf;	\
@@ -94,8 +94,8 @@ rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 				rtree_ctx->cache[0].leafkey = leafkey;	\
 				rtree_ctx->cache[0].leaf = leaf;	\
 									\
-				uintptr_t subkey = rtree_subkey(rtree,	\
-				    key, rtree->height-1);		\
+				uintptr_t subkey = rtree_subkey(key,	\
+				    RTREE_HEIGHT-1);			\
 				return &leaf[subkey];			\
 			}						\
 		}							\

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -348,7 +348,7 @@ rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, uintptr_t key,
 	rtree_elm_t *elm;
 
 	elm = rtree_elm_lookup(tsdn, rtree, rtree_ctx, key, dependent, false);
-	if (elm == NULL) {
+	if (!dependent && elm == NULL) {
 		return NULL;
 	}
 

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -153,21 +153,22 @@ rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, uintptr_t key,
 JEMALLOC_INLINE rtree_elm_t *
 rtree_elm_acquire(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, bool dependent, bool init_missing) {
-	rtree_elm_t *elm;
-
-	elm = rtree_elm_lookup(tsdn, rtree, rtree_ctx, key, dependent,
-	    init_missing);
+	rtree_elm_t *elm = rtree_elm_lookup(tsdn, rtree, rtree_ctx, key,
+	    dependent, init_missing);
 	if (!dependent && elm == NULL) {
 		return NULL;
 	}
 
-	extent_t *extent;
-	void *s;
-	do {
-		extent = rtree_elm_read(elm, false);
+	spin_t spinner = SPIN_INITIALIZER;
+	while (true) {
+		extent_t *extent = rtree_elm_read(elm, false);
 		/* The least significant bit serves as a lock. */
-		s = (void *)((uintptr_t)extent | (uintptr_t)0x1);
-	} while (atomic_cas_p(&elm->pun, (void *)extent, s));
+		void *s = (void *)((uintptr_t)extent | (uintptr_t)0x1);
+		if (!atomic_cas_p(&elm->pun, (void *)extent, s)) {
+			break;
+		}
+		spin_adaptive(&spinner);
+	}
 
 	if (config_debug) {
 		rtree_elm_witness_acquire(tsdn, rtree, key, elm);

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -3,8 +3,7 @@
 
 #ifndef JEMALLOC_ENABLE_INLINE
 unsigned	rtree_start_level(const rtree_t *rtree, uintptr_t key);
-unsigned	rtree_ctx_start_level(const rtree_t *rtree,
-    const rtree_ctx_t *rtree_ctx, uintptr_t key);
+uintptr_t rtree_leafkey(rtree_t *rtree, uintptr_t key);
 uintptr_t	rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level);
 
 bool	rtree_node_valid(rtree_elm_t *node);
@@ -50,31 +49,24 @@ rtree_start_level(const rtree_t *rtree, uintptr_t key) {
 	return start_level;
 }
 
-JEMALLOC_ALWAYS_INLINE unsigned
-rtree_ctx_start_level(const rtree_t *rtree, const rtree_ctx_t *rtree_ctx,
-    uintptr_t key) {
-	unsigned start_level;
-	uintptr_t key_diff;
-
-	/* Compute the difference between old and new lookup keys. */
-	key_diff = key ^ rtree_ctx->key;
-	assert(key_diff != 0); /* Handled in rtree_elm_lookup(). */
-
-	/*
-	 * Compute the last traversal path element at which the keys' paths
-	 * are the same.
-	 */
-	start_level = rtree->start_level[(lg_floor(key_diff) + 1) >>
-	    LG_RTREE_BITS_PER_LEVEL];
-	assert(start_level < rtree->height);
-	return start_level;
+JEMALLOC_ALWAYS_INLINE uintptr_t
+rtree_leafkey(rtree_t *rtree, uintptr_t key) {
+	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
+	unsigned cumbits = (rtree->levels[rtree->height-1].cumbits -
+	    rtree->levels[rtree->height-1].bits);
+	unsigned maskbits = ptrbits - cumbits;
+	uintptr_t mask = ~((ZU(1) << maskbits) - 1);
+	return (key & mask);
 }
 
 JEMALLOC_ALWAYS_INLINE uintptr_t
 rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level) {
-	return ((key >> ((ZU(1) << (LG_SIZEOF_PTR+3)) -
-	    rtree->levels[level].cumbits)) & ((ZU(1) <<
-	    rtree->levels[level].bits) - 1));
+	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
+	unsigned cumbits = rtree->levels[level].cumbits;
+	unsigned shiftbits = ptrbits - cumbits;
+	unsigned maskbits = rtree->levels[level].bits;
+	unsigned mask = (ZU(1) << maskbits) - 1;
+	return ((key >> shiftbits) & mask);
 }
 
 JEMALLOC_ALWAYS_INLINE bool
@@ -170,103 +162,89 @@ rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
 JEMALLOC_ALWAYS_INLINE rtree_elm_t *
 rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, bool dependent, bool init_missing) {
-	uintptr_t subkey;
-	unsigned start_level;
-	rtree_elm_t *node;
-
 	assert(!dependent || !init_missing);
 
-	if (dependent || init_missing) {
-		if (likely(rtree_ctx->valid)) {
-			if (key == rtree_ctx->key) {
-				return rtree_ctx->elms[rtree->height];
-			} else {
-				unsigned no_ctx_start_level =
-				    rtree_start_level(rtree, key);
-				unsigned ctx_start_level;
-
-				if (likely(no_ctx_start_level <=
-				    rtree_ctx->start_level && (ctx_start_level =
-				    rtree_ctx_start_level(rtree, rtree_ctx,
-				    key)) >= rtree_ctx->start_level)) {
-					start_level = ctx_start_level;
-					node = rtree_ctx->elms[ctx_start_level];
-				} else {
-					start_level = no_ctx_start_level;
-					node = init_missing ?
-					    rtree_subtree_read(tsdn, rtree,
-					    no_ctx_start_level, dependent) :
-					    rtree_subtree_tryread(rtree,
-					    no_ctx_start_level, dependent);
-					rtree_ctx->start_level =
-					    no_ctx_start_level;
-					rtree_ctx->elms[no_ctx_start_level] =
-					    node;
-				}
-			}
-		} else {
-			unsigned no_ctx_start_level = rtree_start_level(rtree,
-			    key);
-
-			start_level = no_ctx_start_level;
-			node = init_missing ? rtree_subtree_read(tsdn, rtree,
-			    no_ctx_start_level, dependent) :
-			    rtree_subtree_tryread(rtree, no_ctx_start_level,
-			    dependent);
-			rtree_ctx->valid = true;
-			rtree_ctx->start_level = no_ctx_start_level;
-			rtree_ctx->elms[no_ctx_start_level] = node;
+	/* Search the cache. */
+	uintptr_t leafkey = rtree_leafkey(rtree, key);
+	if (likely(key != 0)) {
+#define RTREE_CACHE_CHECK(i) do {					\
+		if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {	\
+			rtree_elm_t *leaf = rtree_ctx->cache[i].leaf;	\
+			if (likely(leaf != NULL)) {			\
+				/* Reorder. */				\
+				memmove(&rtree_ctx->cache[1],		\
+				    &rtree_ctx->cache[0],		\
+				    sizeof(rtree_ctx_cache_elm_t) * i);	\
+				rtree_ctx->cache[0].leafkey = leafkey;	\
+				rtree_ctx->cache[0].leaf = leaf;	\
+									\
+				uintptr_t subkey = rtree_subkey(rtree,	\
+				    key, rtree->height-1);		\
+				return &leaf[subkey];			\
+			}						\
+		}							\
+} while (0)
+		/* Check the MRU cache entry. */
+		RTREE_CACHE_CHECK(0);
+		/*
+		 * Search the remaining cache elements, and on success move the
+		 * matching element to the front.  Unroll the first iteration to
+		 * avoid calling memmove() (the compiler typically optimizes it
+		 * into raw moves).
+		 */
+		if (RTREE_CTX_NCACHE > 1) {
+			RTREE_CACHE_CHECK(1);
 		}
-		rtree_ctx->key = key;
-	} else {
-		start_level = rtree_start_level(rtree, key);
-		node = init_missing ? rtree_subtree_read(tsdn, rtree,
-		    start_level, dependent) : rtree_subtree_tryread(rtree,
-		    start_level, dependent);
+		for (unsigned i = 2; i < RTREE_CTX_NCACHE; i++) {
+			RTREE_CACHE_CHECK(i);
+		}
+#undef RTREE_CACHE_CHECK
 	}
+
+	unsigned start_level = rtree_start_level(rtree, key);
+	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
+	    start_level, dependent) : rtree_subtree_tryread(rtree, start_level,
+	    dependent);
 
 #define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
 	switch (start_level + RTREE_GET_BIAS) {
 #define RTREE_GET_SUBTREE(level)					\
-	case level:							\
+	case level: {							\
 		assert(level < (RTREE_HEIGHT_MAX-1));			\
 		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
-			if (init_missing) {				\
-				rtree_ctx->valid = false;		\
-			}						\
 			return NULL;					\
 		}							\
-		subkey = rtree_subkey(rtree, key, level -		\
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
 		    RTREE_GET_BIAS);					\
 		node = init_missing ? rtree_child_read(tsdn, rtree,	\
 		    &node[subkey], level - RTREE_GET_BIAS, dependent) :	\
 		    rtree_child_tryread(&node[subkey], dependent);	\
-		if (dependent || init_missing) {			\
-			rtree_ctx->elms[level - RTREE_GET_BIAS + 1] =	\
-			    node;					\
-		}							\
-		/* Fall through. */
+		/* Fall through. */					\
+	}
 #define RTREE_GET_LEAF(level)						\
-	case level:							\
+	case level: {							\
 		assert(level == (RTREE_HEIGHT_MAX-1));			\
 		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
-			if (init_missing) {				\
-				rtree_ctx->valid = false;		\
-			}						\
 			return NULL;					\
 		}							\
-		subkey = rtree_subkey(rtree, key, level -		\
-		    RTREE_GET_BIAS);					\
 		/*							\
 		 * node is a leaf, so it contains values rather than	\
 		 * child pointers.					\
 		 */							\
-		node = &node[subkey];					\
-		if (dependent || init_missing) {			\
-			rtree_ctx->elms[level - RTREE_GET_BIAS + 1] =	\
-			    node;					\
+		if (likely(key != 0)) {					\
+			if (RTREE_CTX_NCACHE > 1) {			\
+				memmove(&rtree_ctx->cache[1],		\
+				    &rtree_ctx->cache[0],		\
+				    sizeof(rtree_ctx_cache_elm_t) *	\
+				    (RTREE_CTX_NCACHE-1));		\
+			}						\
+			rtree_ctx->cache[0].leafkey = leafkey;		\
+			rtree_ctx->cache[0].leaf = node;		\
 		}							\
-		return node;
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
+		    RTREE_GET_BIAS);					\
+		return &node[subkey];					\
+	}
 #if RTREE_HEIGHT_MAX > 1
 	RTREE_GET_SUBTREE(0)
 #endif
@@ -365,16 +343,14 @@ rtree_elm_acquire(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 	if (!dependent && elm == NULL) {
 		return NULL;
 	}
-	{
-		extent_t *extent;
-		void *s;
 
-		do {
-			extent = rtree_elm_read(elm, false);
-			/* The least significant bit serves as a lock. */
-			s = (void *)((uintptr_t)extent | (uintptr_t)0x1);
-		} while (atomic_cas_p(&elm->pun, (void *)extent, s));
-	}
+	extent_t *extent;
+	void *s;
+	do {
+		extent = rtree_elm_read(elm, false);
+		/* The least significant bit serves as a lock. */
+		s = (void *)((uintptr_t)extent | (uintptr_t)0x1);
+	} while (atomic_cas_p(&elm->pun, (void *)extent, s));
 
 	if (config_debug) {
 		rtree_elm_witness_acquire(tsdn, rtree, key, elm);

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -19,32 +19,6 @@ struct rtree_elm_witness_tsd_s {
 };
 
 struct rtree_level_s {
-	/*
-	 * A non-NULL subtree points to a subtree rooted along the hypothetical
-	 * path to the leaf node corresponding to key 0.  Depending on what keys
-	 * have been used to store to the tree, an arbitrary combination of
-	 * subtree pointers may remain NULL.
-	 *
-	 * Suppose keys comprise 48 bits, and LG_RTREE_BITS_PER_LEVEL is 4.
-	 * This results in a 3-level tree, and the leftmost leaf can be directly
-	 * accessed via levels[2], the subtree prefixed by 0x0000 (excluding
-	 * 0x00000000) can be accessed via levels[1], and the remainder of the
-	 * tree can be accessed via levels[0].
-	 *
-	 *   levels[0] : [<unused> | 0x0001******** | 0x0002******** | ...]
-	 *
-	 *   levels[1] : [<unused> | 0x00000001**** | 0x00000002**** | ... ]
-	 *
-	 *   levels[2] : [extent(0x000000000000) | extent(0x000000000001) | ...]
-	 *
-	 * This has practical implications on x64, which currently uses only the
-	 * lower 47 bits of virtual address space in userland, thus leaving
-	 * levels[0] unused and avoiding a level of tree traversal.
-	 */
-	union {
-		void		*subtree_pun;
-		rtree_elm_t	*subtree;
-	};
 	/* Number of key bits distinguished by this level. */
 	unsigned		bits;
 	/*
@@ -68,11 +42,10 @@ struct rtree_ctx_s {
 
 struct rtree_s {
 	unsigned		height;
-	/*
-	 * Precomputed table used to convert from the number of leading 0 key
-	 * bits to which subtree level to start at.
-	 */
-	unsigned		start_level[RTREE_HEIGHT_MAX + 1];
+	union {
+		void		*root_pun;
+		rtree_elm_t	*root;
+	};
 	rtree_level_t		levels[RTREE_HEIGHT_MAX];
 	malloc_mutex_t		init_lock;
 };

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -54,22 +54,16 @@ struct rtree_level_s {
 	unsigned		cumbits;
 };
 
+struct rtree_ctx_cache_elm_s {
+	uintptr_t	leafkey;
+	rtree_elm_t	*leaf;
+};
+
 struct rtree_ctx_s {
-	/* If false, key/elms have not yet been initialized by a lookup. */
-	bool		valid;
-	/* Key that corresponds to the tree path recorded in elms. */
-	uintptr_t	key;
-	/* Memoized rtree_start_level(key). */
-	unsigned	start_level;
-	/*
-	 * A path through rtree, driven by key.  Only elements that could
-	 * actually be used for subsequent lookups are initialized, i.e. if
-	 * start_level = rtree_start_level(key) is non-zero, the first
-	 * start_level elements are uninitialized.  The last element contains a
-	 * pointer to the leaf node element that corresponds to key, so that
-	 * exact matches require no tree node offset computation.
-	 */
-	rtree_elm_t	*elms[RTREE_HEIGHT_MAX + 1];
+#ifndef _MSC_VER
+	JEMALLOC_ALIGNED(CACHELINE)
+#endif
+	rtree_ctx_cache_elm_t cache[RTREE_CTX_NCACHE];
 };
 
 struct rtree_s {

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -41,12 +41,10 @@ struct rtree_ctx_s {
 };
 
 struct rtree_s {
-	unsigned		height;
 	union {
 		void		*root_pun;
 		rtree_elm_t	*root;
 	};
-	rtree_level_t		levels[RTREE_HEIGHT_MAX];
 	malloc_mutex_t		init_lock;
 };
 

--- a/include/jemalloc/internal/rtree_types.h
+++ b/include/jemalloc/internal/rtree_types.h
@@ -16,15 +16,14 @@ typedef struct rtree_ctx_cache_elm_s rtree_ctx_cache_elm_t;
 typedef struct rtree_ctx_s rtree_ctx_t;
 typedef struct rtree_s rtree_t;
 
-/*
- * RTREE_BITS_PER_LEVEL must be a power of two that is no larger than the
- * machine address width.
- */
-#define LG_RTREE_BITS_PER_LEVEL	4
-#define RTREE_BITS_PER_LEVEL	(1U << LG_RTREE_BITS_PER_LEVEL)
-/* Maximum rtree height. */
-#define RTREE_HEIGHT_MAX						\
-    ((1U << (LG_SIZEOF_PTR+3)) / RTREE_BITS_PER_LEVEL)
+/* Number of high insignificant bits. */
+#define RTREE_NHIB ((1U << (LG_SIZEOF_PTR+3)) - LG_VADDR)
+/* Number of low insigificant bits. */
+#define RTREE_NLIB LG_PAGE
+/* Number of significant bits. */
+#define RTREE_NSB (LG_VADDR - RTREE_NLIB)
+/* Number of levels in radix tree. */
+#define RTREE_HEIGHT (sizeof(rtree_levels)/sizeof(rtree_level_t))
 
 /*
  * Number of leafkey/leaf pairs to cache.  Each entry supports an entire leaf,

--- a/include/jemalloc/internal/spin_inlines.h
+++ b/include/jemalloc/internal/spin_inlines.h
@@ -2,16 +2,10 @@
 #define JEMALLOC_INTERNAL_SPIN_INLINES_H
 
 #ifndef JEMALLOC_ENABLE_INLINE
-void	spin_init(spin_t *spin);
 void	spin_adaptive(spin_t *spin);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_SPIN_C_))
-JEMALLOC_INLINE void
-spin_init(spin_t *spin) {
-	spin->iteration = 0;
-}
-
 JEMALLOC_INLINE void
 spin_adaptive(spin_t *spin) {
 	volatile uint64_t i;

--- a/include/jemalloc/internal/spin_types.h
+++ b/include/jemalloc/internal/spin_types.h
@@ -3,4 +3,6 @@
 
 typedef struct spin_s spin_t;
 
+#define SPIN_INITIALIZER {0U}
+
 #endif /* JEMALLOC_INTERNAL_SPIN_TYPES_H */

--- a/src/extent.c
+++ b/src/extent.c
@@ -1522,8 +1522,7 @@ extent_merge_wrapper(tsdn_t *tsdn, arena_t *arena,
 
 bool
 extent_boot(void) {
-	if (rtree_new(&extents_rtree, (unsigned)((ZU(1) << (LG_SIZEOF_PTR+3)) -
-	    LG_PAGE))) {
+	if (rtree_new(&extents_rtree)) {
 		return true;
 	}
 

--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -62,13 +62,12 @@ extent_dss_prec_set(dss_prec_t dss_prec) {
 static void *
 extent_dss_max_update(void *new_addr) {
 	void *max_cur;
-	spin_t spinner;
 
 	/*
 	 * Get the current end of the DSS as max_cur and assure that dss_max is
 	 * up to date.
 	 */
-	spin_init(&spinner);
+	spin_t spinner = SPIN_INITIALIZER;
 	while (true) {
 		void *max_prev = atomic_read_p(&dss_max);
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1153,10 +1153,8 @@ malloc_init_hard_needed(void) {
 	}
 #ifdef JEMALLOC_THREADED_INIT
 	if (malloc_initializer != NO_INITIALIZER && !IS_INITIALIZER) {
-		spin_t spinner;
-
 		/* Busy-wait until the initializing thread completes. */
-		spin_init(&spinner);
+		spin_t spinner = SPIN_INITIALIZER;
 		do {
 			malloc_mutex_unlock(TSDN_NULL, &init_lock);
 			spin_adaptive(&spinner);

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -158,6 +158,111 @@ rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm,
 	return rtree_node_init(tsdn, rtree, level+1, &elm->child);
 }
 
+rtree_elm_t *
+rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
+    uintptr_t key, bool dependent, bool init_missing) {
+	unsigned start_level = rtree_start_level(rtree, key);
+	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
+	    start_level, dependent) : rtree_subtree_tryread(rtree, start_level,
+	    dependent);
+
+#define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
+	switch (start_level + RTREE_GET_BIAS) {
+#define RTREE_GET_SUBTREE(level)					\
+	case level: {							\
+		assert(level < (RTREE_HEIGHT_MAX-1));			\
+		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
+			return NULL;					\
+		}							\
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
+		    RTREE_GET_BIAS);					\
+		node = init_missing ? rtree_child_read(tsdn, rtree,	\
+		    &node[subkey], level - RTREE_GET_BIAS, dependent) :	\
+		    rtree_child_tryread(&node[subkey], dependent);	\
+		/* Fall through. */					\
+	}
+#define RTREE_GET_LEAF(level)						\
+	case level: {							\
+		assert(level == (RTREE_HEIGHT_MAX-1));			\
+		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
+			return NULL;					\
+		}							\
+		/*							\
+		 * node is a leaf, so it contains values rather than	\
+		 * child pointers.					\
+		 */							\
+		if (likely(key != 0)) {					\
+			if (RTREE_CTX_NCACHE > 1) {			\
+				memmove(&rtree_ctx->cache[1],		\
+				    &rtree_ctx->cache[0],		\
+				    sizeof(rtree_ctx_cache_elm_t) *	\
+				    (RTREE_CTX_NCACHE-1));		\
+			}						\
+			uintptr_t leafkey = rtree_leafkey(rtree, key);	\
+			rtree_ctx->cache[0].leafkey = leafkey;		\
+			rtree_ctx->cache[0].leaf = node;		\
+		}							\
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
+		    RTREE_GET_BIAS);					\
+		return &node[subkey];					\
+	}
+#if RTREE_HEIGHT_MAX > 1
+	RTREE_GET_SUBTREE(0)
+#endif
+#if RTREE_HEIGHT_MAX > 2
+	RTREE_GET_SUBTREE(1)
+#endif
+#if RTREE_HEIGHT_MAX > 3
+	RTREE_GET_SUBTREE(2)
+#endif
+#if RTREE_HEIGHT_MAX > 4
+	RTREE_GET_SUBTREE(3)
+#endif
+#if RTREE_HEIGHT_MAX > 5
+	RTREE_GET_SUBTREE(4)
+#endif
+#if RTREE_HEIGHT_MAX > 6
+	RTREE_GET_SUBTREE(5)
+#endif
+#if RTREE_HEIGHT_MAX > 7
+	RTREE_GET_SUBTREE(6)
+#endif
+#if RTREE_HEIGHT_MAX > 8
+	RTREE_GET_SUBTREE(7)
+#endif
+#if RTREE_HEIGHT_MAX > 9
+	RTREE_GET_SUBTREE(8)
+#endif
+#if RTREE_HEIGHT_MAX > 10
+	RTREE_GET_SUBTREE(9)
+#endif
+#if RTREE_HEIGHT_MAX > 11
+	RTREE_GET_SUBTREE(10)
+#endif
+#if RTREE_HEIGHT_MAX > 12
+	RTREE_GET_SUBTREE(11)
+#endif
+#if RTREE_HEIGHT_MAX > 13
+	RTREE_GET_SUBTREE(12)
+#endif
+#if RTREE_HEIGHT_MAX > 14
+	RTREE_GET_SUBTREE(13)
+#endif
+#if RTREE_HEIGHT_MAX > 15
+	RTREE_GET_SUBTREE(14)
+#endif
+#if RTREE_HEIGHT_MAX > 16
+#  error Unsupported RTREE_HEIGHT_MAX
+#endif
+	RTREE_GET_LEAF(RTREE_HEIGHT_MAX-1)
+#undef RTREE_GET_SUBTREE
+#undef RTREE_GET_LEAF
+	default: not_reached();
+	}
+#undef RTREE_GET_BIAS
+	not_reached();
+}
+
 static int
 rtree_elm_witness_comp(const witness_t *a, void *oa, const witness_t *b,
     void *ob) {

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -170,17 +170,15 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		 * node is a leaf, so it contains values rather than	\
 		 * child pointers.					\
 		 */							\
-		if (likely(key != 0)) {					\
-			if (RTREE_CTX_NCACHE > 1) {			\
-				memmove(&rtree_ctx->cache[1],		\
-				    &rtree_ctx->cache[0],		\
-				    sizeof(rtree_ctx_cache_elm_t) *	\
-				    (RTREE_CTX_NCACHE-1));		\
-			}						\
-			uintptr_t leafkey = rtree_leafkey(key);		\
-			rtree_ctx->cache[0].leafkey = leafkey;		\
-			rtree_ctx->cache[0].leaf = node;		\
+		if (RTREE_CTX_NCACHE > 1) {				\
+			memmove(&rtree_ctx->cache[1],			\
+			    &rtree_ctx->cache[0],			\
+			    sizeof(rtree_ctx_cache_elm_t) *		\
+			    (RTREE_CTX_NCACHE-1));			\
 		}							\
+		uintptr_t leafkey = rtree_leafkey(key);			\
+		rtree_ctx->cache[0].leafkey = leafkey;			\
+		rtree_ctx->cache[0].leaf = node;			\
 		uintptr_t subkey = rtree_subkey(key, level);		\
 		return &node[subkey];					\
 	}

--- a/test/unit/rtree.c
+++ b/test/unit/rtree.c
@@ -33,31 +33,26 @@ rtree_node_dalloc_intercept(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *node) {
 
 TEST_BEGIN(test_rtree_read_empty) {
 	tsdn_t *tsdn;
-	unsigned i;
 
 	tsdn = tsdn_fetch();
 
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
-		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
-		    "rtree_read() should return NULL for empty tree");
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
-	}
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
+	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
+	    "rtree_read() should return NULL for empty tree");
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 #define NTHREADS	8
-#define MAX_NBITS	18
+#define MAX_NBITS	30
 #define NITERS		1000
 #define SEED		42
 
 typedef struct {
-	unsigned	nbits;
 	rtree_t		rtree;
 	uint32_t	seed;
 } thd_start_arg_t;
@@ -77,7 +72,8 @@ thd_start(void *varg) {
 	tsdn = tsdn_fetch();
 
 	for (i = 0; i < NITERS; i++) {
-		uintptr_t key = (uintptr_t)gen_rand64(sfmt);
+		uintptr_t key = (uintptr_t)(gen_rand64(sfmt) & ((ZU(1) <<
+		    MAX_NBITS) - ZU(1)));
 		if (i % 2 == 0) {
 			rtree_elm_t *elm;
 
@@ -110,165 +106,134 @@ TEST_BEGIN(test_rtree_concurrent) {
 	thd_t thds[NTHREADS];
 	sfmt_t *sfmt;
 	tsdn_t *tsdn;
-	unsigned i, j;
 
 	sfmt = init_gen_rand(SEED);
 	tsdn = tsdn_fetch();
-	for (i = 1; i < MAX_NBITS; i++) {
-		arg.nbits = i;
-		test_rtree = &arg.rtree;
-		assert_false(rtree_new(&arg.rtree, arg.nbits),
-		    "Unexpected rtree_new() failure");
-		arg.seed = gen_rand32(sfmt);
-		for (j = 0; j < NTHREADS; j++) {
-			thd_create(&thds[j], thd_start, (void *)&arg);
-		}
-		for (j = 0; j < NTHREADS; j++) {
-			thd_join(thds[j], NULL);
-		}
-		rtree_delete(tsdn, &arg.rtree);
-		test_rtree = NULL;
+	test_rtree = &arg.rtree;
+	assert_false(rtree_new(&arg.rtree), "Unexpected rtree_new() failure");
+	arg.seed = gen_rand32(sfmt);
+	for (unsigned i = 0; i < NTHREADS; i++) {
+		thd_create(&thds[i], thd_start, (void *)&arg);
 	}
+	for (unsigned i = 0; i < NTHREADS; i++) {
+		thd_join(thds[i], NULL);
+	}
+	rtree_delete(tsdn, &arg.rtree);
+	test_rtree = NULL;
 	fini_gen_rand(sfmt);
 }
 TEST_END
 
 #undef NTHREADS
-#undef MAX_NBITS
 #undef NITERS
 #undef SEED
 
 TEST_BEGIN(test_rtree_extrema) {
-	unsigned i;
 	extent_t extent_a, extent_b;
 	tsdn_t *tsdn;
 
 	tsdn = tsdn_fetch();
 
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0,
-		    &extent_a), "Unexpected rtree_write() failure, i=%u", i);
-		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true),
-		    &extent_a,
-		    "rtree_read() should return previously set value, i=%u", i);
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0, &extent_a),
+	    "Unexpected rtree_write() failure");
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true), &extent_a,
+	    "rtree_read() should return previously set value");
 
-		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx,
-		    ~((uintptr_t)0), &extent_b),
-		    "Unexpected rtree_write() failure, i=%u", i);
-		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-		    ~((uintptr_t)0), true), &extent_b,
-		    "rtree_read() should return previously set value, i=%u", i);
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
+	    &extent_b), "Unexpected rtree_write() failure");
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
+	    true), &extent_b,
+	    "rtree_read() should return previously set value");
 
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
-	}
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 TEST_BEGIN(test_rtree_bits) {
-	tsdn_t *tsdn;
-	unsigned i, j, k;
+	tsdn_t *tsdn = tsdn_fetch();
 
-	tsdn = tsdn_fetch();
+	uintptr_t keys[] = {0, 1, (((uintptr_t)1) << LG_PAGE) - 1};
 
-	for (i = 1; i < (sizeof(uintptr_t) << 3); i++) {
-		uintptr_t keys[] = {0, 1,
-		    (((uintptr_t)1) << (sizeof(uintptr_t)*8-i)) - 1};
-		extent_t extent;
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	extent_t extent;
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
 
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree),
+	    "Unexpected rtree_new() failure");
 
-		for (j = 0; j < sizeof(keys)/sizeof(uintptr_t); j++) {
-			assert_false(rtree_write(tsdn, &rtree, &rtree_ctx,
-			    keys[j], &extent),
-			    "Unexpected rtree_write() failure");
-			for (k = 0; k < sizeof(keys)/sizeof(uintptr_t); k++) {
-				assert_ptr_eq(rtree_read(tsdn, &rtree,
-				    &rtree_ctx, keys[k], true), &extent,
-				    "rtree_read() should return previously set "
-				    "value and ignore insignificant key bits; "
-				    "i=%u, j=%u, k=%u, set key=%#"FMTxPTR", "
-				    "get key=%#"FMTxPTR, i, j, k, keys[j],
-				    keys[k]);
-			}
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    (((uintptr_t)1) << (sizeof(uintptr_t)*8-i)), false),
-			    "Only leftmost rtree leaf should be set; "
-			    "i=%u, j=%u", i, j);
-			rtree_clear(tsdn, &rtree, &rtree_ctx, keys[j]);
+	for (unsigned i = 0; i < sizeof(keys)/sizeof(uintptr_t); i++) {
+		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, keys[i],
+		    &extent), "Unexpected rtree_write() failure");
+		for (unsigned j = 0; j < sizeof(keys)/sizeof(uintptr_t); j++) {
+			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
+			    keys[j], true), &extent,
+			    "rtree_read() should return previously set "
+			    "value and ignore insignificant key bits; "
+			    "i=%u, j=%u, set key=%#"FMTxPTR", get "
+			    "key=%#"FMTxPTR, i, j, keys[i], keys[j]);
 		}
-
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
+		    (((uintptr_t)1) << LG_PAGE), false),
+		    "Only leftmost rtree leaf should be set; i=%u", i);
+		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
 	}
+
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 TEST_BEGIN(test_rtree_random) {
-	unsigned i;
-	sfmt_t *sfmt;
-	tsdn_t *tsdn;
 #define NSET 16
 #define SEED 42
+	sfmt_t *sfmt = init_gen_rand(SEED);
+	tsdn_t *tsdn = tsdn_fetch();
+	uintptr_t keys[NSET];
+	extent_t extent;
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	rtree_elm_t *elm;
 
-	sfmt = init_gen_rand(SEED);
-	tsdn = tsdn_fetch();
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		uintptr_t keys[NSET];
-		extent_t extent;
-		unsigned j;
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		rtree_elm_t *elm;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
-
-		for (j = 0; j < NSET; j++) {
-			keys[j] = (uintptr_t)gen_rand64(sfmt);
-			elm = rtree_elm_acquire(tsdn, &rtree, &rtree_ctx,
-			    keys[j], false, true);
-			assert_ptr_not_null(elm,
-			    "Unexpected rtree_elm_acquire() failure");
-			rtree_elm_write_acquired(tsdn, &rtree, elm, &extent);
-			rtree_elm_release(tsdn, &rtree, elm);
-			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true), &extent,
-			    "rtree_read() should return previously set value");
-		}
-		for (j = 0; j < NSET; j++) {
-			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true), &extent,
-			    "rtree_read() should return previously set value, "
-			    "j=%u", j);
-		}
-
-		for (j = 0; j < NSET; j++) {
-			rtree_clear(tsdn, &rtree, &rtree_ctx, keys[j]);
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true),
-			    "rtree_read() should return previously set value");
-		}
-		for (j = 0; j < NSET; j++) {
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true),
-			    "rtree_read() should return previously set value");
-		}
-
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
+	for (unsigned i = 0; i < NSET; i++) {
+		keys[i] = (uintptr_t)gen_rand64(sfmt);
+		elm = rtree_elm_acquire(tsdn, &rtree, &rtree_ctx, keys[i],
+		    false, true);
+		assert_ptr_not_null(elm,
+		    "Unexpected rtree_elm_acquire() failure");
+		rtree_elm_write_acquired(tsdn, &rtree, elm, &extent);
+		rtree_elm_release(tsdn, &rtree, elm);
+		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), &extent,
+		    "rtree_read() should return previously set value");
 	}
+	for (unsigned i = 0; i < NSET; i++) {
+		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), &extent,
+		    "rtree_read() should return previously set value, i=%u", i);
+	}
+
+	for (unsigned i = 0; i < NSET; i++) {
+		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), "rtree_read() should return previously set value");
+	}
+	for (unsigned i = 0; i < NSET; i++) {
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), "rtree_read() should return previously set value");
+	}
+
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 	fini_gen_rand(sfmt);
 #undef NSET
 #undef SEED

--- a/test/unit/rtree.c
+++ b/test/unit/rtree.c
@@ -40,7 +40,7 @@ TEST_BEGIN(test_rtree_read_empty) {
 	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
 	test_rtree = &rtree;
 	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
-	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
+	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, PAGE, false),
 	    "rtree_read() should return NULL for empty tree");
 	rtree_delete(tsdn, &rtree);
 	test_rtree = NULL;
@@ -139,9 +139,10 @@ TEST_BEGIN(test_rtree_extrema) {
 	test_rtree = &rtree;
 	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0, &extent_a),
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, PAGE, &extent_a),
 	    "Unexpected rtree_write() failure");
-	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true), &extent_a,
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, PAGE, true),
+	    &extent_a,
 	    "rtree_read() should return previously set value");
 
 	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
@@ -158,7 +159,8 @@ TEST_END
 TEST_BEGIN(test_rtree_bits) {
 	tsdn_t *tsdn = tsdn_fetch();
 
-	uintptr_t keys[] = {0, 1, (((uintptr_t)1) << LG_PAGE) - 1};
+	uintptr_t keys[] = {PAGE, PAGE + 1,
+	    PAGE + (((uintptr_t)1) << LG_PAGE) - 1};
 
 	extent_t extent;
 	rtree_t rtree;
@@ -180,7 +182,7 @@ TEST_BEGIN(test_rtree_bits) {
 			    "key=%#"FMTxPTR, i, j, keys[i], keys[j]);
 		}
 		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-		    (((uintptr_t)1) << LG_PAGE), false),
+		    (((uintptr_t)2) << LG_PAGE), false),
 		    "Only leftmost rtree leaf should be set; i=%u", i);
 		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
 	}

--- a/test/unit/spin.c
+++ b/test/unit/spin.c
@@ -1,0 +1,16 @@
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_spin) {
+	spin_t spinner = SPIN_INITIALIZER;
+
+	for (unsigned i = 0; i < 100; i++) {
+		spin_adaptive(&spinner);
+	}
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_spin);
+}


### PR DESCRIPTION
These changes primarily simplify the rtree lookup caching mechanism, making it more robust and slightly faster (measured ~2% speedup for test/stress/microbench).  This makes progress on #465, but does not address the bit width imbalance between levels; that will be a separate effort.

The separate changes should be pretty straightforward to review, as opposed to their squashed equivalent.