### PR TITLE
Put -D_REENTRANT in CPPFLAGS rather than CFLAGS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1503,7 +1503,7 @@ if test "x$abi" != "xpecoff" ; then
   fi
 fi
 
-JE_APPEND_VS(CFLAGS, -D_REENTRANT)
+JE_APPEND_VS(CPPFLAGS, -D_REENTRANT)
 
 dnl Check whether clock_gettime(2) is in libc or librt.
 AC_SEARCH_LIBS([clock_gettime], [rt])


### PR DESCRIPTION
This regression was introduced by
194d6f9de8ff92841b67f38a2a6a06818e3240dd (Restructure *CFLAGS/*CXXFLAGS
configuration.).