### PR TITLE
Fix a race in rtree_szind_slab_update() for RTREE_LEAF_COMPACT.

### DIFF
--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -439,6 +439,7 @@ rtree_leaf_elm_release
 rtree_leaf_elm_slab_read
 rtree_leaf_elm_slab_write
 rtree_leaf_elm_szind_read
+rtree_leaf_elm_szind_slab_update
 rtree_leaf_elm_szind_write
 rtree_leaf_elm_witness_access
 rtree_leaf_elm_witness_acquire


### PR DESCRIPTION
This fixes a race that does not currently cause problems in practice, other than to cause intermittent assertion failures when clobbering the lock bit.