### PR TITLE
Remove remainder of mb (memory barrier).

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,7 +100,6 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/extent_mmap.c \
 	$(srcroot)src/hash.c \
 	$(srcroot)src/large.c \
-	$(srcroot)src/mb.c \
 	$(srcroot)src/mutex.c \
 	$(srcroot)src/nstime.c \
 	$(srcroot)src/pages.c \

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -296,7 +296,6 @@ malloc_tsd_no_cleanup
 malloc_vcprintf
 malloc_vsnprintf
 malloc_write
-mb_write
 narenas_auto
 narenas_total_get
 ncpus

--- a/src/mb.c
+++ b/src/mb.c
@@ -1,2 +1,0 @@
-#define JEMALLOC_MB_C_
-#include "jemalloc/internal/jemalloc_internal.h"


### PR DESCRIPTION
This complements 94c5d22a4da7844d0bdc5b370e47b1ba14268af2 (Remove mb.h,
which is unused).