### PR TITLE
Do not generate unused tsd_*_[gs]et() functions.

### DIFF
--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -485,8 +485,6 @@ ticker_ticks
 tsd_arena_get
 tsd_arena_set
 tsd_arenap_get
-tsd_arenas_tdata_bypass_get
-tsd_arenas_tdata_bypass_set
 tsd_arenas_tdata_bypassp_get
 tsd_arenas_tdata_get
 tsd_arenas_tdata_set
@@ -518,11 +516,7 @@ tsd_nominal
 tsd_prof_tdata_get
 tsd_prof_tdata_set
 tsd_prof_tdatap_get
-tsd_rtree_ctx_get
-tsd_rtree_ctx_set
 tsd_rtree_ctxp_get
-tsd_rtree_elm_witnesses_get
-tsd_rtree_elm_witnesses_set
 tsd_rtree_elm_witnessesp_get
 tsd_set
 tsd_tcache_enabled_get
@@ -543,8 +537,6 @@ tsd_tsdn
 tsd_witness_fork_get
 tsd_witness_fork_set
 tsd_witness_forkp_get
-tsd_witnesses_get
-tsd_witnesses_set
 tsd_witnessesp_get
 tsdn_fetch
 tsdn_null

--- a/include/jemalloc/internal/tsd_inlines.h
+++ b/include/jemalloc/internal/tsd_inlines.h
@@ -8,7 +8,7 @@ tsd_t	*tsd_fetch_impl(bool init);
 tsd_t	*tsd_fetch(void);
 tsdn_t	*tsd_tsdn(tsd_t *tsd);
 bool	tsd_nominal(tsd_t *tsd);
-#define O(n, t, c)							\
+#define O(n, t, gs, c)							\
 t	*tsd_##n##p_get(tsd_t *tsd);					\
 t	tsd_##n##_get(tsd_t *tsd);					\
 void	tsd_##n##_set(tsd_t *tsd, t n);
@@ -64,23 +64,27 @@ tsd_nominal(tsd_t *tsd) {
 	return (tsd->state == tsd_state_nominal);
 }
 
-#define O(n, t, c)							\
-JEMALLOC_ALWAYS_INLINE t *						\
-tsd_##n##p_get(tsd_t *tsd) {						\
-	return &tsd->n;							\
-}									\
-									\
+#define MALLOC_TSD_getset_yes(n, t)					\
 JEMALLOC_ALWAYS_INLINE t						\
 tsd_##n##_get(tsd_t *tsd) {						\
 	return *tsd_##n##p_get(tsd);					\
 }									\
-									\
 JEMALLOC_ALWAYS_INLINE void						\
 tsd_##n##_set(tsd_t *tsd, t n) {					\
 	assert(tsd->state == tsd_state_nominal);			\
 	tsd->n = n;							\
 }
+#define MALLOC_TSD_getset_no(n, t)
+#define O(n, t, gs, c)							\
+JEMALLOC_ALWAYS_INLINE t *						\
+tsd_##n##p_get(tsd_t *tsd) {						\
+	return &tsd->n;							\
+}									\
+									\
+MALLOC_TSD_getset_##gs(n, t)
 MALLOC_TSD
+#undef MALLOC_TSD_getset_yes
+#undef MALLOC_TSD_getset_no
 #undef O
 
 JEMALLOC_ALWAYS_INLINE tsdn_t *

--- a/include/jemalloc/internal/tsd_structs.h
+++ b/include/jemalloc/internal/tsd_structs.h
@@ -15,21 +15,23 @@ struct tsd_init_head_s {
 #endif
 
 #define MALLOC_TSD							\
-/*  O(name,			type,			cleanup) */	\
-    O(tcache,			tcache_t *,		yes)		\
-    O(thread_allocated,		uint64_t,		no)		\
-    O(thread_deallocated,	uint64_t,		no)		\
-    O(prof_tdata,		prof_tdata_t *,		yes)		\
-    O(iarena,			arena_t *,		yes)		\
-    O(arena,			arena_t *,		yes)		\
-    O(arenas_tdata,		arena_tdata_t *,	yes)		\
-    O(narenas_tdata,		unsigned,		no)		\
-    O(arenas_tdata_bypass,	bool,			no)		\
-    O(tcache_enabled,		tcache_enabled_t,	no)		\
-    O(rtree_ctx,		rtree_ctx_t,		no)		\
-    O(witnesses,		witness_list_t,		yes)		\
-    O(rtree_elm_witnesses,	rtree_elm_witness_tsd_t,no)		\
-    O(witness_fork,		bool,			no)		\
+/*  O(name,			type,		[gs]et,	cleanup) */	\
+    O(tcache,			tcache_t *,	yes,	yes)		\
+    O(thread_allocated,		uint64_t,	yes,	no)		\
+    O(thread_deallocated,	uint64_t,	yes,	no)		\
+    O(prof_tdata,		prof_tdata_t *,	yes,	yes)		\
+    O(iarena,			arena_t *,	yes,	yes)		\
+    O(arena,			arena_t *,	yes,	yes)		\
+    O(arenas_tdata,		arena_tdata_t *,yes,	yes)		\
+    O(narenas_tdata,		unsigned,	yes,	no)		\
+    O(arenas_tdata_bypass,	bool,		no,	no)		\
+    O(tcache_enabled,		tcache_enabled_t,			\
+						yes,	no)		\
+    O(rtree_ctx,		rtree_ctx_t,	no,	no)		\
+    O(witnesses,		witness_list_t,	no,	yes)		\
+    O(rtree_elm_witnesses,	rtree_elm_witness_tsd_t,		\
+						no,	no)		\
+    O(witness_fork,		bool,		yes,	no)		\
 
 #define TSD_INITIALIZER {						\
     tsd_state_uninitialized,						\
@@ -51,7 +53,7 @@ struct tsd_init_head_s {
 
 struct tsd_s {
 	tsd_state_t	state;
-#define O(n, t, c)							\
+#define O(n, t, gs, c)							\
 	t		n;
 MALLOC_TSD
 #undef O

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -72,7 +72,7 @@ tsd_cleanup(void *arg) {
 #define MALLOC_TSD_cleanup_yes(n, t)					\
 		n##_cleanup(tsd);
 #define MALLOC_TSD_cleanup_no(n, t)
-#define O(n, t, c)							\
+#define O(n, t, gs, c)							\
 		MALLOC_TSD_cleanup_##c(n, t)
 MALLOC_TSD
 #undef MALLOC_TSD_cleanup_yes


### PR DESCRIPTION
This avoids a gcc diagnostic note:
    note: The ABI for passing parameters with 64-byte alignment has
    changed in GCC 4.6
This note related to the cacheline alignment of rtree_ctx_t, which was
introduced by 4a346f55939af4f200121cc4454089592d952f18 (Replace rtree
path cache with LRU cache.).