### PR TITLE
Broaden rtrees

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,26 @@ case "${host_cpu}" in
 esac
 AC_DEFINE_UNQUOTED([CPU_SPINWAIT], [$CPU_SPINWAIT])
 
+AC_MSG_CHECKING([number of significant virtual address bits])
+case "${host_cpu}" in
+  x86_64|aarch64)
+    LG_VADDR=48
+    ;;
+  *)
+    if test "x${LG_SIZEOF_PTR}" = "x3" ; then
+      LG_VADDR=64
+    elif test "x${LG_SIZEOF_PTR}" = "x2" ; then
+      LG_VADDR=32
+    elif test "x${LG_SIZEOF_PTR}" = "xLG_SIZEOF_PTR_WIN" ; then
+      LG_VADDR="(1U << (LG_SIZEOF_PTR_WIN+3))"
+    else
+      AC_MSG_ERROR([Unsupported lg(pointer size): ${LG_SIZEOF_PTR}])
+    fi
+    ;;
+esac
+AC_MSG_RESULT([$LG_VADDR])
+AC_DEFINE_UNQUOTED([LG_VADDR], [$LG_VADDR])
+
 LD_PRELOAD_VAR="LD_PRELOAD"
 so="so"
 importlib="${so}"

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -22,6 +22,13 @@
  */
 #undef CPU_SPINWAIT
 
+/*
+ * Number of significant bits in virtual addresses.  This may be less than the
+ * total number of bits in a pointer, e.g. on x64, for which the uppermost 16
+ * bits are the same as bit 47.
+ */
+#undef LG_VADDR
+
 /* Defined if C11 atomics are available. */
 #undef JEMALLOC_C11ATOMICS
 

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -419,7 +419,6 @@ rtree_child_read
 rtree_child_read_hard
 rtree_child_tryread
 rtree_clear
-rtree_ctx_start_level
 rtree_delete
 rtree_elm_acquire
 rtree_elm_lookup

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -422,6 +422,7 @@ rtree_clear
 rtree_delete
 rtree_elm_acquire
 rtree_elm_lookup
+rtree_elm_lookup_hard
 rtree_elm_read
 rtree_elm_read_acquired
 rtree_elm_release

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -428,10 +428,12 @@ rtree_elm_witness_acquire
 rtree_elm_witness_release
 rtree_elm_write
 rtree_elm_write_acquired
+rtree_leafkey
 rtree_new
 rtree_node_alloc
 rtree_node_dalloc
 rtree_read
+rtree_subkey
 rtree_write
 s2u
 s2u_compute

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -445,7 +445,6 @@ size2index_compute
 size2index_lookup
 size2index_tab
 spin_adaptive
-spin_init
 stats_print
 tcache_alloc_easy
 tcache_alloc_large

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -415,9 +415,6 @@ prof_thread_name_get
 prof_thread_name_set
 psz2ind
 psz2u
-rtree_child_read
-rtree_child_read_hard
-rtree_child_tryread
 rtree_clear
 rtree_delete
 rtree_elm_acquire
@@ -434,13 +431,7 @@ rtree_elm_write_acquired
 rtree_new
 rtree_node_alloc
 rtree_node_dalloc
-rtree_node_valid
 rtree_read
-rtree_start_level
-rtree_subkey
-rtree_subtree_read
-rtree_subtree_read_hard
-rtree_subtree_tryread
 rtree_write
 s2u
 s2u_compute

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -7,19 +7,15 @@ typedef rtree_elm_t *(rtree_node_alloc_t)(tsdn_t *, rtree_t *, size_t);
 extern rtree_node_alloc_t *rtree_node_alloc;
 typedef void (rtree_node_dalloc_t)(tsdn_t *, rtree_t *, rtree_elm_t *);
 extern rtree_node_dalloc_t *rtree_node_dalloc;
-void	rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
+void rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
 #endif
-rtree_elm_t	*rtree_subtree_read_hard(tsdn_t *tsdn, rtree_t *rtree,
-    unsigned level);
-rtree_elm_t	*rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree,
-    rtree_elm_t *elm, unsigned level);
 rtree_elm_t *rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
     rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
-void	rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
     uintptr_t key, const rtree_elm_t *elm);
-void	rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,
     const rtree_elm_t *elm);
-void	rtree_elm_witness_release(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_witness_release(tsdn_t *tsdn, const rtree_t *rtree,
     const rtree_elm_t *elm);
 
 #endif /* JEMALLOC_INTERNAL_RTREE_EXTERNS_H */

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -1,7 +1,30 @@
 #ifndef JEMALLOC_INTERNAL_RTREE_EXTERNS_H
 #define JEMALLOC_INTERNAL_RTREE_EXTERNS_H
 
-bool rtree_new(rtree_t *rtree, unsigned bits);
+/*
+ * Split the bits into one to three partitions depending on number of
+ * significant bits.  It the number of bits does not divide evenly into the
+ * number of levels, place one remainder bit per level starting at the leaf
+ * level.
+ */
+static const rtree_level_t rtree_levels[] = {
+#if RTREE_NSB <= 10
+	{RTREE_NSB, RTREE_NHIB + RTREE_NSB}
+#elif RTREE_NSB <= 36
+	{RTREE_NSB/2, RTREE_NHIB + RTREE_NSB/2},
+	{RTREE_NSB/2 + RTREE_NSB%2, RTREE_NHIB + RTREE_NSB}
+#elif RTREE_NSB <= 52
+	{RTREE_NSB/3, RTREE_NHIB + RTREE_NSB/3},
+	{RTREE_NSB/3 + RTREE_NSB%3/2,
+	    RTREE_NHIB + RTREE_NSB/3*2 + RTREE_NSB%3/2},
+	{RTREE_NSB/3 + RTREE_NSB%3 - RTREE_NSB%3/2, RTREE_NHIB + RTREE_NSB}
+#else
+#  error Unsupported number of significant virtual address bits
+#endif
+};
+
+
+bool rtree_new(rtree_t *rtree);
 #ifdef JEMALLOC_JET
 typedef rtree_elm_t *(rtree_node_alloc_t)(tsdn_t *, rtree_t *, size_t);
 extern rtree_node_alloc_t *rtree_node_alloc;

--- a/include/jemalloc/internal/rtree_externs.h
+++ b/include/jemalloc/internal/rtree_externs.h
@@ -13,6 +13,8 @@ rtree_elm_t	*rtree_subtree_read_hard(tsdn_t *tsdn, rtree_t *rtree,
     unsigned level);
 rtree_elm_t	*rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree,
     rtree_elm_t *elm, unsigned level);
+rtree_elm_t *rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
+    rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
 void	rtree_elm_witness_acquire(tsdn_t *tsdn, const rtree_t *rtree,
     uintptr_t key, const rtree_elm_t *elm);
 void	rtree_elm_witness_access(tsdn_t *tsdn, const rtree_t *rtree,

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -348,7 +348,7 @@ rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, uintptr_t key,
 	rtree_elm_t *elm;
 
 	elm = rtree_elm_lookup(tsdn, rtree, rtree_ctx, key, dependent, false);
-	if (elm == NULL) {
+	if (!dependent && elm == NULL) {
 		return NULL;
 	}
 

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -2,90 +2,26 @@
 #define JEMALLOC_INTERNAL_RTREE_INLINES_H
 
 #ifndef JEMALLOC_ENABLE_INLINE
-unsigned	rtree_start_level(const rtree_t *rtree, uintptr_t key);
-uintptr_t	rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level);
-
-bool	rtree_node_valid(rtree_elm_t *node);
-rtree_elm_t	*rtree_child_tryread(rtree_elm_t *elm, bool dependent);
-rtree_elm_t	*rtree_child_read(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm,
-    unsigned level, bool dependent);
-extent_t	*rtree_elm_read(rtree_elm_t *elm, bool dependent);
-void	rtree_elm_write(rtree_elm_t *elm, const extent_t *extent);
-rtree_elm_t	*rtree_subtree_tryread(rtree_t *rtree, unsigned level,
-    bool dependent);
-rtree_elm_t	*rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree,
-    unsigned level, bool dependent);
-rtree_elm_t	*rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree,
+extent_t *rtree_elm_read(rtree_elm_t *elm, bool dependent);
+void rtree_elm_write(rtree_elm_t *elm, const extent_t *extent);
+rtree_elm_t *rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree,
     rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
