### PR TITLE
Fix BITMAP_USE_TREE version of bitmap_ffu().

### DIFF
--- a/include/jemalloc/internal/bitmap_inlines.h
+++ b/include/jemalloc/internal/bitmap_inlines.h
@@ -112,6 +112,19 @@ bitmap_ffu(const bitmap_t *bitmap, const bitmap_info_t *binfo, size_t min_bit) {
 			group &= group_mask;
 		}
 		if (group == 0LU) {
+			/*
+			 * If min_bit is not the first bit in its group, try
+			 * again starting at the first bit of the next group.
+			 * This will only recurse at most once, since on
+			 * recursion, min_bit will be the first bit in its
+			 * group.
+			 */
+			size_t ceil_min_bit = (min_bit +
+			    BITMAP_GROUP_NBITS_MASK) & ~BITMAP_GROUP_NBITS_MASK;
+			if (ceil_min_bit != min_bit && ceil_min_bit <
+			    binfo->nbits) {
+				return bitmap_ffu(bitmap, binfo, ceil_min_bit);
+			}
 			return binfo->nbits;
 		}
 		bit = (bit << LG_BITMAP_GROUP_NBITS) + (ffs_lu(group) - 1);


### PR DESCRIPTION
This fixes an extent searching regression on 32-bit systems, caused by
the initial bitmap_ffu() implementation in
c8021d01f6efe14dc1bd200021a815638063cb5f (Implement bitmap_ffu(), which
finds the first unset bit.), as first used in
5d33233a5e6601902df7cddd8cc8aa0b135c77b2 (Use a bitmap in extents_t to
speed up search.).