### PR TITLE
Extent layout

### DIFF
--- a/include/jemalloc/internal/extent_inlines.h
+++ b/include/jemalloc/internal/extent_inlines.h
@@ -49,7 +49,7 @@ int extent_snad_comp(const extent_t *a, const extent_t *b);
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_EXTENT_C_))
 JEMALLOC_INLINE arena_t *
 extent_arena_get(const extent_t *extent) {
-	return extent->e_arena;
+	return arenas[extent->e_arena_ind];
 }
 
 JEMALLOC_INLINE void *
@@ -151,7 +151,7 @@ extent_prof_tctx_get(const extent_t *extent) {
 
 JEMALLOC_INLINE void
 extent_arena_set(extent_t *extent, arena_t *arena) {
-	extent->e_arena = arena;
+	extent->e_arena_ind = (arena != NULL) ? arena_ind_get(arena) : UINT_MAX;
 }
 
 JEMALLOC_INLINE void

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -10,8 +10,8 @@ typedef enum {
 
 /* Extent (span of pages).  Use accessor functions for e_* fields. */
 struct extent_s {
-	/* Arena from which this extent came, if any. */
-	arena_t			*e_arena;
+	/* Arena from which this extent came, or UINT_MAX if unassociated. */
+	unsigned		e_arena_ind;
 
 	/* Pointer to the extent that this structure is responsible for. */
 	void			*e_addr;

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -932,7 +932,6 @@ decay_ticker_get(tsd_t *tsd, unsigned ind) {
 }
 #endif
 
-#include "jemalloc/internal/extent_inlines.h"
 #include "jemalloc/internal/rtree_inlines.h"
 #include "jemalloc/internal/base_inlines.h"
 #include "jemalloc/internal/bitmap_inlines.h"
@@ -942,6 +941,7 @@ decay_ticker_get(tsd_t *tsd, unsigned ind) {
  */
 #include "jemalloc/internal/prof_inlines_a.h"
 #include "jemalloc/internal/arena_inlines_a.h"
+#include "jemalloc/internal/extent_inlines.h"
 
 #ifndef JEMALLOC_ENABLE_INLINE
 extent_t	*iealloc(tsdn_t *tsdn, const void *ptr);


### PR DESCRIPTION
These changes relate to #461, and compact ```extent_t``` to 136 bytes.  I see a few options for reaching 128 bytes, but I'm not very excited about any of them:
- Remove the ```nfree``` field from ```arena_slab_data_t```, and use inherently slower bitmap operations to detect edge conditions.
- Move the ```nfree``` field from ```arena_slab_data_t``` into ```extent_t```'s ```e_bits``` (and reduce the serial number range to 31 bits).  This feels like a layering violation.
- Overlay ```extent_t```'s ```e_size``` field with ```e_slab_data```, and use the ```szind``` bits to track size when in the slab state.  I experimented with this, and it's tricky enough to get the state transitions right that we'd need to change the extent getter/setter API to make inconsistent transitions impossible.