-
-bool	rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
+bool rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, const extent_t *extent);
-extent_t	*rtree_read(tsdn_t *tsdn, rtree_t *rtree,
-    rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent);
-rtree_elm_t	*rtree_elm_acquire(tsdn_t *tsdn, rtree_t *rtree,
+extent_t *rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
+    uintptr_t key, bool dependent);
+rtree_elm_t *rtree_elm_acquire(tsdn_t *tsdn, rtree_t *rtree,
     rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
-extent_t	*rtree_elm_read_acquired(tsdn_t *tsdn, const rtree_t *rtree,
+extent_t *rtree_elm_read_acquired(tsdn_t *tsdn, const rtree_t *rtree,
     rtree_elm_t *elm);
-void	rtree_elm_write_acquired(tsdn_t *tsdn, const rtree_t *rtree,
+void rtree_elm_write_acquired(tsdn_t *tsdn, const rtree_t *rtree,
     rtree_elm_t *elm, const extent_t *extent);
-void	rtree_elm_release(tsdn_t *tsdn, const rtree_t *rtree, rtree_elm_t *elm);
-void	rtree_clear(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
+void rtree_elm_release(tsdn_t *tsdn, const rtree_t *rtree, rtree_elm_t *elm);
+void rtree_clear(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_RTREE_C_))
-JEMALLOC_ALWAYS_INLINE unsigned
-rtree_start_level(const rtree_t *rtree, uintptr_t key) {
-	unsigned start_level;
-
-	if (unlikely(key == 0)) {
-		return rtree->height - 1;
-	}
-
-	start_level = rtree->start_level[(lg_floor(key) + 1) >>
-	    LG_RTREE_BITS_PER_LEVEL];
-	assert(start_level < rtree->height);
-	return start_level;
-}
-
-JEMALLOC_ALWAYS_INLINE uintptr_t
-rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level) {
-	return ((key >> ((ZU(1) << (LG_SIZEOF_PTR+3)) -
-	    rtree->levels[level].cumbits)) & ((ZU(1) <<
-	    rtree->levels[level].bits) - 1));
-}
-
-JEMALLOC_ALWAYS_INLINE bool
-rtree_node_valid(rtree_elm_t *node) {
-	return ((uintptr_t)node != (uintptr_t)0);
-}
-
-JEMALLOC_ALWAYS_INLINE rtree_elm_t *
-rtree_child_tryread(rtree_elm_t *elm, bool dependent) {
-	rtree_elm_t *child;
-
-	/* Double-checked read (first read may be stale). */
-	child = elm->child;
-	if (!dependent && !rtree_node_valid(child)) {
-		child = (rtree_elm_t *)atomic_read_p(&elm->pun);
-	}
-	assert(!dependent || child != NULL);
-	return child;
-}
-
-JEMALLOC_ALWAYS_INLINE rtree_elm_t *
-rtree_child_read(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm, unsigned level,
-    bool dependent) {
-	rtree_elm_t *child;
-
-	child = rtree_child_tryread(elm, dependent);
-	if (!dependent && unlikely(!rtree_node_valid(child))) {
-		child = rtree_child_read_hard(tsdn, rtree, elm, level);
-	}
-	assert(!dependent || child != NULL);
-	return child;
-}
-
 JEMALLOC_ALWAYS_INLINE extent_t *
 rtree_elm_read(rtree_elm_t *elm, bool dependent) {
 	extent_t *extent;
@@ -116,33 +52,6 @@ rtree_elm_read(rtree_elm_t *elm, bool dependent) {
 JEMALLOC_INLINE void
 rtree_elm_write(rtree_elm_t *elm, const extent_t *extent) {
 	atomic_write_p(&elm->pun, extent);
-}
-
-JEMALLOC_ALWAYS_INLINE rtree_elm_t *
-rtree_subtree_tryread(rtree_t *rtree, unsigned level, bool dependent) {
-	rtree_elm_t *subtree;
-
-	/* Double-checked read (first read may be stale). */
-	subtree = rtree->levels[level].subtree;
-	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
-		subtree = (rtree_elm_t *)atomic_read_p(
-		    &rtree->levels[level].subtree_pun);
-	}
-	assert(!dependent || subtree != NULL);
-	return subtree;
-}
-
-JEMALLOC_ALWAYS_INLINE rtree_elm_t *
-rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
-    bool dependent) {
-	rtree_elm_t *subtree;
-
-	subtree = rtree_subtree_tryread(rtree, level, dependent);
-	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
-		subtree = rtree_subtree_read_hard(tsdn, rtree, level);
-	}
-	assert(!dependent || subtree != NULL);
-	return subtree;
 }
 
 JEMALLOC_ALWAYS_INLINE rtree_elm_t *

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -79,17 +79,15 @@ rtree_elm_write(rtree_elm_t *elm, const extent_t *extent) {
 JEMALLOC_ALWAYS_INLINE rtree_elm_t *
 rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, bool dependent, bool init_missing) {
+	assert(key != 0);
 	assert(!dependent || !init_missing);
 
-	if (likely(key != 0)) {
-		uintptr_t leafkey = rtree_leafkey(key);
-		if (likely(rtree_ctx->cache[0].leafkey == leafkey)) {
-			rtree_elm_t *leaf = rtree_ctx->cache[0].leaf;
-			if (likely(leaf != NULL)) {
-				uintptr_t subkey = rtree_subkey(key,
-				    RTREE_HEIGHT-1);
-				return &leaf[subkey];
-			}
+	uintptr_t leafkey = rtree_leafkey(key);
+	if (likely(rtree_ctx->cache[0].leafkey == leafkey)) {
+		rtree_elm_t *leaf = rtree_ctx->cache[0].leaf;
+		if (likely(leaf != NULL)) {
+			uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
+			return &leaf[subkey];
 		}
 	}
 

--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -150,129 +150,14 @@ rtree_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, bool dependent, bool init_missing) {
 	assert(!dependent || !init_missing);
 
-	/*
-	 * Search the remaining cache elements, and on success move the matching
-	 * element to the front.
-	 */
 	if (likely(key != 0)) {
 		if (likely(rtree_ctx->cache[0].key == key)) {
 			return rtree_ctx->cache[0].elm;
 		}
-		for (unsigned i = 1; i < RTREE_CTX_NCACHE; i++) {
-			if (rtree_ctx->cache[i].key == key) {
-				/* Reorder. */
-				rtree_elm_t *elm = rtree_ctx->cache[i].elm;
-				memmove(&rtree_ctx->cache[1],
-				    &rtree_ctx->cache[0],
-				    sizeof(rtree_ctx_cache_elm_t) * i);
-				rtree_ctx->cache[0].key = key;
-				rtree_ctx->cache[0].elm = elm;
-
-				return elm;
-			}
-		}
 	}
 
-	unsigned start_level = rtree_start_level(rtree, key);
-	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
-	    start_level, dependent) : rtree_subtree_tryread(rtree, start_level,
-	    dependent);
-
-#define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
-	switch (start_level + RTREE_GET_BIAS) {
-#define RTREE_GET_SUBTREE(level)					\
-	case level: {							\
-		assert(level < (RTREE_HEIGHT_MAX-1));			\
-		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
-			return NULL;					\
-		}							\
-		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
-		    RTREE_GET_BIAS);					\
-		node = init_missing ? rtree_child_read(tsdn, rtree,	\
-		    &node[subkey], level - RTREE_GET_BIAS, dependent) :	\
-		    rtree_child_tryread(&node[subkey], dependent);	\
-		/* Fall through. */					\
-	}
-#define RTREE_GET_LEAF(level)						\
-	case level: {							\
-		assert(level == (RTREE_HEIGHT_MAX-1));			\
-		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
-			return NULL;					\
-		}							\
-		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
-		    RTREE_GET_BIAS);					\
-		/*							\
-		 * node is a leaf, so it contains values rather than	\
-		 * child pointers.					\
-		 */							\
-		node = &node[subkey];					\
-		if (likely(key != 0)) {					\
-			if (RTREE_CTX_NCACHE > 1) {			\
-				memmove(&rtree_ctx->cache[1],		\
-				    &rtree_ctx->cache[0],		\
-				    sizeof(rtree_ctx_cache_elm_t) *	\
-				    (RTREE_CTX_NCACHE-1));		\
-			}						\
-			rtree_ctx->cache[0].key = key;			\
-			rtree_ctx->cache[0].elm = node;			\
-		}							\
-		return node;						\
-	}
-#if RTREE_HEIGHT_MAX > 1
-	RTREE_GET_SUBTREE(0)
-#endif
-#if RTREE_HEIGHT_MAX > 2
-	RTREE_GET_SUBTREE(1)
-#endif
-#if RTREE_HEIGHT_MAX > 3
-	RTREE_GET_SUBTREE(2)
-#endif
-#if RTREE_HEIGHT_MAX > 4
-	RTREE_GET_SUBTREE(3)
-#endif
-#if RTREE_HEIGHT_MAX > 5
-	RTREE_GET_SUBTREE(4)
-#endif
-#if RTREE_HEIGHT_MAX > 6
-	RTREE_GET_SUBTREE(5)
-#endif
-#if RTREE_HEIGHT_MAX > 7
-	RTREE_GET_SUBTREE(6)
-#endif
-#if RTREE_HEIGHT_MAX > 8
-	RTREE_GET_SUBTREE(7)
-#endif
-#if RTREE_HEIGHT_MAX > 9
-	RTREE_GET_SUBTREE(8)
-#endif
-#if RTREE_HEIGHT_MAX > 10
-	RTREE_GET_SUBTREE(9)
-#endif
-#if RTREE_HEIGHT_MAX > 11
-	RTREE_GET_SUBTREE(10)
-#endif
-#if RTREE_HEIGHT_MAX > 12
-	RTREE_GET_SUBTREE(11)
-#endif
-#if RTREE_HEIGHT_MAX > 13
-	RTREE_GET_SUBTREE(12)
-#endif
-#if RTREE_HEIGHT_MAX > 14
-	RTREE_GET_SUBTREE(13)
-#endif
-#if RTREE_HEIGHT_MAX > 15
-	RTREE_GET_SUBTREE(14)
-#endif
-#if RTREE_HEIGHT_MAX > 16
-#  error Unsupported RTREE_HEIGHT_MAX
-#endif
-	RTREE_GET_LEAF(RTREE_HEIGHT_MAX-1)
-#undef RTREE_GET_SUBTREE
-#undef RTREE_GET_LEAF
-	default: not_reached();
-	}
-#undef RTREE_GET_BIAS
-	not_reached();
+	return rtree_elm_lookup_hard(tsdn, rtree, rtree_ctx, key, dependent,
+	    init_missing);
 }
 
 JEMALLOC_INLINE bool

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -54,22 +54,13 @@ struct rtree_level_s {
 	unsigned		cumbits;
 };
 
