### PR TITLE
Conditianalize lg_tcache_max use on JEMALLOC_TCACHE.

### DIFF
--- a/test/unit/decay.c
+++ b/test/unit/decay.c
@@ -1,6 +1,10 @@
 #include "test/jemalloc_test.h"
 
-const char *malloc_conf = "decay_time:1,lg_tcache_max:0";
+const char *malloc_conf = "decay_time:1"
+#ifdef JEMALLOC_TCACHE
+    ",lg_tcache_max:0"
+#endif
+    ;
 
 static nstime_monotonic_t *nstime_monotonic_orig;
 static nstime_update_t *nstime_update_orig;


### PR DESCRIPTION
This avoids a run-time warning I noticed while looking through CI logs.