### PR TITLE
Remove the leafkey NULL check in leaf_elm_lookup.

### DIFF
--- a/include/jemalloc/internal/rtree_inlines.h
+++ b/include/jemalloc/internal/rtree_inlines.h
@@ -324,19 +324,15 @@ rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 #define RTREE_CACHE_CHECK(i) do {					\
 	if (likely(rtree_ctx->cache[i].leafkey == leafkey)) {		\
 		rtree_leaf_elm_t *leaf = rtree_ctx->cache[i].leaf;	\
-		if (likely(leaf != NULL)) {				\
+		assert(leaf != NULL);					\
+		if (i > 0) {						\
 			/* Bubble up by one. */				\
-			if (i > 0) {					\
-				rtree_ctx->cache[i] =			\
-					rtree_ctx->cache[i - 1];	\
-				rtree_ctx->cache[i - 1].leafkey =	\
-					leafkey;			\
-				rtree_ctx->cache[i - 1].leaf = leaf;	\
-			}						\
-			uintptr_t subkey = rtree_subkey(key,		\
-			    RTREE_HEIGHT-1);				\
-			return &leaf[subkey];				\
+			rtree_ctx->cache[i] = rtree_ctx->cache[i - 1];	\
+			rtree_ctx->cache[i - 1].leafkey = leafkey;	\
+			rtree_ctx->cache[i - 1].leaf = leaf;		\
 		}							\
+		uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);	\
+		return &leaf[subkey];					\
 	}								\
 } while (0)
 	/* Check the first cache entry. */

--- a/include/jemalloc/internal/rtree_types.h
+++ b/include/jemalloc/internal/rtree_types.h
@@ -39,7 +39,7 @@ typedef struct rtree_s rtree_t;
 #endif
 
 /* Needed for initialization only. */
-#define RTREE_LEAFKEY_INVALID	((uintptr_t)1)
+#define RTREE_LEAFKEY_INVALID ((uintptr_t)1)
 
 /*
  * Number of leafkey/leaf pairs to cache.  Each entry supports an entire leaf,
@@ -54,7 +54,7 @@ typedef struct rtree_s rtree_t;
  * the tree nodes, and the cache will itself suffer cache misses if made overly
  * large, not to mention the cost of linear search.
  */
-#define RTREE_CTX_NCACHE	8
+#define RTREE_CTX_NCACHE 8
 
 /*
  * Zero initializer required for tsd initialization only.  Proper initialization
@@ -68,7 +68,7 @@ typedef struct rtree_s rtree_t;
  * would have a witness_t directly embedded, but that would dramatically bloat
  * the tree.  This must contain enough entries to e.g. coalesce two extents.
  */
-#define RTREE_ELM_ACQUIRE_MAX	4
+#define RTREE_ELM_ACQUIRE_MAX 4
 
 /* Initializers for rtree_leaf_elm_witness_tsd_t. */
 #define RTREE_ELM_WITNESS_INITIALIZER {					\


### PR DESCRIPTION
This gets rid of a branch on rcache lookup. u-benchmark shows a ~2% improvement. 