-struct rtree_ctx_s {
-	/* If false, key/elms have not yet been initialized by a lookup. */
-	bool		valid;
-	/* Key that corresponds to the tree path recorded in elms. */
+struct rtree_ctx_cache_elm_s {
 	uintptr_t	key;
-	/* Memoized rtree_start_level(key). */
-	unsigned	start_level;
-	/*
-	 * A path through rtree, driven by key.  Only elements that could
-	 * actually be used for subsequent lookups are initialized, i.e. if
-	 * start_level = rtree_start_level(key) is non-zero, the first
-	 * start_level elements are uninitialized.  The last element contains a
-	 * pointer to the leaf node element that corresponds to key, so that
-	 * exact matches require no tree node offset computation.
-	 */
-	rtree_elm_t	*elms[RTREE_HEIGHT_MAX + 1];
+	rtree_elm_t	*elm;
+};
+
+struct rtree_ctx_s {
+	rtree_ctx_cache_elm_t cache[RTREE_CTX_NCACHE];
 };
 
 struct rtree_s {

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -29,8 +29,8 @@ struct rtree_level_s {
 };
 
 struct rtree_ctx_cache_elm_s {
-	uintptr_t	key;
-	rtree_elm_t	*elm;
+	uintptr_t	leafkey;
+	rtree_elm_t	*leaf;
 };
 
 struct rtree_ctx_s {
@@ -38,12 +38,10 @@ struct rtree_ctx_s {
 };
 
 struct rtree_s {
-	unsigned		height;
 	union {
 		void		*root_pun;
 		rtree_elm_t	*root;
 	};
-	rtree_level_t		levels[RTREE_HEIGHT_MAX];
 	malloc_mutex_t		init_lock;
 };
 

--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -19,32 +19,6 @@ struct rtree_elm_witness_tsd_s {
 };
 
 struct rtree_level_s {
-	/*
-	 * A non-NULL subtree points to a subtree rooted along the hypothetical
-	 * path to the leaf node corresponding to key 0.  Depending on what keys
-	 * have been used to store to the tree, an arbitrary combination of
-	 * subtree pointers may remain NULL.
-	 *
-	 * Suppose keys comprise 48 bits, and LG_RTREE_BITS_PER_LEVEL is 4.
-	 * This results in a 3-level tree, and the leftmost leaf can be directly
-	 * accessed via levels[2], the subtree prefixed by 0x0000 (excluding
-	 * 0x00000000) can be accessed via levels[1], and the remainder of the
-	 * tree can be accessed via levels[0].
-	 *
-	 *   levels[0] : [<unused> | 0x0001******** | 0x0002******** | ...]
-	 *
-	 *   levels[1] : [<unused> | 0x00000001**** | 0x00000002**** | ... ]
-	 *
-	 *   levels[2] : [extent(0x000000000000) | extent(0x000000000001) | ...]
-	 *
-	 * This has practical implications on x64, which currently uses only the
-	 * lower 47 bits of virtual address space in userland, thus leaving
-	 * levels[0] unused and avoiding a level of tree traversal.
-	 */
-	union {
-		void		*subtree_pun;
-		rtree_elm_t	*subtree;
-	};
 	/* Number of key bits distinguished by this level. */
 	unsigned		bits;
 	/*
@@ -65,11 +39,10 @@ struct rtree_ctx_s {
 
 struct rtree_s {
 	unsigned		height;
-	/*
-	 * Precomputed table used to convert from the number of leading 0 key
-	 * bits to which subtree level to start at.
-	 */
-	unsigned		start_level[RTREE_HEIGHT_MAX + 1];
+	union {
+		void		*root_pun;
+		rtree_elm_t	*root;
+	};
 	rtree_level_t		levels[RTREE_HEIGHT_MAX];
 	malloc_mutex_t		init_lock;
 };

--- a/include/jemalloc/internal/rtree_types.h
+++ b/include/jemalloc/internal/rtree_types.h
@@ -12,6 +12,7 @@ typedef struct rtree_elm_s rtree_elm_t;
 typedef struct rtree_elm_witness_s rtree_elm_witness_t;
 typedef struct rtree_elm_witness_tsd_s rtree_elm_witness_tsd_t;
 typedef struct rtree_level_s rtree_level_t;
+typedef struct rtree_ctx_cache_elm_s rtree_ctx_cache_elm_t;
 typedef struct rtree_ctx_s rtree_ctx_t;
 typedef struct rtree_s rtree_t;
 
@@ -25,11 +26,12 @@ typedef struct rtree_s rtree_t;
 #define RTREE_HEIGHT_MAX						\
     ((1U << (LG_SIZEOF_PTR+3)) / RTREE_BITS_PER_LEVEL)
 
+/* Number of key/elm pairs to cache. */
+#define RTREE_CTX_NCACHE 2
+
+/* Static initializer for rtree_ctx_t. */
 #define RTREE_CTX_INITIALIZER	{					\
-	false,								\
-	0,								\
-	0,								\
-	{NULL /* C initializes all trailing elements to NULL. */}	\
+	{{0, NULL} /* C initializes all trailing elements to NULL. */}	\
 }
 
 /*

--- a/include/jemalloc/internal/rtree_types.h
+++ b/include/jemalloc/internal/rtree_types.h
@@ -16,17 +16,21 @@ typedef struct rtree_ctx_cache_elm_s rtree_ctx_cache_elm_t;
 typedef struct rtree_ctx_s rtree_ctx_t;
 typedef struct rtree_s rtree_t;
 
-/*
- * RTREE_BITS_PER_LEVEL must be a power of two that is no larger than the
- * machine address width.
- */
-#define LG_RTREE_BITS_PER_LEVEL	4
-#define RTREE_BITS_PER_LEVEL	(1U << LG_RTREE_BITS_PER_LEVEL)
-/* Maximum rtree height. */
-#define RTREE_HEIGHT_MAX						\
-    ((1U << (LG_SIZEOF_PTR+3)) / RTREE_BITS_PER_LEVEL)
+/* Number of high insignificant bits. */
+#define RTREE_NHIB ((1U << (LG_SIZEOF_PTR+3)) - LG_VADDR)
+/* Number of low insigificant bits. */
+#define RTREE_NLIB LG_PAGE
+/* Number of significant bits. */
+#define RTREE_NSB (LG_VADDR - RTREE_NLIB)
+/* Number of levels in radix tree. */
+#define RTREE_HEIGHT (sizeof(rtree_levels)/sizeof(rtree_level_t))
 
-/* Number of key/elm pairs to cache. */
+/*
+ * Number of leafkey/leaf pairs to cache.  Each entry supports an entire leaf,
+ * so the cache hit rate is typically high even with a small number of entries.
+ * Two entries is enough to keep the hit rate high even when an arena uses a
+ * combination of dss and mmap.
+ */
 #define RTREE_CTX_NCACHE 2
 
 /* Static initializer for rtree_ctx_t. */

--- a/include/jemalloc/internal/spin_inlines.h
+++ b/include/jemalloc/internal/spin_inlines.h
@@ -2,16 +2,10 @@
 #define JEMALLOC_INTERNAL_SPIN_INLINES_H
 
 #ifndef JEMALLOC_ENABLE_INLINE
-void	spin_init(spin_t *spin);
 void	spin_adaptive(spin_t *spin);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_SPIN_C_))
