### PR TITLE
Check nstime_monotonic (compile time const) first in nstime_update.

### DIFF
--- a/src/nstime.c
+++ b/src/nstime.c
@@ -141,8 +141,12 @@ nstime_monotonic_t *nstime_monotonic = JEMALLOC_N(n_nstime_monotonic);
 #endif
 bool
 nstime_update(nstime_t *time) {
-	nstime_t old_time;
+	if (nstime_monotonic()) {
+		nstime_get(time);
+		return false;
+	}
 
+	nstime_t old_time;
 	nstime_copy(&old_time, time);
 	nstime_get(time);
 


### PR DESCRIPTION
Avoids calling nstime_compare in nstime_update.