### PR TITLE
Dodge 32-bit-clang-specific backtracing failure.

### DIFF
--- a/scripts/gen_run_tests.py
+++ b/scripts/gen_run_tests.py
@@ -28,6 +28,10 @@ print 'unamestr=`uname`'
 for cc, cxx in possible_compilers:
     for compiler_opts in powerset(possible_compiler_opts):
         for config_opts in powerset(possible_config_opts):
+            if cc is 'clang' \
+              and '-m32' in possible_compiler_opts \
+              and '--enable-prof' in config_opts:
+                continue
             config_line = (
                 './configure '
                 + 'CC="{} {}" '.format(cc, " ".join(compiler_opts))


### PR DESCRIPTION
This disables run_tests.sh configurations that use the combination of
32-bit clang and heap profiling.