-JEMALLOC_INLINE void
-spin_init(spin_t *spin) {
-	spin->iteration = 0;
-}
-
 JEMALLOC_INLINE void
 spin_adaptive(spin_t *spin) {
 	volatile uint64_t i;

--- a/include/jemalloc/internal/spin_types.h
+++ b/include/jemalloc/internal/spin_types.h
@@ -3,4 +3,6 @@
 
 typedef struct spin_s spin_t;
 
+#define SPIN_INITIALIZER {0U}
+
 #endif /* JEMALLOC_INTERNAL_SPIN_TYPES_H */

--- a/src/extent.c
+++ b/src/extent.c
@@ -1507,8 +1507,7 @@ extent_merge_wrapper(tsdn_t *tsdn, arena_t *arena,
 
 bool
 extent_boot(void) {
-	if (rtree_new(&extents_rtree, (unsigned)((ZU(1) << (LG_SIZEOF_PTR+3)) -
-	    LG_PAGE))) {
+	if (rtree_new(&extents_rtree)) {
 		return true;
 	}
 

--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -62,13 +62,12 @@ extent_dss_prec_set(dss_prec_t dss_prec) {
 static void *
 extent_dss_max_update(void *new_addr) {
 	void *max_cur;
-	spin_t spinner;
 
 	/*
 	 * Get the current end of the DSS as max_cur and assure that dss_max is
 	 * up to date.
 	 */
-	spin_init(&spinner);
+	spin_t spinner = SPIN_INITIALIZER;
 	while (true) {
 		void *max_prev = atomic_read_p(&dss_max);
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1153,10 +1153,8 @@ malloc_init_hard_needed(void) {
 	}
 #ifdef JEMALLOC_THREADED_INIT
 	if (malloc_initializer != NO_INITIALIZER && !IS_INITIALIZER) {
-		spin_t spinner;
-
 		/* Busy-wait until the initializing thread completes. */
-		spin_init(&spinner);
+		spin_t spinner = SPIN_INITIALIZER;
 		do {
 			malloc_mutex_unlock(TSDN_NULL, &init_lock);
 			spin_adaptive(&spinner);

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -1,11 +1,6 @@
 #define JEMALLOC_RTREE_C_
 #include "jemalloc/internal/jemalloc_internal.h"
 
-static unsigned
-hmin(unsigned ha, unsigned hb) {
-	return (ha < hb ? ha : hb);
-}
-
 /*
  * Only the most significant bits of keys passed to rtree_{read,write}() are
  * used.
@@ -32,31 +27,23 @@ rtree_new(rtree_t *rtree, unsigned bits) {
 
 	rtree->height = height;
 
+	rtree->root_pun = NULL;
+
 	/* Root level. */
-	rtree->levels[0].subtree = NULL;
 	rtree->levels[0].bits = (height > 1) ? RTREE_BITS_PER_LEVEL :
 	    bits_in_leaf;
 	rtree->levels[0].cumbits = rtree->levels[0].bits;
 	/* Interior levels. */
 	for (i = 1; i < height-1; i++) {
-		rtree->levels[i].subtree = NULL;
 		rtree->levels[i].bits = RTREE_BITS_PER_LEVEL;
 		rtree->levels[i].cumbits = rtree->levels[i-1].cumbits +
 		    RTREE_BITS_PER_LEVEL;
 	}
 	/* Leaf level. */
 	if (height > 1) {
-		rtree->levels[height-1].subtree = NULL;
 		rtree->levels[height-1].bits = bits_in_leaf;
 		rtree->levels[height-1].cumbits = bits;
 	}
-
-	/* Compute lookup table to be used by rtree_[ctx_]start_level(). */
-	for (i = 0; i < RTREE_HEIGHT_MAX; i++) {
-		rtree->start_level[i] = hmin(RTREE_HEIGHT_MAX - 1 - i, height -
-		    1);
-	}
-	rtree->start_level[RTREE_HEIGHT_MAX] = 0;
 
 	malloc_mutex_init(&rtree->init_lock, "rtree", WITNESS_RANK_RTREE);
 
@@ -114,13 +101,8 @@ rtree_delete_subtree(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *node,
 
 void
 rtree_delete(tsdn_t *tsdn, rtree_t *rtree) {
-	unsigned i;
-
-	for (i = 0; i < rtree->height; i++) {
-		rtree_elm_t *subtree = rtree->levels[i].subtree;
-		if (subtree != NULL) {
-			rtree_delete_subtree(tsdn, rtree, subtree, i);
-		}
+	if (rtree->root_pun != NULL) {
+		rtree_delete_subtree(tsdn, rtree, rtree->root, 0);
 	}
 }
 #endif
@@ -144,20 +126,6 @@ rtree_node_init(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
 	malloc_mutex_unlock(tsdn, &rtree->init_lock);
 
 	return node;
-}
-
-static unsigned
-rtree_start_level(const rtree_t *rtree, uintptr_t key) {
-	unsigned start_level;
-
-	if (unlikely(key == 0)) {
-		return rtree->height - 1;
-	}
-
-	start_level = rtree->start_level[(lg_floor(key) + 1) >>
-	    LG_RTREE_BITS_PER_LEVEL];
-	assert(start_level < rtree->height);
-	return start_level;
 }
 
 static uintptr_t
@@ -199,28 +167,21 @@ rtree_child_read(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm, unsigned level,
 }
 
 static rtree_elm_t *
-rtree_subtree_tryread(rtree_t *rtree, unsigned level, bool dependent) {
-	rtree_elm_t *subtree;
-
+rtree_subtree_tryread(rtree_t *rtree, bool dependent) {
 	/* Double-checked read (first read may be stale). */
-	subtree = rtree->levels[level].subtree;
+	rtree_elm_t *subtree = rtree->root;
 	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
-		subtree = (rtree_elm_t *)atomic_read_p(
-		    &rtree->levels[level].subtree_pun);
+		subtree = (rtree_elm_t *)atomic_read_p(&rtree->root_pun);
 	}
 	assert(!dependent || subtree != NULL);
 	return subtree;
 }
 
 static rtree_elm_t *
-rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
-    bool dependent) {
-	rtree_elm_t *subtree;
-
-	subtree = rtree_subtree_tryread(rtree, level, dependent);
+rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree, bool dependent) {
+	rtree_elm_t *subtree = rtree_subtree_tryread(rtree, dependent);
 	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
-		subtree = rtree_node_init(tsdn, rtree, level,
-		    &rtree->levels[level].subtree);
+		subtree = rtree_node_init(tsdn, rtree, 0, &rtree->root);
 	}
 	assert(!dependent || subtree != NULL);
 	return subtree;
@@ -249,13 +210,11 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		}
 	}
 
-	unsigned start_level = rtree_start_level(rtree, key);
 	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
-	    start_level, dependent) : rtree_subtree_tryread(rtree, start_level,
-	    dependent);
+	    dependent) : rtree_subtree_tryread(rtree, dependent);
 
 #define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
-	switch (start_level + RTREE_GET_BIAS) {
+	switch (RTREE_GET_BIAS) {
 #define RTREE_GET_SUBTREE(level)					\
 	case level: {							\
 		assert(level < (RTREE_HEIGHT_MAX-1));			\

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -153,22 +153,20 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 	 * element to the front.
 	 */
 	uintptr_t leafkey = rtree_leafkey(key);
-	if (likely(key != 0)) {
-		for (unsigned i = 1; i < RTREE_CTX_NCACHE; i++) {
-			if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {
-				rtree_elm_t *leaf = rtree_ctx->cache[i].leaf;
-				if (likely(leaf != NULL)) {
-					/* Reorder. */
-					memmove(&rtree_ctx->cache[1],
-					    &rtree_ctx->cache[0],
-					    sizeof(rtree_ctx_cache_elm_t) * i);
-					rtree_ctx->cache[0].leafkey = leafkey;
-					rtree_ctx->cache[0].leaf = leaf;
+	for (unsigned i = 1; i < RTREE_CTX_NCACHE; i++) {
+		if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {
+			rtree_elm_t *leaf = rtree_ctx->cache[i].leaf;
+			if (likely(leaf != NULL)) {
+				/* Reorder. */
+				memmove(&rtree_ctx->cache[1],
+				    &rtree_ctx->cache[0],
+				    sizeof(rtree_ctx_cache_elm_t) * i);
+				rtree_ctx->cache[0].leafkey = leafkey;
+				rtree_ctx->cache[0].leaf = leaf;
 
-					uintptr_t subkey = rtree_subkey(key,
-					    RTREE_HEIGHT-1);
-					return &leaf[subkey];
-				}
+				uintptr_t subkey = rtree_subkey(key,
+				    RTREE_HEIGHT-1);
+				return &leaf[subkey];
 			}
 		}
 	}
@@ -195,16 +193,14 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		 * node is a leaf, so it contains values rather than	\
 		 * child pointers.					\
 		 */							\
-		if (likely(key != 0)) {					\
-			if (RTREE_CTX_NCACHE > 1) {			\
-				memmove(&rtree_ctx->cache[1],		\
-				    &rtree_ctx->cache[0],		\
-				    sizeof(rtree_ctx_cache_elm_t) *	\
-				    (RTREE_CTX_NCACHE-1));		\
-			}						\
-			rtree_ctx->cache[0].leafkey = leafkey;		\
-			rtree_ctx->cache[0].leaf = node;		\
+		if (RTREE_CTX_NCACHE > 1) {				\
+			memmove(&rtree_ctx->cache[1],			\
+			    &rtree_ctx->cache[0],			\
+			    sizeof(rtree_ctx_cache_elm_t) *		\
+			    (RTREE_CTX_NCACHE-1));			\
 		}							\
+		rtree_ctx->cache[0].leafkey = leafkey;			\
+		rtree_ctx->cache[0].leaf = node;			\
 		uintptr_t subkey = rtree_subkey(key, level);		\
 		return &node[subkey];					\
 	}

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -6,46 +6,11 @@
  * used.
  */
 bool
-rtree_new(rtree_t *rtree, unsigned bits) {
-	unsigned bits_in_leaf, height, i;
-
-	assert(RTREE_HEIGHT_MAX == ((ZU(1) << (LG_SIZEOF_PTR+3)) /
-	    RTREE_BITS_PER_LEVEL));
-	assert(bits > 0 && bits <= (sizeof(uintptr_t) << 3));
-
-	bits_in_leaf = (bits % RTREE_BITS_PER_LEVEL) == 0 ? RTREE_BITS_PER_LEVEL
-	    : (bits % RTREE_BITS_PER_LEVEL);
-	if (bits > bits_in_leaf) {
-		height = 1 + (bits - bits_in_leaf) / RTREE_BITS_PER_LEVEL;
-		if ((height-1) * RTREE_BITS_PER_LEVEL + bits_in_leaf != bits) {
-			height++;
-		}
-	} else {
-		height = 1;
-	}
-	assert((height-1) * RTREE_BITS_PER_LEVEL + bits_in_leaf == bits);
-
-	rtree->height = height;
-
+rtree_new(rtree_t *rtree) {
 	rtree->root_pun = NULL;
-
-	/* Root level. */
-	rtree->levels[0].bits = (height > 1) ? RTREE_BITS_PER_LEVEL :
-	    bits_in_leaf;
-	rtree->levels[0].cumbits = rtree->levels[0].bits;
-	/* Interior levels. */
-	for (i = 1; i < height-1; i++) {
-		rtree->levels[i].bits = RTREE_BITS_PER_LEVEL;
-		rtree->levels[i].cumbits = rtree->levels[i-1].cumbits +
-		    RTREE_BITS_PER_LEVEL;
+	if (malloc_mutex_init(&rtree->init_lock, "rtree", WITNESS_RANK_RTREE)) {
+		return true;
 	}
-	/* Leaf level. */
-	if (height > 1) {
-		rtree->levels[height-1].bits = bits_in_leaf;
-		rtree->levels[height-1].cumbits = bits;
-	}
-
-	malloc_mutex_init(&rtree->init_lock, "rtree", WITNESS_RANK_RTREE);
 
 	return false;
 }
@@ -84,10 +49,10 @@ rtree_node_dalloc_t *rtree_node_dalloc = JEMALLOC_N(rtree_node_dalloc_impl);
 static void
 rtree_delete_subtree(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *node,
     unsigned level) {
-	if (level + 1 < rtree->height) {
+	if (level + 1 < RTREE_HEIGHT) {
 		size_t nchildren, i;
 
-		nchildren = ZU(1) << rtree->levels[level].bits;
+		nchildren = ZU(1) << rtree_levels[level].bits;
 		for (i = 0; i < nchildren; i++) {
 			rtree_elm_t *child = node[i].child;
 			if (child != NULL) {
@@ -116,7 +81,7 @@ rtree_node_init(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
 	node = atomic_read_p((void**)elmp);
 	if (node == NULL) {
 		node = rtree_node_alloc(tsdn, rtree, ZU(1) <<
-		    rtree->levels[level].bits);
+		    rtree_levels[level].bits);
 		if (node == NULL) {
 			malloc_mutex_unlock(tsdn, &rtree->init_lock);
 			return NULL;
@@ -126,13 +91,6 @@ rtree_node_init(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
 	malloc_mutex_unlock(tsdn, &rtree->init_lock);
 
 	return node;
-}
-
-static uintptr_t
-rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level) {
-	return ((key >> ((ZU(1) << (LG_SIZEOF_PTR+3)) -
-	    rtree->levels[level].cumbits)) & ((ZU(1) <<
-	    rtree->levels[level].bits) - 1));
 }
 
 static bool
@@ -194,18 +152,23 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 	 * Search the remaining cache elements, and on success move the matching
 	 * element to the front.
 	 */
+	uintptr_t leafkey = rtree_leafkey(key);
 	if (likely(key != 0)) {
 		for (unsigned i = 1; i < RTREE_CTX_NCACHE; i++) {
-			if (rtree_ctx->cache[i].key == key) {
-				/* Reorder. */
-				rtree_elm_t *elm = rtree_ctx->cache[i].elm;
-				memmove(&rtree_ctx->cache[1],
-				    &rtree_ctx->cache[0],
-				    sizeof(rtree_ctx_cache_elm_t) * i);
-				rtree_ctx->cache[0].key = key;
-				rtree_ctx->cache[0].elm = elm;
+			if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {
+				rtree_elm_t *leaf = rtree_ctx->cache[i].leaf;
+				if (likely(leaf != NULL)) {
+					/* Reorder. */
+					memmove(&rtree_ctx->cache[1],
+					    &rtree_ctx->cache[0],
+					    sizeof(rtree_ctx_cache_elm_t) * i);
+					rtree_ctx->cache[0].leafkey = leafkey;
+					rtree_ctx->cache[0].leaf = leaf;
 
-				return elm;
+					uintptr_t subkey = rtree_subkey(key,
+					    RTREE_HEIGHT-1);
+					return &leaf[subkey];
+				}
 			}
 		}
 	}
@@ -213,34 +176,25 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
 	    dependent) : rtree_subtree_tryread(rtree, dependent);
 
-#define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
-	switch (RTREE_GET_BIAS) {
-#define RTREE_GET_SUBTREE(level)					\
-	case level: {							\
-		assert(level < (RTREE_HEIGHT_MAX-1));			\
+#define RTREE_GET_SUBTREE(level) {					\
+		assert(level < RTREE_HEIGHT-1);				\
 		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
 			return NULL;					\
 		}							\
-		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
-		    RTREE_GET_BIAS);					\
+		uintptr_t subkey = rtree_subkey(key, level);		\
 		node = init_missing ? rtree_child_read(tsdn, rtree,	\
-		    &node[subkey], level - RTREE_GET_BIAS, dependent) :	\
+		    &node[subkey], level, dependent) :			\
 		    rtree_child_tryread(&node[subkey], dependent);	\
-		/* Fall through. */					\
 	}
-#define RTREE_GET_LEAF(level)						\
-	case level: {							\
-		assert(level == (RTREE_HEIGHT_MAX-1));			\
+#define RTREE_GET_LEAF(level) {						\
+		assert(level == RTREE_HEIGHT-1);			\
 		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
 			return NULL;					\
 		}							\
-		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
-		    RTREE_GET_BIAS);					\
 		/*							\
 		 * node is a leaf, so it contains values rather than	\
 		 * child pointers.					\
 		 */							\
-		node = &node[subkey];					\
 		if (likely(key != 0)) {					\
 			if (RTREE_CTX_NCACHE > 1) {			\
 				memmove(&rtree_ctx->cache[1],		\
@@ -248,65 +202,26 @@ rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 				    sizeof(rtree_ctx_cache_elm_t) *	\
 				    (RTREE_CTX_NCACHE-1));		\
 			}						\
-			rtree_ctx->cache[0].key = key;			\
-			rtree_ctx->cache[0].elm = node;			\
+			rtree_ctx->cache[0].leafkey = leafkey;		\
+			rtree_ctx->cache[0].leaf = node;		\
 		}							\
-		return node;						\
+		uintptr_t subkey = rtree_subkey(key, level);		\
+		return &node[subkey];					\
 	}
-#if RTREE_HEIGHT_MAX > 1
-	RTREE_GET_SUBTREE(0)
-#endif
-#if RTREE_HEIGHT_MAX > 2
-	RTREE_GET_SUBTREE(1)
-#endif
-#if RTREE_HEIGHT_MAX > 3
-	RTREE_GET_SUBTREE(2)
-#endif
-#if RTREE_HEIGHT_MAX > 4
-	RTREE_GET_SUBTREE(3)
-#endif
-#if RTREE_HEIGHT_MAX > 5
-	RTREE_GET_SUBTREE(4)
-#endif
-#if RTREE_HEIGHT_MAX > 6
-	RTREE_GET_SUBTREE(5)
-#endif
-#if RTREE_HEIGHT_MAX > 7
-	RTREE_GET_SUBTREE(6)
-#endif
-#if RTREE_HEIGHT_MAX > 8
-	RTREE_GET_SUBTREE(7)
-#endif
-#if RTREE_HEIGHT_MAX > 9
-	RTREE_GET_SUBTREE(8)
-#endif
-#if RTREE_HEIGHT_MAX > 10
-	RTREE_GET_SUBTREE(9)
-#endif
-#if RTREE_HEIGHT_MAX > 11
-	RTREE_GET_SUBTREE(10)
-#endif
-#if RTREE_HEIGHT_MAX > 12
-	RTREE_GET_SUBTREE(11)
-#endif
-#if RTREE_HEIGHT_MAX > 13
-	RTREE_GET_SUBTREE(12)
-#endif
-#if RTREE_HEIGHT_MAX > 14
-	RTREE_GET_SUBTREE(13)
-#endif
-#if RTREE_HEIGHT_MAX > 15
-	RTREE_GET_SUBTREE(14)
-#endif
-#if RTREE_HEIGHT_MAX > 16
-#  error Unsupported RTREE_HEIGHT_MAX
-#endif
-	RTREE_GET_LEAF(RTREE_HEIGHT_MAX-1)
+	if (RTREE_HEIGHT > 1) {
+		RTREE_GET_SUBTREE(0)
+	}
+	if (RTREE_HEIGHT > 2) {
+		RTREE_GET_SUBTREE(1)
+	}
+	if (RTREE_HEIGHT > 3) {
+		for (unsigned i = 2; i < RTREE_HEIGHT-1; i++) {
+			RTREE_GET_SUBTREE(i)
+		}
+	}
+	RTREE_GET_LEAF(RTREE_HEIGHT-1)
 #undef RTREE_GET_SUBTREE
 #undef RTREE_GET_LEAF
-	default: not_reached();
-	}
-#undef RTREE_GET_BIAS
 	not_reached();
 }
 
@@ -378,7 +293,7 @@ rtree_elm_witness_dalloc(tsd_t *tsd, witness_t *witness,
 			witness_init(&rew->witness, "rtree_elm",
 			    WITNESS_RANK_RTREE_ELM, rtree_elm_witness_comp,
 			    NULL);
-			    return;
+			return;
 		}
 	}
 	not_reached();

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -158,6 +158,131 @@ rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm,
 	return rtree_node_init(tsdn, rtree, level+1, &elm->child);
 }
 
+rtree_elm_t *
+rtree_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
+    uintptr_t key, bool dependent, bool init_missing) {
+	/*
+	 * Search the remaining cache elements, and on success move the matching
+	 * element to the front.
+	 */
+	if (likely(key != 0)) {
+		for (unsigned i = 1; i < RTREE_CTX_NCACHE; i++) {
+			if (rtree_ctx->cache[i].key == key) {
+				/* Reorder. */
+				rtree_elm_t *elm = rtree_ctx->cache[i].elm;
+				memmove(&rtree_ctx->cache[1],
+				    &rtree_ctx->cache[0],
+				    sizeof(rtree_ctx_cache_elm_t) * i);
+				rtree_ctx->cache[0].key = key;
+				rtree_ctx->cache[0].elm = elm;
+
+				return elm;
+			}
+		}
+	}
+
+	unsigned start_level = rtree_start_level(rtree, key);
+	rtree_elm_t *node = init_missing ? rtree_subtree_read(tsdn, rtree,
+	    start_level, dependent) : rtree_subtree_tryread(rtree, start_level,
+	    dependent);
+
+#define RTREE_GET_BIAS	(RTREE_HEIGHT_MAX - rtree->height)
+	switch (start_level + RTREE_GET_BIAS) {
+#define RTREE_GET_SUBTREE(level)					\
+	case level: {							\
+		assert(level < (RTREE_HEIGHT_MAX-1));			\
+		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
+			return NULL;					\
+		}							\
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
+		    RTREE_GET_BIAS);					\
+		node = init_missing ? rtree_child_read(tsdn, rtree,	\
+		    &node[subkey], level - RTREE_GET_BIAS, dependent) :	\
+		    rtree_child_tryread(&node[subkey], dependent);	\
+		/* Fall through. */					\
+	}
+#define RTREE_GET_LEAF(level)						\
+	case level: {							\
+		assert(level == (RTREE_HEIGHT_MAX-1));			\
+		if (!dependent && unlikely(!rtree_node_valid(node))) {	\
+			return NULL;					\
+		}							\
+		uintptr_t subkey = rtree_subkey(rtree, key, level -	\
+		    RTREE_GET_BIAS);					\
+		/*							\
+		 * node is a leaf, so it contains values rather than	\
+		 * child pointers.					\
+		 */							\
+		node = &node[subkey];					\
+		if (likely(key != 0)) {					\
+			if (RTREE_CTX_NCACHE > 1) {			\
+				memmove(&rtree_ctx->cache[1],		\
+				    &rtree_ctx->cache[0],		\
+				    sizeof(rtree_ctx_cache_elm_t) *	\
+				    (RTREE_CTX_NCACHE-1));		\
+			}						\
+			rtree_ctx->cache[0].key = key;			\
+			rtree_ctx->cache[0].elm = node;			\
+		}							\
+		return node;						\
+	}
+#if RTREE_HEIGHT_MAX > 1
+	RTREE_GET_SUBTREE(0)
+#endif
+#if RTREE_HEIGHT_MAX > 2
+	RTREE_GET_SUBTREE(1)
+#endif
+#if RTREE_HEIGHT_MAX > 3
+	RTREE_GET_SUBTREE(2)
+#endif
+#if RTREE_HEIGHT_MAX > 4
+	RTREE_GET_SUBTREE(3)
+#endif
+#if RTREE_HEIGHT_MAX > 5
+	RTREE_GET_SUBTREE(4)
+#endif
+#if RTREE_HEIGHT_MAX > 6
+	RTREE_GET_SUBTREE(5)
+#endif
+#if RTREE_HEIGHT_MAX > 7
+	RTREE_GET_SUBTREE(6)
+#endif
+#if RTREE_HEIGHT_MAX > 8
+	RTREE_GET_SUBTREE(7)
+#endif
+#if RTREE_HEIGHT_MAX > 9
+	RTREE_GET_SUBTREE(8)
+#endif
+#if RTREE_HEIGHT_MAX > 10
+	RTREE_GET_SUBTREE(9)
+#endif
+#if RTREE_HEIGHT_MAX > 11
+	RTREE_GET_SUBTREE(10)
+#endif
+#if RTREE_HEIGHT_MAX > 12
+	RTREE_GET_SUBTREE(11)
+#endif
+#if RTREE_HEIGHT_MAX > 13
+	RTREE_GET_SUBTREE(12)
+#endif
+#if RTREE_HEIGHT_MAX > 14
+	RTREE_GET_SUBTREE(13)
+#endif
+#if RTREE_HEIGHT_MAX > 15
+	RTREE_GET_SUBTREE(14)
+#endif
+#if RTREE_HEIGHT_MAX > 16
+#  error Unsupported RTREE_HEIGHT_MAX
+#endif
+	RTREE_GET_LEAF(RTREE_HEIGHT_MAX-1)
+#undef RTREE_GET_SUBTREE
+#undef RTREE_GET_LEAF
+	default: not_reached();
+	}
+#undef RTREE_GET_BIAS
+	not_reached();
+}
+
 static int
 rtree_elm_witness_comp(const witness_t *a, void *oa, const witness_t *b,
     void *ob) {

--- a/src/rtree.c
+++ b/src/rtree.c
@@ -146,16 +146,84 @@ rtree_node_init(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
 	return node;
 }
 
-rtree_elm_t *
-rtree_subtree_read_hard(tsdn_t *tsdn, rtree_t *rtree, unsigned level) {
-	return rtree_node_init(tsdn, rtree, level,
-	    &rtree->levels[level].subtree);
+static unsigned
+rtree_start_level(const rtree_t *rtree, uintptr_t key) {
+	unsigned start_level;
+
+	if (unlikely(key == 0)) {
+		return rtree->height - 1;
+	}
+
+	start_level = rtree->start_level[(lg_floor(key) + 1) >>
+	    LG_RTREE_BITS_PER_LEVEL];
+	assert(start_level < rtree->height);
+	return start_level;
 }
 
-rtree_elm_t *
-rtree_child_read_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm,
-    unsigned level) {
-	return rtree_node_init(tsdn, rtree, level+1, &elm->child);
+static uintptr_t
+rtree_subkey(rtree_t *rtree, uintptr_t key, unsigned level) {
+	return ((key >> ((ZU(1) << (LG_SIZEOF_PTR+3)) -
+	    rtree->levels[level].cumbits)) & ((ZU(1) <<
+	    rtree->levels[level].bits) - 1));
+}
+
+static bool
+rtree_node_valid(rtree_elm_t *node) {
+	return ((uintptr_t)node != (uintptr_t)0);
+}
+
+static rtree_elm_t *
+rtree_child_tryread(rtree_elm_t *elm, bool dependent) {
+	rtree_elm_t *child;
+
+	/* Double-checked read (first read may be stale). */
+	child = elm->child;
+	if (!dependent && !rtree_node_valid(child)) {
+		child = (rtree_elm_t *)atomic_read_p(&elm->pun);
+	}
+	assert(!dependent || child != NULL);
+	return child;
+}
+
+static rtree_elm_t *
+rtree_child_read(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *elm, unsigned level,
+    bool dependent) {
+	rtree_elm_t *child;
+
+	child = rtree_child_tryread(elm, dependent);
+	if (!dependent && unlikely(!rtree_node_valid(child))) {
+		child = rtree_node_init(tsdn, rtree, level+1, &elm->child);
+	}
+	assert(!dependent || child != NULL);
+	return child;
+}
+
+static rtree_elm_t *
+rtree_subtree_tryread(rtree_t *rtree, unsigned level, bool dependent) {
+	rtree_elm_t *subtree;
+
+	/* Double-checked read (first read may be stale). */
+	subtree = rtree->levels[level].subtree;
+	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
+		subtree = (rtree_elm_t *)atomic_read_p(
+		    &rtree->levels[level].subtree_pun);
+	}
+	assert(!dependent || subtree != NULL);
+	return subtree;
+}
+
+static rtree_elm_t *
+rtree_subtree_read(tsdn_t *tsdn, rtree_t *rtree, unsigned level,
+    bool dependent) {
+	rtree_elm_t *subtree;
+
+	subtree = rtree_subtree_tryread(rtree, level, dependent);
+	if (!dependent && unlikely(!rtree_node_valid(subtree))) {
+		subtree = rtree_node_init(tsdn, rtree, level,
+		    &rtree->levels[level].subtree);
+	}
+	assert(!dependent || subtree != NULL);
+	return subtree;
 }
 
 rtree_elm_t *

--- a/test/unit/rtree.c
+++ b/test/unit/rtree.c
@@ -33,31 +33,26 @@ rtree_node_dalloc_intercept(tsdn_t *tsdn, rtree_t *rtree, rtree_elm_t *node) {
 
 TEST_BEGIN(test_rtree_read_empty) {
 	tsdn_t *tsdn;
-	unsigned i;
 
 	tsdn = tsdn_fetch();
 
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
-		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
-		    "rtree_read() should return NULL for empty tree");
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
-	}
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
+	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
+	    "rtree_read() should return NULL for empty tree");
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 #define NTHREADS	8
-#define MAX_NBITS	18
+#define MAX_NBITS	30
 #define NITERS		1000
 #define SEED		42
 
 typedef struct {
-	unsigned	nbits;
 	rtree_t		rtree;
 	uint32_t	seed;
 } thd_start_arg_t;
@@ -77,7 +72,8 @@ thd_start(void *varg) {
 	tsdn = tsdn_fetch();
 
 	for (i = 0; i < NITERS; i++) {
-		uintptr_t key = (uintptr_t)gen_rand64(sfmt);
+		uintptr_t key = (uintptr_t)(gen_rand64(sfmt) & ((ZU(1) <<
+		    MAX_NBITS) - ZU(1)));
 		if (i % 2 == 0) {
 			rtree_elm_t *elm;
 
@@ -110,165 +106,134 @@ TEST_BEGIN(test_rtree_concurrent) {
 	thd_t thds[NTHREADS];
 	sfmt_t *sfmt;
 	tsdn_t *tsdn;
-	unsigned i, j;
 
 	sfmt = init_gen_rand(SEED);
 	tsdn = tsdn_fetch();
-	for (i = 1; i < MAX_NBITS; i++) {
-		arg.nbits = i;
-		test_rtree = &arg.rtree;
-		assert_false(rtree_new(&arg.rtree, arg.nbits),
-		    "Unexpected rtree_new() failure");
-		arg.seed = gen_rand32(sfmt);
-		for (j = 0; j < NTHREADS; j++) {
-			thd_create(&thds[j], thd_start, (void *)&arg);
-		}
-		for (j = 0; j < NTHREADS; j++) {
-			thd_join(thds[j], NULL);
-		}
-		rtree_delete(tsdn, &arg.rtree);
-		test_rtree = NULL;
+	test_rtree = &arg.rtree;
+	assert_false(rtree_new(&arg.rtree), "Unexpected rtree_new() failure");
+	arg.seed = gen_rand32(sfmt);
+	for (unsigned i = 0; i < NTHREADS; i++) {
+		thd_create(&thds[i], thd_start, (void *)&arg);
 	}
+	for (unsigned i = 0; i < NTHREADS; i++) {
+		thd_join(thds[i], NULL);
+	}
+	rtree_delete(tsdn, &arg.rtree);
+	test_rtree = NULL;
 	fini_gen_rand(sfmt);
 }
 TEST_END
 
 #undef NTHREADS
-#undef MAX_NBITS
 #undef NITERS
 #undef SEED
 
 TEST_BEGIN(test_rtree_extrema) {
-	unsigned i;
 	extent_t extent_a, extent_b;
 	tsdn_t *tsdn;
 
 	tsdn = tsdn_fetch();
 
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0,
-		    &extent_a), "Unexpected rtree_write() failure, i=%u", i);
-		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true),
-		    &extent_a,
-		    "rtree_read() should return previously set value, i=%u", i);
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0, &extent_a),
+	    "Unexpected rtree_write() failure");
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true), &extent_a,
+	    "rtree_read() should return previously set value");
 
-		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx,
-		    ~((uintptr_t)0), &extent_b),
-		    "Unexpected rtree_write() failure, i=%u", i);
-		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-		    ~((uintptr_t)0), true), &extent_b,
-		    "rtree_read() should return previously set value, i=%u", i);
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
+	    &extent_b), "Unexpected rtree_write() failure");
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
+	    true), &extent_b,
+	    "rtree_read() should return previously set value");
 
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
-	}
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 TEST_BEGIN(test_rtree_bits) {
-	tsdn_t *tsdn;
-	unsigned i, j, k;
+	tsdn_t *tsdn = tsdn_fetch();
 
-	tsdn = tsdn_fetch();
+	uintptr_t keys[] = {0, 1, (((uintptr_t)1) << LG_PAGE) - 1};
 
-	for (i = 1; i < (sizeof(uintptr_t) << 3); i++) {
-		uintptr_t keys[] = {0, 1,
-		    (((uintptr_t)1) << (sizeof(uintptr_t)*8-i)) - 1};
-		extent_t extent;
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	extent_t extent;
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
 
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree),
+	    "Unexpected rtree_new() failure");
 
