### PR TITLE
Mutex profiling

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -430,7 +430,8 @@ for (i = 0; i < nbins; i++) {
       can be specified to omit merged arena, destroyed merged arena, and per
       arena statistics, respectively; <quote>b</quote> and <quote>l</quote> can
       be specified to omit per size class statistics for bins and large objects,
-      respectively.  Unrecognized characters are silently ignored.  Note that
+      respectively; <quote>x</quote> can be specified to omit all mutex
+      statistics.  Unrecognized characters are silently ignored.  Note that
       thread caching may prevent some statistics from being completely up to
       date, since extra locking would be required to merge counters that track
       thread cache operations.</para>

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -2153,6 +2153,80 @@ struct extent_hooks_s {
         </para></listitem>
       </varlistentry>
 
+      <varlistentry id="stats.mutexes.ctl">
+        <term>
+          <mallctl>stats.mutexes.ctl.{counter};</mallctl>
+          (<type>counter specific type</type>)
+          <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>ctl</varname> mutex (global
+        scope; mallctl related).  <mallctl>{counter}</mallctl> is one of the
+        counters below:</para>
+        <varlistentry id="mutex_counters">
+          <listitem><para><varname>num_ops</varname> (<type>uint64_t</type>):
+          Total number of lock acquisition operations on this mutex.</para>
+
+	  <para><varname>num_spin_acq</varname> (<type>uint64_t</type>): Number
+	  of times the mutex was spin-acquired.  When the mutex is currently
+	  locked and cannot be acquired immediately, a short period of
+	  spin-retry within jemalloc will be performed.  Acquired through spin
+	  generally means the contention was lightweight and not causing context
+	  switches.</para>
+
+	  <para><varname>num_wait</varname> (<type>uint64_t</type>): Number of
+	  times the mutex was wait-acquired, which means the mutex contention
+	  was not solved by spin-retry, and blocking operation was likely
+	  involved in order to acquire the mutex.  This event generally implies
+	  higher cost / longer delay, and should be investigated if it happens
+	  often.</para>
+
+	  <para><varname>max_wait_time</varname> (<type>uint64_t</type>):
+	  Maximum length of time in nanoseconds spent on a single wait-acquired
+	  lock operation.  Note that to avoid profiling overhead on the common
+	  path, this does not consider spin-acquired cases.</para>
+
+	  <para><varname>total_wait_time</varname> (<type>uint64_t</type>):
+	  Cumulative time in nanoseconds spent on wait-acquired lock operations.
+	  Similarly, spin-acquired cases are not considered.</para>
+
+	  <para><varname>max_num_thds</varname> (<type>uint32_t</type>): Maximum
+	  number of threads waiting on this mutex simultaneously.  Similarly,
+	  spin-acquired cases are not considered.</para>
+
+	  <para><varname>num_owner_switch</varname> (<type>uint64_t</type>):
+	  Number of times the current mutex owner is different from the previous
+	  one.  This event does not generally imply an issue; rather it is an
+	  indicator of how often the protected data are accessed by different
+	  threads.
+	  </para>
+	  </listitem>
+	</varlistentry>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.mutexes.prof">
+        <term>
+          <mallctl>stats.mutexes.prof.{counter}</mallctl>
+	  (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>prof</varname> mutex (global
+        scope; profiling related).  <mallctl>{counter}</mallctl> is one of the
+        counters in <link linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.mutexes.reset">
+        <term>
+          <mallctl>stats.mutexes.reset</mallctl>
+	  (<type>void</type>) <literal>--</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Reset all mutex profile statistics, including global
+        mutexes, arena mutexes and bin mutexes.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="stats.arenas.i.dss">
         <term>
           <mallctl>stats.arenas.&lt;i&gt;.dss</mallctl>
@@ -2547,6 +2621,19 @@ struct extent_hooks_s {
         <listitem><para>Current number of slabs.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="stats.arenas.i.bins.mutex">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.bins.&lt;j&gt;.mutex.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on
+        <varname>arena.&lt;i&gt;.bins.&lt;j&gt;</varname> mutex (arena bin
+        scope; bin operation related).  <mallctl>{counter}</mallctl> is one of
+        the counters in <link linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="stats.arenas.i.lextents.j.nmalloc">
         <term>
           <mallctl>stats.arenas.&lt;i&gt;.lextents.&lt;j&gt;.nmalloc</mallctl>
@@ -2590,6 +2677,125 @@ struct extent_hooks_s {
         <listitem><para>Current number of large allocations for this size class.
         </para></listitem>
       </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.large">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.large.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.large</varname>
+        mutex (arena scope; large allocation related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.extent_freelist">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extent_freelist.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extent_freelist
+        </varname> mutex (arena scope; extent freelist related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.extents_dirty">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extents_dirty.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extents_dirty
+        </varname> mutex (arena scope; dirty extents related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.extents_muzzy">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extents_muzzy.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extents_muzzy
+        </varname> mutex (arena scope; muzzy extents related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.extents_retained">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extents_retained.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extents_retained
+        </varname> mutex (arena scope; retained extents related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.decay_dirty">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.decay_dirty.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.decay_dirty
+        </varname> mutex (arena scope; decay for dirty pages related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.decay_muzzy">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.decay_muzzy.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.decay_muzzy
+        </varname> mutex (arena scope; decay for muzzy pages related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.base">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.base.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.base</varname>
+        mutex (arena scope; base allocator related).
+        <mallctl>{counter}</mallctl> is one of the counters in <link
+        linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="stats.arenas.i.mutexes.tcache_list">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.tcache_list.{counter}</mallctl>
+          (<type>counter specific type</type>) <literal>r-</literal>
+          [<option>--enable-stats</option>]
+        </term>
+        <listitem><para>Statistics on
+        <varname>arena.&lt;i&gt;.tcache_list</varname> mutex (arena scope;
+        tcache to arena association related).  This mutex is expected to be
+        accessed less often.  <mallctl>{counter}</mallctl> is one of the
+        counters in <link linkend="mutex_counters">mutex profiling
+        counters</link>.</para></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
   <refsect1 id="heap_profile_format">

--- a/include/jemalloc/internal/ctl_externs.h
+++ b/include/jemalloc/internal/ctl_externs.h
@@ -4,13 +4,13 @@
 /* Maximum ctl tree depth. */
 #define CTL_MAX_DEPTH	7
 
-#define NUM_GLOBAL_PROF_LOCKS	3
-#define NUM_ARENA_PROF_LOCKS	6
-#define NUM_LOCK_PROF_COUNTERS	7
+#define NUM_GLOBAL_PROF_MUTEXES	3
+#define NUM_ARENA_PROF_MUTEXES	6
+#define NUM_MUTEX_PROF_COUNTERS	7
 
-extern const char *arena_lock_names[NUM_ARENA_PROF_LOCKS];
-extern const char *global_lock_names[NUM_GLOBAL_PROF_LOCKS];
-extern const char *lock_counter_names[NUM_LOCK_PROF_COUNTERS];
+extern const char *arena_mutex_names[NUM_ARENA_PROF_MUTEXES];
+extern const char *global_mutex_names[NUM_GLOBAL_PROF_MUTEXES];
+extern const char *mutex_counter_names[NUM_MUTEX_PROF_COUNTERS];
 
 int	ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
     void *newp, size_t newlen);

--- a/include/jemalloc/internal/ctl_externs.h
+++ b/include/jemalloc/internal/ctl_externs.h
@@ -1,6 +1,14 @@
 #ifndef JEMALLOC_INTERNAL_CTL_EXTERNS_H
 #define JEMALLOC_INTERNAL_CTL_EXTERNS_H
 
+/* Maximum ctl tree depth. */
+#define CTL_MAX_DEPTH	7
+
+#define NUM_ARENA_PROF_LOCKS 6
+#define NUM_LOCK_PROF_COUNTERS 7
+const char *arena_lock_names[NUM_ARENA_PROF_LOCKS];
+const char *lock_counter_names[NUM_LOCK_PROF_COUNTERS];
+
 int	ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
     void *newp, size_t newlen);
 int	ctl_nametomib(tsdn_t *tsdn, const char *name, size_t *mibp,

--- a/include/jemalloc/internal/ctl_externs.h
+++ b/include/jemalloc/internal/ctl_externs.h
@@ -4,10 +4,13 @@
 /* Maximum ctl tree depth. */
 #define CTL_MAX_DEPTH	7
 
-#define NUM_ARENA_PROF_LOCKS 6
-#define NUM_LOCK_PROF_COUNTERS 7
-const char *arena_lock_names[NUM_ARENA_PROF_LOCKS];
-const char *lock_counter_names[NUM_LOCK_PROF_COUNTERS];
+#define NUM_GLOBAL_PROF_LOCKS	3
+#define NUM_ARENA_PROF_LOCKS	6
+#define NUM_LOCK_PROF_COUNTERS	7
+
+extern const char *arena_lock_names[NUM_ARENA_PROF_LOCKS];
+extern const char *global_lock_names[NUM_GLOBAL_PROF_LOCKS];
+extern const char *lock_counter_names[NUM_LOCK_PROF_COUNTERS];
 
 int	ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
     void *newp, size_t newlen);

--- a/include/jemalloc/internal/ctl_externs.h
+++ b/include/jemalloc/internal/ctl_externs.h
@@ -4,14 +4,6 @@
 /* Maximum ctl tree depth. */
 #define CTL_MAX_DEPTH	7
 
-#define NUM_GLOBAL_PROF_MUTEXES	3
-#define NUM_ARENA_PROF_MUTEXES	8
-#define NUM_MUTEX_PROF_COUNTERS	7
-
-extern const char *arena_mutex_names[NUM_ARENA_PROF_MUTEXES];
-extern const char *global_mutex_names[NUM_GLOBAL_PROF_MUTEXES];
-extern const char *mutex_counter_names[NUM_MUTEX_PROF_COUNTERS];
-
 int	ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
     void *newp, size_t newlen);
 int	ctl_nametomib(tsdn_t *tsdn, const char *name, size_t *mibp,

--- a/include/jemalloc/internal/ctl_externs.h
+++ b/include/jemalloc/internal/ctl_externs.h
@@ -5,7 +5,7 @@
 #define CTL_MAX_DEPTH	7
 
 #define NUM_GLOBAL_PROF_MUTEXES	3
-#define NUM_ARENA_PROF_MUTEXES	6
+#define NUM_ARENA_PROF_MUTEXES	8
 #define NUM_MUTEX_PROF_COUNTERS	7
 
 extern const char *arena_mutex_names[NUM_ARENA_PROF_MUTEXES];

--- a/include/jemalloc/internal/ctl_structs.h
+++ b/include/jemalloc/internal/ctl_structs.h
@@ -42,8 +42,8 @@ struct ctl_stats_s {
 	size_t			mapped;
 	size_t			retained;
 
-#define MTX(mutex) lock_prof_data_t mutex##_mtx_data;
-GLOBAL_PROF_MUTEXES
+#define MTX(mutex) mutex_prof_data_t mutex##_mtx_data;
+	GLOBAL_PROF_MUTEXES
 #undef MTX
 };
 

--- a/include/jemalloc/internal/ctl_structs.h
+++ b/include/jemalloc/internal/ctl_structs.h
@@ -42,9 +42,7 @@ struct ctl_stats_s {
 	size_t			mapped;
 	size_t			retained;
 
-#define MTX(mutex) mutex_prof_data_t mutex##_mtx_data;
-	GLOBAL_PROF_MUTEXES
-#undef MTX
+	mutex_prof_data_t	mutex_prof_data[num_global_prof_mutexes];
 };
 
 struct ctl_arena_s {

--- a/include/jemalloc/internal/ctl_structs.h
+++ b/include/jemalloc/internal/ctl_structs.h
@@ -41,6 +41,10 @@ struct ctl_stats_s {
 	size_t			resident;
 	size_t			mapped;
 	size_t			retained;
+
+#define MTX(mutex) lock_prof_data_t mutex##_mtx_data;
+GLOBAL_PROF_MUTEXES
+#undef MTX
 };
 
 struct ctl_arena_s {

--- a/include/jemalloc/internal/ctl_types.h
+++ b/include/jemalloc/internal/ctl_types.h
@@ -2,7 +2,6 @@
 #define JEMALLOC_INTERNAL_CTL_TYPES_H
 
 #define GLOBAL_PROF_MUTEXES						\
-    OP(base)								\
     OP(ctl)								\
     OP(prof)
 
@@ -21,6 +20,7 @@ typedef enum {
     OP(extents_retained)						\
     OP(decay_dirty)							\
     OP(decay_muzzy)							\
+    OP(base)								\
     OP(tcache_list)
 
 typedef enum {

--- a/include/jemalloc/internal/ctl_types.h
+++ b/include/jemalloc/internal/ctl_types.h
@@ -2,9 +2,49 @@
 #define JEMALLOC_INTERNAL_CTL_TYPES_H
 
 #define GLOBAL_PROF_MUTEXES						\
-    MTX(base)								\
-    MTX(ctl)								\
-    MTX(prof)
+    OP(base)								\
+    OP(ctl)								\
+    OP(prof)
+
+typedef enum {
+#define OP(mtx) global_prof_mutex_##mtx,
+	GLOBAL_PROF_MUTEXES
+#undef OP
+	num_global_prof_mutexes
+} global_prof_mutex_ind_t;
+
+#define ARENA_PROF_MUTEXES						\
+    OP(large)								\
+    OP(extent_freelist)							\
+    OP(extents_dirty)							\
+    OP(extents_muzzy)							\
+    OP(extents_retained)						\
+    OP(decay_dirty)							\
+    OP(decay_muzzy)							\
+    OP(tcache_list)
+
+typedef enum {
+#define OP(mtx) arena_prof_mutex_##mtx,
+	ARENA_PROF_MUTEXES
+#undef OP
+	num_arena_prof_mutexes
+} arena_prof_mutex_ind_t;
+
+#define MUTEX_PROF_COUNTERS						\
+    OP(num_ops, uint64_t)						\
+    OP(num_wait, uint64_t)						\
+    OP(num_spin_acq, uint64_t)						\
+    OP(num_owner_switch, uint64_t)					\
+    OP(total_wait_time, uint64_t)					\
+    OP(max_wait_time, uint64_t)						\
+    OP(max_num_thds, uint32_t)
+
+typedef enum {
+#define OP(counter, type) mutex_counter_##counter,
+	MUTEX_PROF_COUNTERS
+#undef OP
+	num_mutex_prof_counters
+} mutex_prof_counter_ind_t;
 
 typedef struct ctl_node_s ctl_node_t;
 typedef struct ctl_named_node_s ctl_named_node_t;

--- a/include/jemalloc/internal/ctl_types.h
+++ b/include/jemalloc/internal/ctl_types.h
@@ -1,6 +1,11 @@
 #ifndef JEMALLOC_INTERNAL_CTL_TYPES_H
 #define JEMALLOC_INTERNAL_CTL_TYPES_H
 
+#define GLOBAL_PROF_MUTEXES						\
+    MTX(base)								\
+    MTX(ctl)								\
+    MTX(prof)
+
 typedef struct ctl_node_s ctl_node_t;
 typedef struct ctl_named_node_s ctl_named_node_t;
 typedef struct ctl_indexed_node_s ctl_indexed_node_t;

--- a/include/jemalloc/internal/mutex_externs.h
+++ b/include/jemalloc/internal/mutex_externs.h
@@ -14,5 +14,6 @@ void	malloc_mutex_prefork(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_postfork_parent(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_postfork_child(tsdn_t *tsdn, malloc_mutex_t *mutex);
 bool	malloc_mutex_boot(void);
+void	malloc_mutex_prof_data_reset(tsdn_t *tsdn, malloc_mutex_t *mutex);
 
 #endif /* JEMALLOC_INTERNAL_MUTEX_EXTERNS_H */

--- a/include/jemalloc/internal/mutex_inlines.h
+++ b/include/jemalloc/internal/mutex_inlines.h
@@ -52,11 +52,13 @@ malloc_mutex_lock(tsdn_t *tsdn, malloc_mutex_t *mutex) {
 			malloc_mutex_lock_slow(mutex);
 		}
 		/* We own the lock now.  Update a few counters. */
-		mutex_prof_data_t *data = &mutex->prof_data;
-		data->n_lock_ops++;
-		if (data->prev_owner != tsdn) {
-			data->prev_owner = tsdn;
-			data->n_owner_switches++;
+		if (config_stats) {
+			mutex_prof_data_t *data = &mutex->prof_data;
+			data->n_lock_ops++;
+			if (data->prev_owner != tsdn) {
+				data->prev_owner = tsdn;
+				data->n_owner_switches++;
+			}
 		}
 	}
 	witness_lock(tsdn, &mutex->witness);

--- a/include/jemalloc/internal/mutex_inlines.h
+++ b/include/jemalloc/internal/mutex_inlines.h
@@ -9,6 +9,9 @@ bool	malloc_mutex_trylock(malloc_mutex_t *mutex);
 void	malloc_mutex_unlock(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_assert_owner(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_assert_not_owner(tsdn_t *tsdn, malloc_mutex_t *mutex);
+void	malloc_lock_prof_read(tsdn_t *tsdn, lock_prof_data_t *data,
+    malloc_mutex_t *mutex);
+void	malloc_lock_prof_merge(lock_prof_data_t *sum, lock_prof_data_t *data);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_MUTEX_C_))
@@ -21,6 +24,24 @@ malloc_mutex_lock_final(malloc_mutex_t *mutex) {
 JEMALLOC_INLINE bool
 malloc_mutex_trylock(malloc_mutex_t *mutex) {
 	return MALLOC_MUTEX_TRYLOCK(mutex);
+}
+
+/* Aggregate lock prof data. */
+JEMALLOC_INLINE void
+malloc_lock_prof_merge(lock_prof_data_t *sum, lock_prof_data_t *data) {
+	nstime_add(&sum->tot_wait_time, &data->tot_wait_time);
+	if (nstime_compare(&data->max_wait_time, &sum->max_wait_time)) {
+		nstime_copy(&sum->max_wait_time, &data->max_wait_time);
+	}
+	sum->n_wait_times += data->n_wait_times;
+	sum->n_spin_acquired += data->n_spin_acquired;
+
+	if (sum->max_n_thds < data->max_n_thds) {
+		sum->max_n_thds = data->max_n_thds;
+	}
+	sum->n_waiting_thds += data->n_waiting_thds;
+	sum->n_owner_switches += data->n_owner_switches;
+	sum->n_lock_ops += data->n_lock_ops;
 }
 
 JEMALLOC_INLINE void
@@ -58,6 +79,20 @@ JEMALLOC_INLINE void
 malloc_mutex_assert_not_owner(tsdn_t *tsdn, malloc_mutex_t *mutex) {
 	witness_assert_not_owner(tsdn, &mutex->witness);
 }
+
+/* Copy the prof data from mutex for processing. */
+JEMALLOC_INLINE void
+malloc_lock_prof_read(tsdn_t *tsdn, lock_prof_data_t *data,
+    malloc_mutex_t *mutex) {
+	lock_prof_data_t *source = &mutex->prof_data;
+	/* Can only read with the lock. */
+	malloc_mutex_assert_owner(tsdn, mutex);
+
+	*data = *source;
+	/* n_wait_thds is not reported (modified w/o locking). */
+	data->n_waiting_thds = 0;
+}
+
 #endif
 
 #endif /* JEMALLOC_INTERNAL_MUTEX_INLINES_H */

--- a/include/jemalloc/internal/mutex_inlines.h
+++ b/include/jemalloc/internal/mutex_inlines.h
@@ -29,10 +29,11 @@ malloc_mutex_trylock(malloc_mutex_t *mutex) {
 /* Aggregate lock prof data. */
 JEMALLOC_INLINE void
 malloc_mutex_prof_merge(mutex_prof_data_t *sum, mutex_prof_data_t *data) {
-	sum->tot_wait_time += data->tot_wait_time;
-	if (data->max_wait_time > sum->max_wait_time) {
-		sum->max_wait_time = data->max_wait_time;
+	nstime_add(&sum->tot_wait_time, &data->tot_wait_time);
+	if (nstime_compare(&sum->max_wait_time, &data->max_wait_time) < 0) {
+		nstime_copy(&sum->max_wait_time, &data->max_wait_time);
 	}
+
 	sum->n_wait_times += data->n_wait_times;
 	sum->n_spin_acquired += data->n_spin_acquired;
 

--- a/include/jemalloc/internal/mutex_inlines.h
+++ b/include/jemalloc/internal/mutex_inlines.h
@@ -1,8 +1,11 @@
 #ifndef JEMALLOC_INTERNAL_MUTEX_INLINES_H
 #define JEMALLOC_INTERNAL_MUTEX_INLINES_H
 
+void	malloc_mutex_lock_slow(malloc_mutex_t *mutex);
+
 #ifndef JEMALLOC_ENABLE_INLINE
 void	malloc_mutex_lock(tsdn_t *tsdn, malloc_mutex_t *mutex);
+bool	malloc_mutex_trylock(malloc_mutex_t *mutex);
 void	malloc_mutex_unlock(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_assert_owner(tsdn_t *tsdn, malloc_mutex_t *mutex);
 void	malloc_mutex_assert_not_owner(tsdn_t *tsdn, malloc_mutex_t *mutex);
@@ -10,22 +13,30 @@ void	malloc_mutex_assert_not_owner(tsdn_t *tsdn, malloc_mutex_t *mutex);
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_MUTEX_C_))
 JEMALLOC_INLINE void
+malloc_mutex_lock_final(malloc_mutex_t *mutex) {
+	MALLOC_MUTEX_LOCK(mutex);
+}
+
+/* Trylock: return false if the lock is successfully acquired. */
+JEMALLOC_INLINE bool
+malloc_mutex_trylock(malloc_mutex_t *mutex) {
+	return MALLOC_MUTEX_TRYLOCK(mutex);
+}
+
+JEMALLOC_INLINE void
 malloc_mutex_lock(tsdn_t *tsdn, malloc_mutex_t *mutex) {
 	witness_assert_not_owner(tsdn, &mutex->witness);
 	if (isthreaded) {
-#ifdef _WIN32
-#  if _WIN32_WINNT >= 0x0600
-		AcquireSRWLockExclusive(&mutex->lock);
-#  else
-		EnterCriticalSection(&mutex->lock);
-#  endif
-#elif (defined(JEMALLOC_OS_UNFAIR_LOCK))
-		os_unfair_lock_lock(&mutex->lock);
-#elif (defined(JEMALLOC_OSSPIN))
-		OSSpinLockLock(&mutex->lock);
-#else
-		pthread_mutex_lock(&mutex->lock);
-#endif
+		if (malloc_mutex_trylock(mutex)) {
+			malloc_mutex_lock_slow(mutex);
+		}
+		/* We own the lock now.  Update a few counters. */
+		lock_prof_data_t *data = &mutex->prof_data;
+		data->n_lock_ops++;
+		if (data->prev_owner != tsdn) {
+			data->prev_owner = tsdn;
+			data->n_owner_switches++;
+		}
 	}
 	witness_lock(tsdn, &mutex->witness);
 }
@@ -34,19 +45,7 @@ JEMALLOC_INLINE void
 malloc_mutex_unlock(tsdn_t *tsdn, malloc_mutex_t *mutex) {
 	witness_unlock(tsdn, &mutex->witness);
 	if (isthreaded) {
-#ifdef _WIN32
-#  if _WIN32_WINNT >= 0x0600
-		ReleaseSRWLockExclusive(&mutex->lock);
-#  else
-		LeaveCriticalSection(&mutex->lock);
-#  endif
-#elif (defined(JEMALLOC_OS_UNFAIR_LOCK))
-		os_unfair_lock_unlock(&mutex->lock);
-#elif (defined(JEMALLOC_OSSPIN))
-		OSSpinLockUnlock(&mutex->lock);
-#else
-		pthread_mutex_unlock(&mutex->lock);
-#endif
+		MALLOC_MUTEX_UNLOCK(mutex);
 	}
 }
 

--- a/include/jemalloc/internal/mutex_inlines.h
+++ b/include/jemalloc/internal/mutex_inlines.h
@@ -29,9 +29,9 @@ malloc_mutex_trylock(malloc_mutex_t *mutex) {
 /* Aggregate lock prof data. */
 JEMALLOC_INLINE void
 malloc_lock_prof_merge(lock_prof_data_t *sum, lock_prof_data_t *data) {
-	nstime_add(&sum->tot_wait_time, &data->tot_wait_time);
-	if (nstime_compare(&data->max_wait_time, &sum->max_wait_time)) {
-		nstime_copy(&sum->max_wait_time, &data->max_wait_time);
+	sum->tot_wait_time += data->tot_wait_time;
+	if (data->max_wait_time > sum->max_wait_time) {
+		sum->max_wait_time = data->max_wait_time;
 	}
 	sum->n_wait_times += data->n_wait_times;
 	sum->n_spin_acquired += data->n_spin_acquired;

--- a/include/jemalloc/internal/mutex_structs.h
+++ b/include/jemalloc/internal/mutex_structs.h
@@ -1,20 +1,20 @@
 #ifndef JEMALLOC_INTERNAL_MUTEX_STRUCTS_H
 #define JEMALLOC_INTERNAL_MUTEX_STRUCTS_H
 
-struct lock_prof_data_s {
+struct mutex_prof_data_s {
 	/*
 	 * Counters touched on the slow path, i.e. when there is lock
 	 * contention.  We update them once we have the lock.
 	 */
-	/* Total time (in nano seconds) spent waiting on this lock. */
+	/* Total time (in nano seconds) spent waiting on this mutex. */
 	uint64_t		tot_wait_time;
 	/* Max time (in nano seconds) spent on a single lock operation. */
 	uint64_t		max_wait_time;
-	/* # of times have to wait for this lock (after spinning). */
+	/* # of times have to wait for this mutex (after spinning). */
 	uint64_t		n_wait_times;
-	/* # of times acquired the lock through local spinning. */
+	/* # of times acquired the mutex through local spinning. */
 	uint64_t		n_spin_acquired;
-	/* Max # of threads waiting for the lock at the same time. */
+	/* Max # of threads waiting for the mutex at the same time. */
 	uint32_t		max_n_thds;
 	/* Current # of threads waiting on the lock.  Atomic synced. */
 	uint32_t		n_waiting_thds;
@@ -25,9 +25,9 @@ struct lock_prof_data_s {
 	 * the lock) so that we have a higher chance of them being on the same
 	 * cacheline.
 	 */
-	/* # of times the new lock holder is different from the previous one. */
+	/* # of times the mutex holder is different than the previous one. */
 	uint64_t		n_owner_switches;
-	/* Previous lock holder, to facilitate n_owner_switches. */
+	/* Previous mutex holder, to facilitate n_owner_switches. */
 	tsdn_t			*prev_owner;
 	/* # of lock() operations in total. */
 	uint64_t		n_lock_ops;
@@ -38,13 +38,13 @@ struct malloc_mutex_s {
 		struct {
 			/*
 			 * prof_data is defined first to reduce cacheline
-			 * bouncing: the data is not touched by the lock holder
+			 * bouncing: the data is not touched by the mutex holder
 			 * during unlocking, while might be modified by
-			 * contenders.  Having it before the lock itself could
+			 * contenders.  Having it before the mutex itself could
 			 * avoid prefetching a modified cacheline (for the
 			 * unlocking thread).
 			 */
-			lock_prof_data_t	prof_data;
+			mutex_prof_data_t	prof_data;
 #ifdef _WIN32
 #  if _WIN32_WINNT >= 0x0600
 			SRWLOCK         	lock;

--- a/include/jemalloc/internal/mutex_structs.h
+++ b/include/jemalloc/internal/mutex_structs.h
@@ -6,10 +6,10 @@ struct lock_prof_data_s {
 	 * Counters touched on the slow path, i.e. when there is lock
 	 * contention.  We update them once we have the lock.
 	 */
-	/* Total time spent waiting on this lock. */
-	nstime_t		tot_wait_time;
-	/* Max time spent on a single lock operation. */
-	nstime_t		max_wait_time;
+	/* Total time (in nano seconds) spent waiting on this lock. */
+	uint64_t		tot_wait_time;
+	/* Max time (in nano seconds) spent on a single lock operation. */
+	uint64_t		max_wait_time;
 	/* # of times have to wait for this lock (after spinning). */
 	uint64_t		n_wait_times;
 	/* # of times acquired the lock through local spinning. */

--- a/include/jemalloc/internal/mutex_structs.h
+++ b/include/jemalloc/internal/mutex_structs.h
@@ -7,9 +7,9 @@ struct mutex_prof_data_s {
 	 * contention.  We update them once we have the lock.
 	 */
 	/* Total time (in nano seconds) spent waiting on this mutex. */
-	uint64_t		tot_wait_time;
+	nstime_t		tot_wait_time;
 	/* Max time (in nano seconds) spent on a single lock operation. */
-	uint64_t		max_wait_time;
+	nstime_t		max_wait_time;
 	/* # of times have to wait for this mutex (after spinning). */
 	uint64_t		n_wait_times;
 	/* # of times acquired the mutex through local spinning. */

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -1,7 +1,7 @@
 #ifndef JEMALLOC_INTERNAL_MUTEX_TYPES_H
 #define JEMALLOC_INTERNAL_MUTEX_TYPES_H
 
-typedef struct lock_prof_data_s lock_prof_data_t;
+typedef struct mutex_prof_data_s mutex_prof_data_t;
 typedef struct malloc_mutex_s malloc_mutex_t;
 
 #ifdef _WIN32

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -28,8 +28,7 @@ typedef struct malloc_mutex_s malloc_mutex_t;
 #    define MALLOC_MUTEX_TRYLOCK(m) (pthread_mutex_trylock(&(m)->lock) != 0)
 #endif
 
-#define LOCK_PROF_DATA_INITIALIZER					\
-    {NSTIME_ZERO_INITIALIZER, NSTIME_ZERO_INITIALIZER, 0, 0, 0, 0, 0, NULL, 0}
+#define LOCK_PROF_DATA_INITIALIZER {0, 0, 0, 0, 0, 0, 0, NULL, 0}
 
 #ifdef _WIN32
 #  define MALLOC_MUTEX_INITIALIZER

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -1,31 +1,63 @@
 #ifndef JEMALLOC_INTERNAL_MUTEX_TYPES_H
 #define JEMALLOC_INTERNAL_MUTEX_TYPES_H
 
+typedef struct lock_prof_data_s lock_prof_data_t;
 typedef struct malloc_mutex_s malloc_mutex_t;
+
+#ifdef _WIN32
+#  if _WIN32_WINNT >= 0x0600
+#    define MALLOC_MUTEX_LOCK(m)    AcquireSRWLockExclusive(&(m)->lock)
+#    define MALLOC_MUTEX_UNLOCK(m)  ReleaseSRWLockExclusive(&(m)->lock)
+#    define MALLOC_MUTEX_TRYLOCK(m) (!TryAcquireSRWLockExclusive(&(m)->lock))
+#  else
+#    define MALLOC_MUTEX_LOCK(m)    EnterCriticalSection(&(m)->lock)
+#    define MALLOC_MUTEX_UNLOCK(m)  LeaveCriticalSection(&(m)->lock)
+#    define MALLOC_MUTEX_TRYLOCK(m) (!TryEnterCriticalSection(&(m)->lock))
+#  endif
+#elif (defined(JEMALLOC_OS_UNFAIR_LOCK))
+#    define MALLOC_MUTEX_LOCK(m)    os_unfair_lock_lock(&(m)->lock)
+#    define MALLOC_MUTEX_UNLOCK(m)  os_unfair_lock_unlock(&(m)->lock)
+#    define MALLOC_MUTEX_TRYLOCK(m) (!os_unfair_lock_trylock(&(m)->lock))
+#elif (defined(JEMALLOC_OSSPIN))
+#    define MALLOC_MUTEX_LOCK(m)    OSSpinLockLock(&(m)->lock)
+#    define MALLOC_MUTEX_UNLOCK(m)  OSSpinLockUnlock(&(m)->lock)
+#    define MALLOC_MUTEX_TRYLOCK(m) (!OSSpinLockTry(&(m)->lock))
+#else
+#    define MALLOC_MUTEX_LOCK(m)    pthread_mutex_lock(&(m)->lock)
+#    define MALLOC_MUTEX_UNLOCK(m)  pthread_mutex_unlock(&(m)->lock)
+#    define MALLOC_MUTEX_TRYLOCK(m) (pthread_mutex_trylock(&(m)->lock) != 0)
+#endif
+
+#define LOCK_PROF_DATA_INITIALIZER					\
+    {NSTIME_ZERO_INITIALIZER, NSTIME_ZERO_INITIALIZER, 0, 0, 0, 0, 0, NULL, 0}
 
 #ifdef _WIN32
 #  define MALLOC_MUTEX_INITIALIZER
 #elif (defined(JEMALLOC_OS_UNFAIR_LOCK))
 #  define MALLOC_MUTEX_INITIALIZER					\
-     {{{OS_UNFAIR_LOCK_INIT}}, WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
+     {{{LOCK_PROF_DATA_INITIALIZER, OS_UNFAIR_LOCK_INIT}},		\
+      WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #elif (defined(JEMALLOC_OSSPIN))
 #  define MALLOC_MUTEX_INITIALIZER					\
-     {{{0}}, WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
+     {{{LOCK_PROF_DATA_INITIALIZER, 0}},				\
+      WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #elif (defined(JEMALLOC_MUTEX_INIT_CB))
 #  define MALLOC_MUTEX_INITIALIZER					\
-     {{{PTHREAD_MUTEX_INITIALIZER, NULL}},				\
+     {{{LOCK_PROF_DATA_INITIALIZER, PTHREAD_MUTEX_INITIALIZER, NULL}},	\
       WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #else
+/* TODO: get rid of adaptive mutex once we do our own spin. */
 #  if (defined(JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP) &&		\
        defined(PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP))
 #    define MALLOC_MUTEX_TYPE PTHREAD_MUTEX_ADAPTIVE_NP
 #    define MALLOC_MUTEX_INITIALIZER					\
-       {{{PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP}},			\
+       {{{LOCK_PROF_DATA_INITIALIZER,					\
+          PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP}},			\
         WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #  else
 #    define MALLOC_MUTEX_TYPE PTHREAD_MUTEX_DEFAULT
 #    define MALLOC_MUTEX_INITIALIZER					\
-       {{{PTHREAD_MUTEX_INITIALIZER}},					\
+       {{{LOCK_PROF_DATA_INITIALIZER, PTHREAD_MUTEX_INITIALIZER}},	\
         WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #  endif
 #endif

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -34,7 +34,8 @@ typedef struct malloc_mutex_s malloc_mutex_t;
 #    define MALLOC_MUTEX_TRYLOCK(m) (pthread_mutex_trylock(&(m)->lock) != 0)
 #endif
 
-#define LOCK_PROF_DATA_INITIALIZER {0, 0, 0, 0, 0, 0, 0, NULL, 0}
+#define LOCK_PROF_DATA_INITIALIZER					\
+    {NSTIME_ZERO_INITIALIZER, NSTIME_ZERO_INITIALIZER, 0, 0, 0, 0, 0, NULL, 0}
 
 #ifdef _WIN32
 #  define MALLOC_MUTEX_INITIALIZER

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -4,6 +4,12 @@
 typedef struct mutex_prof_data_s mutex_prof_data_t;
 typedef struct malloc_mutex_s malloc_mutex_t;
 
+/*
+ * Based on benchmark results, a fixed spin with this amount of retries works
+ * well for our critical sections.
+ */
+#define MALLOC_MUTEX_MAX_SPIN 250
+
 #ifdef _WIN32
 #  if _WIN32_WINNT >= 0x0600
 #    define MALLOC_MUTEX_LOCK(m)    AcquireSRWLockExclusive(&(m)->lock)
@@ -45,20 +51,10 @@ typedef struct malloc_mutex_s malloc_mutex_t;
      {{{LOCK_PROF_DATA_INITIALIZER, PTHREAD_MUTEX_INITIALIZER, NULL}},	\
       WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
 #else
-/* TODO: get rid of adaptive mutex once we do our own spin. */
-#  if (defined(JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP) &&		\
-       defined(PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP))
-#    define MALLOC_MUTEX_TYPE PTHREAD_MUTEX_ADAPTIVE_NP
-#    define MALLOC_MUTEX_INITIALIZER					\
-       {{{LOCK_PROF_DATA_INITIALIZER,					\
-          PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP}},			\
-        WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
-#  else
 #    define MALLOC_MUTEX_TYPE PTHREAD_MUTEX_DEFAULT
 #    define MALLOC_MUTEX_INITIALIZER					\
        {{{LOCK_PROF_DATA_INITIALIZER, PTHREAD_MUTEX_INITIALIZER}},	\
         WITNESS_INITIALIZER("mutex", WITNESS_RANK_OMIT)}
-#  endif
 #endif
 
 #endif /* JEMALLOC_INTERNAL_MUTEX_TYPES_H */

--- a/include/jemalloc/internal/nstime_externs.h
+++ b/include/jemalloc/internal/nstime_externs.h
@@ -5,6 +5,7 @@ void	nstime_init(nstime_t *time, uint64_t ns);
 void	nstime_init2(nstime_t *time, uint64_t sec, uint64_t nsec);
 uint64_t	nstime_ns(const nstime_t *time);
 uint64_t	nstime_sec(const nstime_t *time);
+uint64_t	nstime_msec(const nstime_t *time);
 uint64_t	nstime_nsec(const nstime_t *time);
 void	nstime_copy(nstime_t *time, const nstime_t *source);
 int	nstime_compare(const nstime_t *a, const nstime_t *b);

--- a/include/jemalloc/internal/nstime_types.h
+++ b/include/jemalloc/internal/nstime_types.h
@@ -6,4 +6,6 @@ typedef struct nstime_s nstime_t;
 /* Maximum supported number of seconds (~584 years). */
 #define NSTIME_SEC_MAX	KQU(18446744072)
 
+#define NSTIME_ZERO_INITIALIZER {0}
+
 #endif /* JEMALLOC_INTERNAL_NSTIME_TYPES_H */

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -106,6 +106,7 @@ bootstrap_calloc
 bootstrap_free
 bootstrap_malloc
 bt_init
+bt2gctx_mtx
 buferror
 ckh_count
 ckh_delete

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -269,6 +269,7 @@ lg_floor
 lg_prof_sample
 malloc_cprintf
 malloc_getcpu
+malloc_mutex_prof_data_reset
 malloc_mutex_assert_not_owner
 malloc_mutex_assert_owner
 malloc_mutex_boot

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -273,6 +273,7 @@ malloc_mutex_assert_owner
 malloc_mutex_boot
 malloc_mutex_init
 malloc_mutex_lock
+malloc_mutex_lock_slow
 malloc_mutex_postfork_child
 malloc_mutex_postfork_parent
 malloc_mutex_prefork
@@ -302,6 +303,7 @@ nstime_imultiply
 nstime_init
 nstime_init2
 nstime_monotonic
+nstime_msec
 nstime_ns
 nstime_nsec
 nstime_sec

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -1,6 +1,8 @@
 #ifndef JEMALLOC_INTERNAL_PROF_EXTERNS_H
 #define JEMALLOC_INTERNAL_PROF_EXTERNS_H
 
+extern malloc_mutex_t	bt2gctx_mtx;
+
 extern bool	opt_prof;
 extern bool	opt_prof_active;
 extern bool	opt_prof_thread_active_init;

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -126,10 +126,12 @@ struct arena_stats_s {
 
 	mutex_prof_data_t large_mtx_data;
 	mutex_prof_data_t extent_freelist_mtx_data;
-	mutex_prof_data_t extents_cached_mtx_data;
+	mutex_prof_data_t extents_dirty_mtx_data;
+	mutex_prof_data_t extents_muzzy_mtx_data;
 	mutex_prof_data_t extents_retained_mtx_data;
-	mutex_prof_data_t decay_mtx_data;
-	mutex_prof_data_t tcache_mtx_data;
+	mutex_prof_data_t decay_dirty_mtx_data;
+	mutex_prof_data_t decay_muzzy_mtx_data;
+	mutex_prof_data_t tcache_list_mtx_data;
 
 	/* One element for each large size class. */
 	malloc_large_stats_t	lstats[NSIZES - NBINS];

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -124,14 +124,7 @@ struct arena_stats_s {
 	/* Number of bytes cached in tcache associated with this arena. */
 	atomic_zu_t		tcache_bytes; /* Derived. */
 
-	mutex_prof_data_t large_mtx_data;
-	mutex_prof_data_t extent_freelist_mtx_data;
-	mutex_prof_data_t extents_dirty_mtx_data;
-	mutex_prof_data_t extents_muzzy_mtx_data;
-	mutex_prof_data_t extents_retained_mtx_data;
-	mutex_prof_data_t decay_dirty_mtx_data;
-	mutex_prof_data_t decay_muzzy_mtx_data;
-	mutex_prof_data_t tcache_list_mtx_data;
+	mutex_prof_data_t mutex_prof_data[num_arena_prof_mutexes];
 
 	/* One element for each large size class. */
 	malloc_large_stats_t	lstats[NSIZES - NBINS];

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -124,6 +124,13 @@ struct arena_stats_s {
 	/* Number of bytes cached in tcache associated with this arena. */
 	atomic_zu_t		tcache_bytes; /* Derived. */
 
+	lock_prof_data_t large_mtx_data;
+	lock_prof_data_t extent_freelist_mtx_data;
+	lock_prof_data_t extents_cached_mtx_data;
+	lock_prof_data_t extents_retained_mtx_data;
+	lock_prof_data_t decay_mtx_data;
+	lock_prof_data_t tcache_mtx_data;
+
 	/* One element for each large size class. */
 	malloc_large_stats_t	lstats[NSIZES - NBINS];
 };

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -56,6 +56,8 @@ struct malloc_bin_stats_s {
 
 	/* Current number of slabs in this bin. */
 	size_t		curslabs;
+
+	lock_prof_data_t lock_data;
 };
 
 struct malloc_large_stats_s {

--- a/include/jemalloc/internal/stats_structs.h
+++ b/include/jemalloc/internal/stats_structs.h
@@ -57,7 +57,7 @@ struct malloc_bin_stats_s {
 	/* Current number of slabs in this bin. */
 	size_t		curslabs;
 
-	lock_prof_data_t lock_data;
+	mutex_prof_data_t mutex_data;
 };
 
 struct malloc_large_stats_s {
@@ -124,12 +124,12 @@ struct arena_stats_s {
 	/* Number of bytes cached in tcache associated with this arena. */
 	atomic_zu_t		tcache_bytes; /* Derived. */
 
-	lock_prof_data_t large_mtx_data;
-	lock_prof_data_t extent_freelist_mtx_data;
-	lock_prof_data_t extents_cached_mtx_data;
-	lock_prof_data_t extents_retained_mtx_data;
-	lock_prof_data_t decay_mtx_data;
-	lock_prof_data_t tcache_mtx_data;
+	mutex_prof_data_t large_mtx_data;
+	mutex_prof_data_t extent_freelist_mtx_data;
+	mutex_prof_data_t extents_cached_mtx_data;
+	mutex_prof_data_t extents_retained_mtx_data;
+	mutex_prof_data_t decay_mtx_data;
+	mutex_prof_data_t tcache_mtx_data;
 
 	/* One element for each large size class. */
 	malloc_large_stats_t	lstats[NSIZES - NBINS];

--- a/src/arena.c
+++ b/src/arena.c
@@ -298,9 +298,9 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 	}
 
 #define READ_ARENA_MUTEX_PROF_DATA(mtx, data)				\
-	malloc_mutex_lock(tsdn, &arena->mtx);				\
-	malloc_lock_prof_read(tsdn, &astats->data, &arena->mtx);	\
-	malloc_mutex_unlock(tsdn, &arena->mtx);
+    malloc_mutex_lock(tsdn, &arena->mtx);				\
+    malloc_lock_prof_read(tsdn, &astats->data, &arena->mtx);		\
+    malloc_mutex_unlock(tsdn, &arena->mtx);
 
 	/* Gather per arena mutex profiling data. */
 	READ_ARENA_MUTEX_PROF_DATA(large_mtx, large_mtx_data)

--- a/src/arena.c
+++ b/src/arena.c
@@ -292,28 +292,32 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 				    tbin->ncached * index2size(i));
 			}
 		}
-		malloc_mutex_prof_read(tsdn, &astats->tcache_list_mtx_data,
+		malloc_mutex_prof_read(tsdn,
+		    &astats->mutex_prof_data[arena_prof_mutex_tcache_list],
 		    &arena->tcache_ql_mtx);
 		malloc_mutex_unlock(tsdn, &arena->tcache_ql_mtx);
 	}
 
-#define READ_ARENA_MUTEX_PROF_DATA(mtx, data)				\
+#define READ_ARENA_MUTEX_PROF_DATA(mtx, ind)				\
     malloc_mutex_lock(tsdn, &arena->mtx);				\
-    malloc_mutex_prof_read(tsdn, &astats->data, &arena->mtx);		\
+    malloc_mutex_prof_read(tsdn, &astats->mutex_prof_data[ind],		\
+        &arena->mtx);							\
     malloc_mutex_unlock(tsdn, &arena->mtx);
 
 	/* Gather per arena mutex profiling data. */
-	READ_ARENA_MUTEX_PROF_DATA(large_mtx, large_mtx_data)
+	READ_ARENA_MUTEX_PROF_DATA(large_mtx, arena_prof_mutex_large);
 	READ_ARENA_MUTEX_PROF_DATA(extent_freelist_mtx,
-	    extent_freelist_mtx_data)
+	    arena_prof_mutex_extent_freelist)
 	READ_ARENA_MUTEX_PROF_DATA(extents_dirty.mtx,
-	    extents_dirty_mtx_data)
+	    arena_prof_mutex_extents_dirty)
 	READ_ARENA_MUTEX_PROF_DATA(extents_muzzy.mtx,
-	    extents_muzzy_mtx_data)
+	    arena_prof_mutex_extents_muzzy)
 	READ_ARENA_MUTEX_PROF_DATA(extents_retained.mtx,
-	    extents_retained_mtx_data)
-	READ_ARENA_MUTEX_PROF_DATA(decay_dirty.mtx, decay_dirty_mtx_data)
-	READ_ARENA_MUTEX_PROF_DATA(decay_muzzy.mtx, decay_muzzy_mtx_data)
+	    arena_prof_mutex_extents_retained)
+	READ_ARENA_MUTEX_PROF_DATA(decay_dirty.mtx,
+	    arena_prof_mutex_decay_dirty)
+	READ_ARENA_MUTEX_PROF_DATA(decay_muzzy.mtx,
+	    arena_prof_mutex_decay_muzzy)
 #undef READ_ARENA_MUTEX_PROF_DATA
 
 	for (szind_t i = 0; i < NBINS; i++) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -318,6 +318,8 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 	    arena_prof_mutex_decay_dirty)
 	READ_ARENA_MUTEX_PROF_DATA(decay_muzzy.mtx,
 	    arena_prof_mutex_decay_muzzy)
+	READ_ARENA_MUTEX_PROF_DATA(base->mtx,
+	    arena_prof_mutex_base)
 #undef READ_ARENA_MUTEX_PROF_DATA
 
 	for (szind_t i = 0; i < NBINS; i++) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -299,6 +299,7 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 		arena_bin_t *bin = &arena->bins[i];
 
 		malloc_mutex_lock(tsdn, &bin->lock);
+		malloc_lock_prof_read(tsdn, &bstats[i].lock_data, &bin->lock);
 		bstats[i].nmalloc += bin->stats.nmalloc;
 		bstats[i].ndalloc += bin->stats.ndalloc;
 		bstats[i].nrequests += bin->stats.nrequests;

--- a/src/arena.c
+++ b/src/arena.c
@@ -292,7 +292,7 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 				    tbin->ncached * index2size(i));
 			}
 		}
-		malloc_mutex_prof_read(tsdn, &astats->tcache_mtx_data,
+		malloc_mutex_prof_read(tsdn, &astats->tcache_list_mtx_data,
 		    &arena->tcache_ql_mtx);
 		malloc_mutex_unlock(tsdn, &arena->tcache_ql_mtx);
 	}
@@ -306,11 +306,14 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 	READ_ARENA_MUTEX_PROF_DATA(large_mtx, large_mtx_data)
 	READ_ARENA_MUTEX_PROF_DATA(extent_freelist_mtx,
 	    extent_freelist_mtx_data)
-	READ_ARENA_MUTEX_PROF_DATA(extents_cached.mtx,
-	    extents_cached_mtx_data)
+	READ_ARENA_MUTEX_PROF_DATA(extents_dirty.mtx,
+	    extents_dirty_mtx_data)
+	READ_ARENA_MUTEX_PROF_DATA(extents_muzzy.mtx,
+	    extents_muzzy_mtx_data)
 	READ_ARENA_MUTEX_PROF_DATA(extents_retained.mtx,
 	    extents_retained_mtx_data)
-	READ_ARENA_MUTEX_PROF_DATA(decay.mtx, decay_mtx_data)
+	READ_ARENA_MUTEX_PROF_DATA(decay_dirty.mtx, decay_dirty_mtx_data)
+	READ_ARENA_MUTEX_PROF_DATA(decay_muzzy.mtx, decay_muzzy_mtx_data)
 #undef READ_ARENA_MUTEX_PROF_DATA
 
 	for (szind_t i = 0; i < NBINS; i++) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -292,14 +292,14 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 				    tbin->ncached * index2size(i));
 			}
 		}
-		malloc_lock_prof_read(tsdn, &astats->tcache_mtx_data,
+		malloc_mutex_prof_read(tsdn, &astats->tcache_mtx_data,
 		    &arena->tcache_ql_mtx);
 		malloc_mutex_unlock(tsdn, &arena->tcache_ql_mtx);
 	}
 
 #define READ_ARENA_MUTEX_PROF_DATA(mtx, data)				\
     malloc_mutex_lock(tsdn, &arena->mtx);				\
-    malloc_lock_prof_read(tsdn, &astats->data, &arena->mtx);		\
+    malloc_mutex_prof_read(tsdn, &astats->data, &arena->mtx);		\
     malloc_mutex_unlock(tsdn, &arena->mtx);
 
 	/* Gather per arena mutex profiling data. */
@@ -317,7 +317,7 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 		arena_bin_t *bin = &arena->bins[i];
 
 		malloc_mutex_lock(tsdn, &bin->lock);
-		malloc_lock_prof_read(tsdn, &bstats[i].lock_data, &bin->lock);
+		malloc_mutex_prof_read(tsdn, &bstats[i].mutex_data, &bin->lock);
 		bstats[i].nmalloc += bin->stats.nmalloc;
 		bstats[i].ndalloc += bin->stats.ndalloc;
 		bstats[i].nrequests += bin->stats.nrequests;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2485,9 +2485,9 @@ CTL_RO_CGEN(config_stats, stats_##n##_num_spin_acq,			\
 CTL_RO_CGEN(config_stats, stats_##n##_num_owner_switch,			\
     l.n_owner_switches, uint64_t) 					\
 CTL_RO_CGEN(config_stats, stats_##n##_total_wait_time,			\
-    l.tot_wait_time, uint64_t)						\
+    nstime_ns(&l.tot_wait_time), uint64_t)				\
 CTL_RO_CGEN(config_stats, stats_##n##_max_wait_time,			\
-    l.max_wait_time, uint64_t)						\
+    nstime_ns(&l.max_wait_time), uint64_t)				\
 CTL_RO_CGEN(config_stats, stats_##n##_max_num_thds,			\
     l.max_n_thds, uint64_t)
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -912,8 +912,6 @@ ctl_refresh(tsdn_t *tsdn) {
     malloc_mutex_prof_read(tsdn, &ctl_stats->mutex_prof_data[i], &mtx);	\
     malloc_mutex_unlock(tsdn, &mtx);
 
-		READ_GLOBAL_MUTEX_PROF_DATA(global_prof_mutex_base,
-		    b0get()->mtx);
 		if (config_prof && opt_prof) {
 			READ_GLOBAL_MUTEX_PROF_DATA(global_prof_mutex_prof,
 			    bt2gctx_mtx);
@@ -2460,12 +2458,12 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     malloc_mutex_prof_data_reset(tsdn, &mtx);				\
     malloc_mutex_unlock(tsdn, &mtx);
 
-	/* Global mutexes: base, prof and ctl. */
-	MUTEX_PROF_RESET(b0get()->mtx);
+	/* Global mutexes: ctl and prof. */
+	MUTEX_PROF_RESET(ctl_mtx);
 	if (config_prof && opt_prof) {
 		MUTEX_PROF_RESET(bt2gctx_mtx);
 	}
-	MUTEX_PROF_RESET(ctl_mtx);
+
 
 	/* Per arena mutexes. */
 	unsigned n = narenas_total_get();
@@ -2485,6 +2483,7 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 		if (config_tcache) {
 			MUTEX_PROF_RESET(arena->tcache_ql_mtx);
 		}
+		MUTEX_PROF_RESET(arena->base->mtx);
 
 		for (szind_t i = 0; i < NBINS; i++) {
 			arena_bin_t *bin = &arena->bins[i];

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -960,7 +960,9 @@ ctl_refresh(tsdn_t *tsdn) {
     malloc_mutex_unlock(tsdn, &mtx);
 
 		READ_GLOBAL_MUTEX_PROF_DATA(b0get()->mtx, base_mtx_data);
-		READ_GLOBAL_MUTEX_PROF_DATA(bt2gctx_mtx, prof_mtx_data);
+		if (config_prof && opt_prof) {
+			READ_GLOBAL_MUTEX_PROF_DATA(bt2gctx_mtx, prof_mtx_data);
+		}
 		/* We own ctl mutex already. */
 		malloc_lock_prof_read(tsdn, &ctl_stats->ctl_mtx_data, &ctl_mtx);
 #undef READ_GLOBAL_MUTEX_PROF_DATA

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -145,6 +145,7 @@ CTL_PROTO(stats_arenas_i_bins_j_nflushes)
 CTL_PROTO(stats_arenas_i_bins_j_nslabs)
 CTL_PROTO(stats_arenas_i_bins_j_nreslabs)
 CTL_PROTO(stats_arenas_i_bins_j_curslabs)
+CTL_PROTO(stats_arenas_i_bins_j_lock_data)
 INDEX_PROTO(stats_arenas_i_bins_j)
 CTL_PROTO(stats_arenas_i_lextents_j_nmalloc)
 CTL_PROTO(stats_arenas_i_lextents_j_ndalloc)
@@ -357,7 +358,8 @@ static const ctl_named_node_t stats_arenas_i_bins_j_node[] = {
 	{NAME("nflushes"),	CTL(stats_arenas_i_bins_j_nflushes)},
 	{NAME("nslabs"),	CTL(stats_arenas_i_bins_j_nslabs)},
 	{NAME("nreslabs"),	CTL(stats_arenas_i_bins_j_nreslabs)},
-	{NAME("curslabs"),	CTL(stats_arenas_i_bins_j_curslabs)}
+	{NAME("curslabs"),	CTL(stats_arenas_i_bins_j_curslabs)},
+	{NAME("lock_data"),	CTL(stats_arenas_i_bins_j_lock_data)}
 };
 static const ctl_named_node_t super_stats_arenas_i_bins_j_node[] = {
 	{NAME(""),		CHILD(named, stats_arenas_i_bins_j)}
@@ -726,6 +728,8 @@ ctl_arena_stats_sdmerge(ctl_arena_t *ctl_sdarena, ctl_arena_t *ctl_arena,
 			} else {
 				assert(astats->bstats[i].curslabs == 0);
 			}
+			malloc_lock_prof_merge(&sdstats->bstats[i].lock_data,
+			    &astats->bstats[i].lock_data);
 		}
 
 		for (i = 0; i < NSIZES - NBINS; i++) {
@@ -2333,6 +2337,8 @@ CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_nreslabs,
     arenas_i(mib[2])->astats->bstats[mib[4]].reslabs, uint64_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_curslabs,
     arenas_i(mib[2])->astats->bstats[mib[4]].curslabs, size_t)
+CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_lock_data,
+    arenas_i(mib[2])->astats->bstats[mib[4]].lock_data, lock_prof_data_t)
 
 static const ctl_named_node_t *
 stats_arenas_i_bins_j_index(tsdn_t *tsdn, const size_t *mib, size_t miblen,

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -67,7 +67,7 @@ JEMALLOC_EXPORT int	_pthread_mutex_init_calloc_cb(pthread_mutex_t *mutex,
 
 void
 malloc_mutex_lock_slow(malloc_mutex_t *mutex) {
-	lock_prof_data_t *data = &mutex->prof_data;
+	mutex_prof_data_t *data = &mutex->prof_data;
 
 	{//TODO: a smart spin policy
 		if (!malloc_mutex_trylock(mutex)) {
@@ -108,15 +108,21 @@ malloc_mutex_lock_slow(malloc_mutex_t *mutex) {
 }
 
 static void
-lock_prof_data_init(lock_prof_data_t *data) {
-	memset(data, 0, sizeof(lock_prof_data_t));
+mutex_prof_data_init(mutex_prof_data_t *data) {
+	memset(data, 0, sizeof(mutex_prof_data_t));
 	data->prev_owner = NULL;
+}
+
+void
+malloc_mutex_prof_data_reset(tsdn_t *tsdn, malloc_mutex_t *mutex) {
+	malloc_mutex_assert_owner(tsdn, mutex);
+	mutex_prof_data_init(&mutex->prof_data);
 }
 
 bool
 malloc_mutex_init(malloc_mutex_t *mutex, const char *name,
     witness_rank_t rank) {
-	lock_prof_data_init(&mutex->prof_data);
+	mutex_prof_data_init(&mutex->prof_data);
 #ifdef _WIN32
 #  if _WIN32_WINNT >= 0x0600
 	InitializeSRWLock(&mutex->lock);

--- a/src/nstime.c
+++ b/src/nstime.c
@@ -1,6 +1,7 @@
 #include "jemalloc/internal/jemalloc_internal.h"
 
 #define BILLION	UINT64_C(1000000000)
+#define MILLION	UINT64_C(1000000)
 
 void
 nstime_init(nstime_t *time, uint64_t ns) {
@@ -15,6 +16,11 @@ nstime_init2(nstime_t *time, uint64_t sec, uint64_t nsec) {
 uint64_t
 nstime_ns(const nstime_t *time) {
 	return time->ns;
+}
+
+uint64_t
+nstime_msec(const nstime_t *time) {
+	return time->ns / MILLION;
 }
 
 uint64_t

--- a/src/prof.c
+++ b/src/prof.c
@@ -78,7 +78,8 @@ static malloc_mutex_t	*tdata_locks;
  * structure that knows about all backtraces currently captured.
  */
 static ckh_t		bt2gctx;
-static malloc_mutex_t	bt2gctx_mtx;
+/* Non static to enable profiling. */
+malloc_mutex_t		bt2gctx_mtx;
 
 /*
  * Tree of all extant prof_tdata_t structures, regardless of state,

--- a/test/unit/stats_print.c
+++ b/test/unit/stats_print.c
@@ -938,11 +938,16 @@ TEST_BEGIN(test_stats_print_json) {
 		"Ja",
 		"Jb",
 		"Jl",
+		"Jx",
 		"Jbl",
 		"Jal",
 		"Jab",
 		"Jabl",
-		"Jgmdabl",
+		"Jax",
+		"Jbx",
+		"Jlx",
+		"Jablx",
+		"Jgmdablx",
 	};
 	unsigned arena_ind, i;
 


### PR DESCRIPTION
Add mutex profiling for a number of mutexes:
Global mtx: ```ctl``` and ```prof```
per arena mtx: 
```
"large",
"extent_freelist",
"extents_dirty",
"extents_muzzy",   
"extents_retained",
"decay_dirty",
"decay_muzzy",
"tcache_list",
"base" 
```
and  ```bin mtx```.

Also, added our own spinning with a fixed spin upper bound.

This resolves #574.