### PR TITLE
Coalesce less

### DIFF
--- a/include/jemalloc/internal/extent_externs.h
+++ b/include/jemalloc/internal/extent_externs.h
@@ -21,7 +21,8 @@ size_t	extent_size_quantize_ceil(size_t size);
 
 ph_proto(, extent_heap_, extent_heap_t, extent_t)
 
-bool extents_init(tsdn_t *tsdn, extents_t *extents, extent_state_t state);
+bool extents_init(tsdn_t *tsdn, extents_t *extents, extent_state_t state,
+    bool try_coalesce);
 extent_state_t extents_state_get(const extents_t *extents);
 size_t extents_npages_get(extents_t *extents);
 extent_t *extents_evict(tsdn_t *tsdn, extents_t *extents, size_t npages_min);

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -115,6 +115,9 @@ struct extents_s {
 
 	/* All stored extents must be in the same state. */
 	extent_state_t		state;
+
+	/* If true, try to coalesce during extent deallocation. */
+	bool			try_coalesce;
 };
 
 #endif /* JEMALLOC_INTERNAL_EXTENT_STRUCTS_H */

--- a/src/arena.c
+++ b/src/arena.c
@@ -1718,11 +1718,12 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		goto label_error;
 	}
 
-	if (extents_init(tsdn, &arena->extents_cached, extent_state_dirty)) {
+	if (extents_init(tsdn, &arena->extents_cached, extent_state_dirty,
+	    false)) {
 		goto label_error;
 	}
 	if (extents_init(tsdn, &arena->extents_retained,
-	    extent_state_retained)) {
+	    extent_state_retained, true)) {
 		goto label_error;
 	}
 


### PR DESCRIPTION
Ignore diffs that are part of #623 and #624; 177dfda080d1a1bc7bcac1d3bda937ec6503e451 (Optimize extent coalescing.) and d75d00b29615063dac3f103790b53ebe5966387f (Disable coalescing of cached extents.) are the only ones relevant here.