-		for (j = 0; j < sizeof(keys)/sizeof(uintptr_t); j++) {
-			assert_false(rtree_write(tsdn, &rtree, &rtree_ctx,
-			    keys[j], &extent),
-			    "Unexpected rtree_write() failure");
-			for (k = 0; k < sizeof(keys)/sizeof(uintptr_t); k++) {
-				assert_ptr_eq(rtree_read(tsdn, &rtree,
-				    &rtree_ctx, keys[k], true), &extent,
-				    "rtree_read() should return previously set "
-				    "value and ignore insignificant key bits; "
-				    "i=%u, j=%u, k=%u, set key=%#"FMTxPTR", "
-				    "get key=%#"FMTxPTR, i, j, k, keys[j],
-				    keys[k]);
-			}
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    (((uintptr_t)1) << (sizeof(uintptr_t)*8-i)), false),
-			    "Only leftmost rtree leaf should be set; "
-			    "i=%u, j=%u", i, j);
-			rtree_clear(tsdn, &rtree, &rtree_ctx, keys[j]);
+	for (unsigned i = 0; i < sizeof(keys)/sizeof(uintptr_t); i++) {
+		assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, keys[i],
+		    &extent), "Unexpected rtree_write() failure");
+		for (unsigned j = 0; j < sizeof(keys)/sizeof(uintptr_t); j++) {
+			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
+			    keys[j], true), &extent,
+			    "rtree_read() should return previously set "
+			    "value and ignore insignificant key bits; "
+			    "i=%u, j=%u, set key=%#"FMTxPTR", get "
+			    "key=%#"FMTxPTR, i, j, keys[i], keys[j]);
 		}
