### PR TITLE
Fix rtree_subkey() regression.

### DIFF
--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -40,7 +40,7 @@ rtree_subkey(uintptr_t key, unsigned level) {
 	unsigned cumbits = rtree_levels[level].cumbits;
 	unsigned shiftbits = ptrbits - cumbits;
 	unsigned maskbits = rtree_levels[level].bits;
-	unsigned mask = (ZU(1) << maskbits) - 1;
+	uintptr_t mask = (ZU(1) << maskbits) - 1;
 	return ((key >> shiftbits) & mask);
 }
 


### PR DESCRIPTION
Fix rtree_subkey() to use uintptr_t rather than unsigned for key
bitmasking.  This regression was introduced by
4a346f55939af4f200121cc4454089592d952f18 (Replace rtree path cache with
LRU cache.).