### PR TITLE
Optimize malloc_large_stats_t maintenance.

### DIFF
--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -64,10 +64,10 @@ struct malloc_large_stats_s {
 	 * This includes requests served by tcache, though tcache only
 	 * periodically merges into this counter.
 	 */
-	uint64_t	nrequests;
+	uint64_t	nrequests; /* Partially derived. */
 
 	/* Current number of allocations of this size class. */
-	size_t		curlextents;
+	size_t		curlextents; /* Derived. */
 };
 
 /*


### PR DESCRIPTION
Convert the nrequests field to be partially derived, and the curlextents
to be fully derived, in order to reduce the number of stats updates
needed during common operations.

This change affects ndalloc stats during arena reset, because it is no
longer possible to cancel out ndalloc effects (curlextents would become
negative).