-
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
+		    (((uintptr_t)1) << LG_PAGE), false),
+		    "Only leftmost rtree leaf should be set; i=%u", i);
+		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
 	}
+
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 }
 TEST_END
 
 TEST_BEGIN(test_rtree_random) {
-	unsigned i;
-	sfmt_t *sfmt;
-	tsdn_t *tsdn;
 #define NSET 16
 #define SEED 42
+	sfmt_t *sfmt = init_gen_rand(SEED);
+	tsdn_t *tsdn = tsdn_fetch();
+	uintptr_t keys[NSET];
+	extent_t extent;
+	rtree_t rtree;
+	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
+	rtree_elm_t *elm;
 
-	sfmt = init_gen_rand(SEED);
-	tsdn = tsdn_fetch();
-	for (i = 1; i <= (sizeof(uintptr_t) << 3); i++) {
-		uintptr_t keys[NSET];
-		extent_t extent;
-		unsigned j;
-		rtree_t rtree;
-		rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
-		rtree_elm_t *elm;
+	test_rtree = &rtree;
+	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-		test_rtree = &rtree;
-		assert_false(rtree_new(&rtree, i),
-		    "Unexpected rtree_new() failure");
-
-		for (j = 0; j < NSET; j++) {
-			keys[j] = (uintptr_t)gen_rand64(sfmt);
-			elm = rtree_elm_acquire(tsdn, &rtree, &rtree_ctx,
-			    keys[j], false, true);
-			assert_ptr_not_null(elm,
-			    "Unexpected rtree_elm_acquire() failure");
-			rtree_elm_write_acquired(tsdn, &rtree, elm, &extent);
-			rtree_elm_release(tsdn, &rtree, elm);
-			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true), &extent,
-			    "rtree_read() should return previously set value");
-		}
-		for (j = 0; j < NSET; j++) {
-			assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true), &extent,
-			    "rtree_read() should return previously set value, "
-			    "j=%u", j);
-		}
-
-		for (j = 0; j < NSET; j++) {
-			rtree_clear(tsdn, &rtree, &rtree_ctx, keys[j]);
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true),
-			    "rtree_read() should return previously set value");
-		}
-		for (j = 0; j < NSET; j++) {
-			assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-			    keys[j], true),
-			    "rtree_read() should return previously set value");
-		}
-
-		rtree_delete(tsdn, &rtree);
-		test_rtree = NULL;
+	for (unsigned i = 0; i < NSET; i++) {
+		keys[i] = (uintptr_t)gen_rand64(sfmt);
+		elm = rtree_elm_acquire(tsdn, &rtree, &rtree_ctx, keys[i],
+		    false, true);
+		assert_ptr_not_null(elm,
+		    "Unexpected rtree_elm_acquire() failure");
+		rtree_elm_write_acquired(tsdn, &rtree, elm, &extent);
+		rtree_elm_release(tsdn, &rtree, elm);
+		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), &extent,
+		    "rtree_read() should return previously set value");
 	}
