### PR TITLE
Use MALLOC_CONF rather than malloc_conf for tests.

### DIFF
--- a/test/integration/extent.c
+++ b/test/integration/extent.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf = "junk:false";
-#endif
-
 #include "test/extent_hooks.h"
 
 static void

--- a/test/integration/extent.sh
+++ b/test/integration/extent.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="junk:false"
+fi

--- a/test/integration/mallocx.c
+++ b/test/integration/mallocx.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf = "junk:false";
-#endif
-
 static unsigned
 get_nsizes_impl(const char *cmd) {
 	unsigned ret;

--- a/test/integration/mallocx.sh
+++ b/test/integration/mallocx.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="junk:false"
+fi

--- a/test/integration/xallocx.c
+++ b/test/integration/xallocx.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf = "junk:false";
-#endif
-
 /*
  * Use a separate arena for xallocx() extension/contraction tests so that
  * internal allocation e.g. by heap profiling can't interpose allocations where

--- a/test/integration/xallocx.sh
+++ b/test/integration/xallocx.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="junk:false"
+fi

--- a/test/test.sh.in
+++ b/test/test.sh.in
@@ -11,6 +11,18 @@ case @abi@ in
     ;;
 esac
 
+# Make a copy of the @JEMALLOC_CPREFIX@MALLOC_CONF passed in to this script, so
+# it can be repeatedly concatenated with per test settings.
+export MALLOC_CONF_ALL=${@JEMALLOC_CPREFIX@MALLOC_CONF}
+# Concatenate the individual test's MALLOC_CONF and MALLOC_CONF_ALL.
+export_malloc_conf() {
+  if [ "x${MALLOC_CONF}" != "x" -a "x${MALLOC_CONF_ALL}" != "x" ] ; then
+    export @JEMALLOC_CPREFIX@MALLOC_CONF="${MALLOC_CONF},${MALLOC_CONF_ALL}"
+  else
+    export @JEMALLOC_CPREFIX@MALLOC_CONF="${MALLOC_CONF}${MALLOC_CONF_ALL}"
+  fi
+}
+
 # Corresponds to test_status_t.
 pass_code=0
 skip_code=1
@@ -24,7 +36,22 @@ for t in $@; do
     echo
   fi
   echo "=== ${t} ==="
-  ${t}@exe@ @abs_srcroot@ @abs_objroot@
+  if [ -e "@srcroot@${t}.sh" ] ; then
+    # Source the shell script corresponding to the test in a subshell and
+    # execute the test.  This allows the shell script to set MALLOC_CONF, which
+    # is then used to set @JEMALLOC_CPREFIX@MALLOC_CONF (thus allowing the
+    # per test shell script to ignore the @JEMALLOC_CPREFIX@ detail).
+    $(enable_fill=@enable_fill@ \
+      enable_prof=@enable_prof@ \
+      enable_tcache=@enable_tcache@ \
+      . @srcroot@${t}.sh && \
+      export_malloc_conf && \
+      ${t}@exe@ @abs_srcroot@ @abs_objroot@)
+  else
+    $(export MALLOC_CONF= && \
+      export_malloc_conf &&
+      ${t}@exe@ @abs_srcroot@ @abs_objroot@)
+  fi
   result_code=$?
   case ${result_code} in
     ${pass_code})

--- a/test/unit/arena_reset_prof.c
+++ b/test/unit/arena_reset_prof.c
@@ -1,5 +1,4 @@
 #include "test/jemalloc_test.h"
 #define ARENA_RESET_PROF_C_
 
-const char *malloc_conf = "prof:true,lg_prof_sample:0";
 #include "arena_reset.c"

--- a/test/unit/arena_reset_prof.sh
+++ b/test/unit/arena_reset_prof.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="prof:true,lg_prof_sample:0"

--- a/test/unit/decay.c
+++ b/test/unit/decay.c
@@ -1,11 +1,5 @@
 #include "test/jemalloc_test.h"
 
-const char *malloc_conf = "decay_time:1"
-#ifdef JEMALLOC_TCACHE
-    ",lg_tcache_max:0"
-#endif
-    ;
-
 static nstime_monotonic_t *nstime_monotonic_orig;
 static nstime_update_t *nstime_update_orig;
 

--- a/test/unit/decay.sh
+++ b/test/unit/decay.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export MALLOC_CONF="decay_time:1"
+if [ "x${enable_tcache}" = "x1" ] ; then
+  export MALLOC_CONF="${MALLOC_CONF},lg_tcache_max:0"
+fi

--- a/test/unit/junk.c
+++ b/test/unit/junk.c
@@ -1,13 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-#  ifndef JEMALLOC_TEST_JUNK_OPT
-#    define JEMALLOC_TEST_JUNK_OPT "junk:true"
-#  endif
-const char *malloc_conf =
-    "abort:false,zero:false," JEMALLOC_TEST_JUNK_OPT;
-#endif
-
 static arena_dalloc_junk_small_t *arena_dalloc_junk_small_orig;
 static large_dalloc_junk_t *large_dalloc_junk_orig;
 static large_dalloc_maybe_junk_t *large_dalloc_maybe_junk_orig;

--- a/test/unit/junk.sh
+++ b/test/unit/junk.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="abort:false,zero:false,junk:true"
+fi

--- a/test/unit/junk_alloc.c
+++ b/test/unit/junk_alloc.c
@@ -1,3 +1,1 @@
-#define JEMALLOC_TEST_JUNK_OPT "junk:alloc"
 #include "junk.c"
-#undef JEMALLOC_TEST_JUNK_OPT

--- a/test/unit/junk_alloc.sh
+++ b/test/unit/junk_alloc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="abort:false,zero:false,junk:alloc"
+fi

--- a/test/unit/junk_free.c
+++ b/test/unit/junk_free.c
@@ -1,3 +1,1 @@
-#define JEMALLOC_TEST_JUNK_OPT "junk:free"
 #include "junk.c"
-#undef JEMALLOC_TEST_JUNK_OPT

--- a/test/unit/junk_free.sh
+++ b/test/unit/junk_free.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="abort:false,zero:false,junk:free"
+fi

--- a/test/unit/pack.c
+++ b/test/unit/pack.c
@@ -1,8 +1,5 @@
 #include "test/jemalloc_test.h"
 
-/* Immediately purge to minimize fragmentation. */
-const char *malloc_conf = "decay_time:-1";
-
 /*
  * Size class that is a divisor of the page size, ideally 4+ regions per run.
  */

--- a/test/unit/pack.sh
+++ b/test/unit/pack.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Immediately purge to minimize fragmentation.
+export MALLOC_CONF="decay_time:-1"

--- a/test/unit/prof_accum.c
+++ b/test/unit/prof_accum.c
@@ -5,11 +5,6 @@
 #define DUMP_INTERVAL		1
 #define BT_COUNT_CHECK_INTERVAL	5
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf =
-    "prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0";
-#endif
-
 static int
 prof_dump_open_intercept(bool propagate_err, const char *filename) {
 	int fd;

--- a/test/unit/prof_accum.sh
+++ b/test/unit/prof_accum.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0"
+fi

--- a/test/unit/prof_active.c
+++ b/test/unit/prof_active.c
@@ -1,10 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf =
-    "prof:true,prof_thread_active_init:false,lg_prof_sample:0";
-#endif
-
 static void
 mallctl_bool_get(const char *name, bool expected, const char *func, int line) {
 	bool old;

--- a/test/unit/prof_active.sh
+++ b/test/unit/prof_active.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_thread_active_init:false,lg_prof_sample:0"
+fi

--- a/test/unit/prof_gdump.c
+++ b/test/unit/prof_gdump.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf = "prof:true,prof_active:false,prof_gdump:true";
-#endif
-
 static bool did_prof_dump_open;
 
 static int

--- a/test/unit/prof_gdump.sh
+++ b/test/unit/prof_gdump.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_active:false,prof_gdump:true"
+fi
+

--- a/test/unit/prof_idump.c
+++ b/test/unit/prof_idump.c
@@ -1,18 +1,5 @@
 #include "test/jemalloc_test.h"
 
-const char *malloc_conf = ""
-#ifdef JEMALLOC_PROF
-    "prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0"
-    ",lg_prof_interval:0"
-#  ifdef JEMALLOC_TCACHE
-    ","
-#  endif
-#endif
-#ifdef JEMALLOC_TCACHE
-    "tcache:false"
-#endif
-    ;
-
 static bool did_prof_dump_open;
 
 static int

--- a/test/unit/prof_idump.sh
+++ b/test/unit/prof_idump.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0,lg_prof_interval:0"
+  if [ "x${enable_tcache}" = "x1" ] ; then
+    export MALLOC_CONF="${MALLOC_CONF},tcache:false"
+  fi
+elif [ "x${enable_tcache}" = "x1" ] ; then
+  export MALLOC_CONF="tcache:false"
+fi
+
+

--- a/test/unit/prof_reset.c
+++ b/test/unit/prof_reset.c
@@ -1,10 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf =
-    "prof:true,prof_active:false,lg_prof_sample:0";
-#endif
-
 static int
 prof_dump_open_intercept(bool propagate_err, const char *filename) {
 	int fd;

--- a/test/unit/prof_reset.sh
+++ b/test/unit/prof_reset.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_active:false,lg_prof_sample:0"
+fi

--- a/test/unit/prof_tctx.c
+++ b/test/unit/prof_tctx.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf = "prof:true,lg_prof_sample:0";
-#endif
-
 TEST_BEGIN(test_prof_realloc) {
 	tsdn_t *tsdn;
 	int flags;

--- a/test/unit/prof_tctx.sh
+++ b/test/unit/prof_tctx.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+fi

--- a/test/unit/prof_thread_name.c
+++ b/test/unit/prof_thread_name.c
@@ -1,9 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_PROF
-const char *malloc_conf = "prof:true,prof_active:false";
-#endif
-
 static void
 mallctl_thread_name_get_impl(const char *thread_name_expected, const char *func,
     int line) {

--- a/test/unit/prof_thread_name.sh
+++ b/test/unit/prof_thread_name.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_active:false"
+fi

--- a/test/unit/zero.c
+++ b/test/unit/zero.c
@@ -1,10 +1,5 @@
 #include "test/jemalloc_test.h"
 
-#ifdef JEMALLOC_FILL
-const char *malloc_conf =
-    "abort:false,junk:false,zero:true";
-#endif
-
 static void
 test_zero(size_t sz_min, size_t sz_max) {
 	uint8_t *s;

--- a/test/unit/zero.sh
+++ b/test/unit/zero.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_fill}" = "x1" ] ; then
+  export MALLOC_CONF="abort:false,junk:false,zero:true"
+fi


### PR DESCRIPTION
This is the nature of the fix for the remaining failures in #632, but for the dev branch rather than rc-4.5.0.  I'll update #632 with a similar fix.