### PR TITLE
Switch atomic uint64_ts in arena_stats_t to C11 atomics

### DIFF
--- a/include/jemalloc/internal/arena_inlines_a.h
+++ b/include/jemalloc/internal/arena_inlines_a.h
@@ -19,17 +19,17 @@ arena_ind_get(const arena_t *arena) {
 
 JEMALLOC_INLINE void
 arena_internal_add(arena_t *arena, size_t size) {
-	atomic_add_zu(&arena->stats.internal, size);
+	atomic_fetch_add_zu(&arena->stats.internal, size, ATOMIC_RELAXED);
 }
 
 JEMALLOC_INLINE void
 arena_internal_sub(arena_t *arena, size_t size) {
-	atomic_sub_zu(&arena->stats.internal, size);
+	atomic_fetch_sub_zu(&arena->stats.internal, size, ATOMIC_RELAXED);
 }
 
 JEMALLOC_INLINE size_t
 arena_internal_get(arena_t *arena) {
-	return atomic_read_zu(&arena->stats.internal);
+	return atomic_load_zu(&arena->stats.internal, ATOMIC_RELAXED);
 }
 
 JEMALLOC_INLINE bool

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -88,7 +88,7 @@ struct arena_stats_s {
 #endif
 
 	/* Number of bytes currently mapped, excluding retained memory. */
-	size_t		mapped; /* Partially derived. */
+	atomic_zu_t		mapped; /* Partially derived. */
 
 	/*
 	 * Number of bytes currently retained as a side effect of munmap() being
@@ -96,7 +96,7 @@ struct arena_stats_s {
 	 * always decommitted or purged), but they are excluded from the mapped
 	 * statistic (above).
 	 */
-	size_t		retained; /* Derived. */
+	atomic_zu_t		retained; /* Derived. */
 
 	/*
 	 * Total number of purge sweeps, total number of madvise calls made,
@@ -107,17 +107,17 @@ struct arena_stats_s {
 	arena_stats_u64_t	nmadvise;
 	arena_stats_u64_t	purged;
 
-	size_t			base; /* Derived. */
-	size_t			internal;
-	size_t			resident; /* Derived. */
+	atomic_zu_t		base; /* Derived. */
+	atomic_zu_t		internal;
+	atomic_zu_t		resident; /* Derived. */
 
-	size_t			allocated_large; /* Derived. */
+	atomic_zu_t		allocated_large; /* Derived. */
 	arena_stats_u64_t	nmalloc_large; /* Derived. */
 	arena_stats_u64_t	ndalloc_large; /* Derived. */
 	arena_stats_u64_t	nrequests_large; /* Derived. */
 
 	/* Number of bytes cached in tcache associated with this arena. */
-	size_t		tcache_bytes; /* Derived. */
+	atomic_zu_t		tcache_bytes; /* Derived. */
 
 	/* One element for each large size class. */
 	malloc_large_stats_t	lstats[NSIZES - NBINS];

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -1,6 +1,13 @@
 #ifndef JEMALLOC_INTERNAL_STATS_STRUCTS_H
 #define JEMALLOC_INTERNAL_STATS_STRUCTS_H
 
+#ifdef JEMALLOC_ATOMIC_U64
+typedef atomic_u64_t arena_stats_u64_t;
+#else
+/* Must hold the arena stats mutex while reading atomically. */
+typedef uint64_t arena_stats_u64_t;
+#endif
+
 struct tcache_bin_stats_s {
 	/*
 	 * Number of allocation requests that corresponded to the size of this
@@ -56,15 +63,15 @@ struct malloc_large_stats_s {
 	 * Total number of allocation/deallocation requests served directly by
 	 * the arena.
 	 */
-	uint64_t	nmalloc;
-	uint64_t	ndalloc;
+	arena_stats_u64_t	nmalloc;
+	arena_stats_u64_t	ndalloc;
 
 	/*
 	 * Number of allocation requests that correspond to this size class.
 	 * This includes requests served by tcache, though tcache only
 	 * periodically merges into this counter.
 	 */
-	uint64_t	nrequests; /* Partially derived. */
+	arena_stats_u64_t	nrequests; /* Partially derived. */
 
 	/* Current number of allocations of this size class. */
 	size_t		curlextents; /* Derived. */
@@ -96,18 +103,18 @@ struct arena_stats_s {
 	 * and total pages purged in order to keep dirty unused memory under
 	 * control.
 	 */
-	uint64_t	npurge;
-	uint64_t	nmadvise;
-	uint64_t	purged;
+	arena_stats_u64_t	npurge;
+	arena_stats_u64_t	nmadvise;
+	arena_stats_u64_t	purged;
 
-	size_t		base; /* Derived. */
-	size_t		internal;
-	size_t		resident; /* Derived. */
+	size_t			base; /* Derived. */
+	size_t			internal;
+	size_t			resident; /* Derived. */
 
-	size_t		allocated_large; /* Derived. */
-	uint64_t	nmalloc_large; /* Derived. */
-	uint64_t	ndalloc_large; /* Derived. */
-	uint64_t	nrequests_large; /* Derived. */
+	size_t			allocated_large; /* Derived. */
+	arena_stats_u64_t	nmalloc_large; /* Derived. */
+	arena_stats_u64_t	ndalloc_large; /* Derived. */
+	arena_stats_u64_t	nrequests_large; /* Derived. */
 
 	/* Number of bytes cached in tcache associated with this arena. */
 	size_t		tcache_bytes; /* Derived. */


### PR DESCRIPTION
I expect this to be the trickiest conversion we will see, since we want atomics
on 64-bit platforms, but are also always able to piggyback on some sort of
external synchronization not under our control on non-64 bit platforms.