### PR TITLE
Any

### DIFF
--- a/include/jemalloc/internal/extent_externs.h
+++ b/include/jemalloc/internal/extent_externs.h
@@ -18,10 +18,11 @@ size_t	extent_size_quantize_ceil(size_t size);
 ph_proto(, extent_heap_, extent_heap_t, extent_t)
 
 bool extents_init(tsdn_t *tsdn, extents_t *extents, extent_state_t state,
-    bool try_coalesce);
+    bool delay_coalesce);
 extent_state_t extents_state_get(const extents_t *extents);
 size_t extents_npages_get(extents_t *extents);
-extent_t *extents_evict(tsdn_t *tsdn, extents_t *extents, size_t npages_min);
+extent_t *extents_evict(tsdn_t *tsdn, arena_t *arena,
+    extent_hooks_t **r_extent_hooks, extents_t *extents, size_t npages_min);
 void extents_prefork(tsdn_t *tsdn, extents_t *extents);
 void extents_postfork_parent(tsdn_t *tsdn, extents_t *extents);
 void extents_postfork_child(tsdn_t *tsdn, extents_t *extents);

--- a/include/jemalloc/internal/extent_inlines.h
+++ b/include/jemalloc/internal/extent_inlines.h
@@ -37,6 +37,8 @@ void extent_list_init(extent_list_t *list);
 extent_t *extent_list_first(const extent_list_t *list);
 extent_t *extent_list_last(const extent_list_t *list);
 void extent_list_append(extent_list_t *list, extent_t *extent);
+void extent_list_replace(extent_list_t *list, extent_t *to_remove,
+    extent_t *to_insert);
 void extent_list_remove(extent_list_t *list, extent_t *extent);
 int	extent_sn_comp(const extent_t *a, const extent_t *b);
 int	extent_ad_comp(const extent_t *a, const extent_t *b);