+	for (unsigned i = 0; i < NSET; i++) {
+		assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), &extent,
+		    "rtree_read() should return previously set value, i=%u", i);
+	}
+
+	for (unsigned i = 0; i < NSET; i++) {
+		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), "rtree_read() should return previously set value");
+	}
+	for (unsigned i = 0; i < NSET; i++) {
+		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, keys[i],
+		    true), "rtree_read() should return previously set value");
+	}
+
+	rtree_delete(tsdn, &rtree);
+	test_rtree = NULL;
 	fini_gen_rand(sfmt);
 #undef NSET
 #undef SEED

--- a/test/unit/rtree.c
+++ b/test/unit/rtree.c
@@ -40,7 +40,7 @@ TEST_BEGIN(test_rtree_read_empty) {
 	rtree_ctx_t rtree_ctx = RTREE_CTX_INITIALIZER;
 	test_rtree = &rtree;
 	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
-	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, 0, false),
+	assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx, PAGE, false),
 	    "rtree_read() should return NULL for empty tree");
 	rtree_delete(tsdn, &rtree);
 	test_rtree = NULL;
@@ -139,9 +139,10 @@ TEST_BEGIN(test_rtree_extrema) {
 	test_rtree = &rtree;
 	assert_false(rtree_new(&rtree), "Unexpected rtree_new() failure");
 
-	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, 0, &extent_a),
+	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, PAGE, &extent_a),
 	    "Unexpected rtree_write() failure");
-	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, 0, true), &extent_a,
+	assert_ptr_eq(rtree_read(tsdn, &rtree, &rtree_ctx, PAGE, true),
+	    &extent_a,
 	    "rtree_read() should return previously set value");
 
 	assert_false(rtree_write(tsdn, &rtree, &rtree_ctx, ~((uintptr_t)0),
@@ -158,7 +159,8 @@ TEST_END
 TEST_BEGIN(test_rtree_bits) {
 	tsdn_t *tsdn = tsdn_fetch();
 
-	uintptr_t keys[] = {0, 1, (((uintptr_t)1) << LG_PAGE) - 1};
+	uintptr_t keys[] = {PAGE, PAGE + 1,
+	    PAGE + (((uintptr_t)1) << LG_PAGE) - 1};
 
 	extent_t extent;
 	rtree_t rtree;
@@ -180,7 +182,7 @@ TEST_BEGIN(test_rtree_bits) {
 			    "key=%#"FMTxPTR, i, j, keys[i], keys[j]);
 		}
 		assert_ptr_null(rtree_read(tsdn, &rtree, &rtree_ctx,
-		    (((uintptr_t)1) << LG_PAGE), false),
+		    (((uintptr_t)2) << LG_PAGE), false),
 		    "Only leftmost rtree leaf should be set; i=%u", i);
 		rtree_clear(tsdn, &rtree, &rtree_ctx, keys[i]);
 	}


### PR DESCRIPTION
[This is based on #602, hence the duplicate changesets.]

These changes simplify rtree lookup by removing the dynamic shortcut for leading zeros, and by determining the number of bits in each level at compile time rather than run time.  On x64 the rtree changes from {[16], 16, 16, 4} (four levels, but the first one was skipped) to {18, 18}.

This wraps up everything I had in mind re: #465.