@@ -251,6 +253,13 @@ extent_list_last(const extent_list_t *list) {
 JEMALLOC_INLINE void
 extent_list_append(extent_list_t *list, extent_t *extent) {
 	ql_tail_insert(list, extent, ql_link);
+}
+
+JEMALLOC_INLINE void
+extent_list_replace(extent_list_t *list, extent_t *to_remove,
+    extent_t *to_insert) {
+	ql_after_insert(to_remove, to_insert, ql_link);
+	ql_remove(list, to_remove, ql_link);
 }
 
 JEMALLOC_INLINE void

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -116,8 +116,11 @@ struct extents_s {
 	/* All stored extents must be in the same state. */
 	extent_state_t		state;
 
-	/* If true, try to coalesce during extent deallocation. */
-	bool			try_coalesce;
+	/*
+	 * If true, delay coalescing until eviction; otherwise coalesce during
+	 * deallocation.
+	 */
+	bool			delay_coalesce;
 };
 
 #endif /* JEMALLOC_INTERNAL_EXTENT_STRUCTS_H */

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -159,8 +159,10 @@ extent_init
 extent_last_get
 extent_list_append
 extent_list_first
+extent_list_init
 extent_list_last
 extent_list_remove
+extent_list_replace
 extent_lookup
 extent_merge_wrapper
 extent_past_get

--- a/test/unit/decay.c
+++ b/test/unit/decay.c
@@ -21,6 +21,106 @@ nstime_update_mock(nstime_t *time) {
 	return !monotonic_mock;
 }
 
+static unsigned
+do_arena_create(ssize_t decay_time) {
+	unsigned arena_ind;
+	size_t sz = sizeof(unsigned);
+	assert_d_eq(mallctl("arenas.create", (void *)&arena_ind, &sz, NULL, 0),
+	    0, "Unexpected mallctl() failure");
+	size_t mib[3];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("arena.0.decay_time", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[1] = (size_t)arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, (void *)&decay_time,
+	    sizeof(decay_time)), 0, "Unexpected mallctlbymib() failure");
+	return arena_ind;
+}
+
+static void
+do_arena_destroy(unsigned arena_ind) {
+	size_t mib[3];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("arena.0.destroy", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[1] = (size_t)arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
+	    "Unexpected mallctlbymib() failure");
+}
+
+void
+do_epoch(void) {
+	uint64_t epoch = 1;
+	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sizeof(epoch)),
+	    0, "Unexpected mallctl() failure");
+}
+
+void
+do_purge(unsigned arena_ind) {
+	size_t mib[3];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("arena.0.purge", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[1] = (size_t)arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
+	    "Unexpected mallctlbymib() failure");
+}
+
+void
+do_decay(unsigned arena_ind) {
+	size_t mib[3];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("arena.0.decay", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[1] = (size_t)arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
+	    "Unexpected mallctlbymib() failure");
+}
+
+static uint64_t
+get_arena_npurge(unsigned arena_ind) {
+	do_epoch();
+	size_t mib[4];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("stats.arenas.0.npurge", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[2] = (size_t)arena_ind;
+	uint64_t npurge = 0;
+	size_t sz = sizeof(npurge);
+	assert_d_eq(mallctlbymib(mib, miblen, (void *)&npurge, &sz, NULL, 0),
+	    config_stats ? 0 : ENOENT, "Unexpected mallctlbymib() failure");
+	return npurge;
+}
+
+static size_t
+get_arena_pdirty(unsigned arena_ind) {
+	do_epoch();
+	size_t mib[4];
+	size_t miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("stats.arenas.0.pdirty", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[2] = (size_t)arena_ind;
+	size_t pdirty;
+	size_t sz = sizeof(pdirty);
+	assert_d_eq(mallctlbymib(mib, miblen, (void *)&pdirty, &sz, NULL, 0), 0,
+	    "Unexpected mallctlbymib() failure");
+	return pdirty;
+}
+
+static void *
+do_mallocx(size_t size, int flags) {
+	void *p = mallocx(size, flags);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+	return p;
+}
+
+static void
+generate_dirty(unsigned arena_ind, size_t size) {
+	int flags = MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE;
+	void *p = do_mallocx(size, flags);
+	dallocx(p, flags);
+}
+
 TEST_BEGIN(test_decay_ticks) {
 	ticker_t *decay_ticker;
 	unsigned tick0, tick1;
@@ -195,45 +295,37 @@ TEST_END
 
 TEST_BEGIN(test_decay_ticker) {
 #define NPS 1024
-	int flags = (MALLOCX_ARENA(0) | MALLOCX_TCACHE_NONE);
+#define NINTERVALS 101
+	ssize_t dt = opt_decay_time;
+	unsigned arena_ind = do_arena_create(dt);
+	int flags = (MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE);
 	void *ps[NPS];
-	uint64_t epoch;
-	uint64_t npurge0 = 0;
-	uint64_t npurge1 = 0;
-	size_t sz, large;
-	unsigned i, nupdates0;
-	nstime_t time, decay_time, deadline;
+	size_t large;
 
 	/*
 	 * Allocate a bunch of large objects, pause the clock, deallocate the
-	 * objects, restore the clock, then [md]allocx() in a tight loop to
-	 * verify the ticker triggers purging.
+	 * objects, restore the clock, then [md]allocx() in a tight loop while
+	 * advancing time rapidly to verify the ticker triggers purging.
 	 */
 
 	if (config_tcache) {
 		size_t tcache_max;
 
-		sz = sizeof(size_t);
+		size_t sz = sizeof(size_t);
 		assert_d_eq(mallctl("arenas.tcache_max", (void *)&tcache_max,
 		    &sz, NULL, 0), 0, "Unexpected mallctl failure");
 		large = nallocx(tcache_max + 1, flags);
 	}  else {
-		sz = sizeof(size_t);
+		size_t sz = sizeof(size_t);
 		assert_d_eq(mallctl("arenas.lextent.0.size", &large, &sz, NULL,
 		    0), 0, "Unexpected mallctl failure");
 	}
 
-	assert_d_eq(mallctl("arena.0.purge", NULL, NULL, NULL, 0), 0,
-	    "Unexpected mallctl failure");
-	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch,
-	    sizeof(uint64_t)), 0, "Unexpected mallctl failure");
-	sz = sizeof(uint64_t);
-	assert_d_eq(mallctl("stats.arenas.0.npurge", (void *)&npurge0, &sz,
-	    NULL, 0), config_stats ? 0 : ENOENT, "Unexpected mallctl result");
+	do_purge(arena_ind);
+	uint64_t npurge0 = get_arena_npurge(arena_ind);
 
-	for (i = 0; i < NPS; i++) {
-		ps[i] = mallocx(large, flags);
-		assert_ptr_not_null(ps[i], "Unexpected mallocx() failure");
+	for (unsigned i = 0; i < NPS; i++) {
+		ps[i] = do_mallocx(large, flags);
 	}
 
 	nupdates_mock = 0;
@@ -246,43 +338,59 @@ TEST_BEGIN(test_decay_ticker) {
 	nstime_monotonic = nstime_monotonic_mock;
 	nstime_update = nstime_update_mock;
 
-	for (i = 0; i < NPS; i++) {
+	for (unsigned i = 0; i < NPS; i++) {
 		dallocx(ps[i], flags);
-		nupdates0 = nupdates_mock;
-		assert_d_eq(mallctl("arena.0.decay", NULL, NULL, NULL, 0), 0,
-		    "Unexpected arena.0.decay failure");
+		unsigned nupdates0 = nupdates_mock;
+		do_decay(arena_ind);
 		assert_u_gt(nupdates_mock, nupdates0,
 		    "Expected nstime_update() to be called");
 	}
 
-	nstime_monotonic = nstime_monotonic_orig;
-	nstime_update = nstime_update_orig;
+	nstime_t time, update_interval, decay_time, deadline;
 
 	nstime_init(&time, 0);
 	nstime_update(&time);
-	nstime_init2(&decay_time, opt_decay_time, 0);
+
+	nstime_init2(&decay_time, dt, 0);
 	nstime_copy(&deadline, &time);
 	nstime_add(&deadline, &decay_time);
-	do {
-		for (i = 0; i < DECAY_NTICKS_PER_UPDATE / 2; i++) {
-			void *p = mallocx(1, flags);
-			assert_ptr_not_null(p, "Unexpected mallocx() failure");
-			dallocx(p, flags);
-		}
-		assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch,
-		    sizeof(uint64_t)), 0, "Unexpected mallctl failure");
-		sz = sizeof(uint64_t);
-		assert_d_eq(mallctl("stats.arenas.0.npurge", (void *)&npurge1,
-		    &sz, NULL, 0), config_stats ? 0 : ENOENT,
-		    "Unexpected mallctl result");
 
+	nstime_init2(&update_interval, dt, 0);
+	nstime_idivide(&update_interval, NINTERVALS);
+
+	nstime_init2(&decay_time, dt, 0);
+	nstime_copy(&deadline, &time);
+	nstime_add(&deadline, &decay_time);
+
+	/*
+	 * Keep q's slab from being deallocated during the looping below.  If
+	 * a cached slab were to repeatedly come and go during looping, it could
+	 * prevent the decay backlog ever becoming empty.
+	 */
+	void *p = do_mallocx(1, flags);
+	uint64_t npurge1;
+	do {
+		for (unsigned i = 0; i < DECAY_NTICKS_PER_UPDATE / 2; i++) {
+			void *q = do_mallocx(1, flags);
+			dallocx(q, flags);
+		}
+		npurge1 = get_arena_npurge(arena_ind);
+
+		nstime_add(&time_mock, &update_interval);
 		nstime_update(&time);
 	} while (nstime_compare(&time, &deadline) <= 0 && npurge1 == npurge0);
+	dallocx(p, flags);
+
+	nstime_monotonic = nstime_monotonic_orig;
+	nstime_update = nstime_update_orig;
 
 	if (config_stats) {
 		assert_u64_gt(npurge1, npurge0, "Expected purging to occur");
 	}
+
+	do_arena_destroy(arena_ind);
 #undef NPS
+#undef NINTERVALS
 }
 TEST_END
 
@@ -290,7 +398,6 @@ TEST_BEGIN(test_decay_nonmonotonic) {
 #define NPS (SMOOTHSTEP_NSTEPS + 1)
 	int flags = (MALLOCX_ARENA(0) | MALLOCX_TCACHE_NONE);
 	void *ps[NPS];
-	uint64_t epoch;
 	uint64_t npurge0 = 0;
 	uint64_t npurge1 = 0;
 	size_t sz, large0;
@@ -302,8 +409,7 @@ TEST_BEGIN(test_decay_nonmonotonic) {
 
 	assert_d_eq(mallctl("arena.0.purge", NULL, NULL, NULL, 0), 0,
 	    "Unexpected mallctl failure");
-	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch,
-	    sizeof(uint64_t)), 0, "Unexpected mallctl failure");
+	do_epoch();
 	sz = sizeof(uint64_t);
 	assert_d_eq(mallctl("stats.arenas.0.npurge", (void *)&npurge0, &sz,
 	    NULL, 0), config_stats ? 0 : ENOENT, "Unexpected mallctl result");
@@ -332,8 +438,7 @@ TEST_BEGIN(test_decay_nonmonotonic) {
 		    "Expected nstime_update() to be called");
 	}
 
-	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch,
-	    sizeof(uint64_t)), 0, "Unexpected mallctl failure");
+	do_epoch();
 	sz = sizeof(uint64_t);
 	assert_d_eq(mallctl("stats.arenas.0.npurge", (void *)&npurge1, &sz,
 	    NULL, 0), config_stats ? 0 : ENOENT, "Unexpected mallctl result");
@@ -347,69 +452,6 @@ TEST_BEGIN(test_decay_nonmonotonic) {
 #undef NPS
 }
 TEST_END
-
-static unsigned
-do_arena_create(ssize_t decay_time) {
-	unsigned arena_ind;
-	size_t sz = sizeof(unsigned);
-	assert_d_eq(mallctl("arenas.create", (void *)&arena_ind, &sz, NULL, 0),
-	    0, "Unexpected mallctl() failure");
-	size_t mib[3];
-	size_t miblen = sizeof(mib)/sizeof(size_t);
-	assert_d_eq(mallctlnametomib("arena.0.decay_time", mib, &miblen), 0,
-	    "Unexpected mallctlnametomib() failure");
-	mib[1] = (size_t)arena_ind;
-	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, (void *)&decay_time,
-	    sizeof(decay_time)), 0, "Unexpected mallctlbymib() failure");
-	return arena_ind;
-}
-
-static void
-do_arena_destroy(unsigned arena_ind) {
-	size_t mib[3];
-	size_t miblen = sizeof(mib)/sizeof(size_t);
-	assert_d_eq(mallctlnametomib("arena.0.destroy", mib, &miblen), 0,
-	    "Unexpected mallctlnametomib() failure");
-	mib[1] = (size_t)arena_ind;
-	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
-	    "Unexpected mallctlbymib() failure");
-}
-
-void
-do_epoch(void) {
-	uint64_t epoch = 1;
-	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sizeof(epoch)),
-	    0, "Unexpected mallctl() failure");
-}
-
-static size_t
-get_arena_pdirty(unsigned arena_ind) {
-	do_epoch();
-	size_t mib[4];
-	size_t miblen = sizeof(mib)/sizeof(size_t);
-	assert_d_eq(mallctlnametomib("stats.arenas.0.pdirty", mib, &miblen), 0,
-	    "Unexpected mallctlnametomib() failure");
-	mib[2] = (size_t)arena_ind;
-	size_t pdirty;
-	size_t sz = sizeof(pdirty);
-	assert_d_eq(mallctlbymib(mib, miblen, (void *)&pdirty, &sz, NULL, 0), 0,
-	    "Unexpected mallctlbymib() failure");
-	return pdirty;
-}
-
-static void *
-do_mallocx(size_t size, int flags) {
-	void *p = mallocx(size, flags);
-	assert_ptr_not_null(p, "Unexpected mallocx() failure");
-	return p;
-}
-
-static void
-generate_dirty(unsigned arena_ind, size_t size) {
-	int flags = MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE;
-	void *p = do_mallocx(size, flags);
-	dallocx(p, flags);
-}
 
 TEST_BEGIN(test_decay_now) {
 	unsigned arena_ind = do_arena_create(0);


### PR DESCRIPTION
This would feel like a hack to me absent the delayed coalescing in #675, but in that context it feels natural and complementary.  The two in combination (plus #678) speed up the large allocation fast path substantially, to the point that it's probably faster than 4.x's.

@djwatson, you may find the (ab)use of the pairing heap's aux list entertaining.