### PR TITLE
Basic reentrancy support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -98,6 +98,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/extent_dss.c \
 	$(srcroot)src/extent_mmap.c \
 	$(srcroot)src/hash.c \
+	$(srcroot)src/hooks.c \
 	$(srcroot)src/large.c \
 	$(srcroot)src/malloc_io.c \
 	$(srcroot)src/mutex.c \
@@ -161,6 +162,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/extent_quantize.c \
 	$(srcroot)test/unit/fork.c \
 	$(srcroot)test/unit/hash.c \
+	$(srcroot)test/unit/hooks.c \
 	$(srcroot)test/unit/junk.c \
 	$(srcroot)test/unit/junk_alloc.c \
 	$(srcroot)test/unit/junk_free.c \

--- a/include/jemalloc/internal/hooks.h
+++ b/include/jemalloc/internal/hooks.h
@@ -1,8 +1,8 @@
 #ifndef JEMALLOC_INTERNAL_HOOKS_H
 #define JEMALLOC_INTERNAL_HOOKS_H
 
-extern void (*hooks_arena_new_hook)();
-extern void (*hooks_libc_hook)();
+extern JEMALLOC_EXPORT void (*hooks_arena_new_hook)();
+extern JEMALLOC_EXPORT void (*hooks_libc_hook)();
 
 #define JEMALLOC_HOOK(fn, hook) ((void)(hook != NULL && (hook(), 0)), fn)
 

--- a/include/jemalloc/internal/hooks.h
+++ b/include/jemalloc/internal/hooks.h
@@ -1,0 +1,19 @@
+#ifndef JEMALLOC_INTERNAL_HOOKS_H
+#define JEMALLOC_INTERNAL_HOOKS_H
+
+extern void (*hooks_arena_new_hook)();
+extern void (*hooks_libc_hook)();
+
+#define JEMALLOC_HOOK(fn, hook) ((void)(hook != NULL && (hook(), 0)), fn)
+
+#define open JEMALLOC_HOOK(open, hooks_libc_hook)
+#define read JEMALLOC_HOOK(read, hooks_libc_hook)
+#define write JEMALLOC_HOOK(write, hooks_libc_hook)
+#define readlink JEMALLOC_HOOK(readlink, hooks_libc_hook)
+#define close JEMALLOC_HOOK(close, hooks_libc_hook)
+#define creat JEMALLOC_HOOK(creat, hooks_libc_hook)
+#define secure_getenv JEMALLOC_HOOK(secure_getenv, hooks_libc_hook)
+/* Note that this is undef'd and re-define'd in src/prof.c. */
+#define _Unwind_Backtrace JEMALLOC_HOOK(_Unwind_Backtrace, hooks_libc_hook)
+
+#endif /* JEMALLOC_INTERNAL_HOOKS_H */

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -23,7 +23,14 @@ extern "C" {
 #  define JEMALLOC_N(n) @private_namespace@##n
 #  include "../jemalloc@install_suffix@.h"
 #endif
+
+/*
+ * Note that the ordering matters here; the hook itself is name-mangled.  We
+ * want the inclusion of hooks to happen early, so that we hook as much as
+ * possible.
+ */
 #include "jemalloc/internal/private_namespace.h"
+#include "jemalloc/internal/hooks.h"
 
 static const bool config_debug =
 #ifdef JEMALLOC_DEBUG

--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -998,6 +998,11 @@ arena_choose_impl(tsd_t *tsd, arena_t *arena, bool internal) {
 		return arena;
 	}
 
+	/* During reentrancy, arena 0 is the safest bet. */
+	if (*tsd_reentrancy_levelp_get(tsd) > 1) {
+		return arena_get(tsd_tsdn(tsd), 0, true);
+	}
+
 	ret = internal ? tsd_iarena_get(tsd) : tsd_arena_get(tsd);
 	if (unlikely(ret == NULL)) {
 		ret = arena_choose_hard(tsd, internal);
@@ -1178,7 +1183,9 @@ idalloctm(tsdn_t *tsdn, void *ptr, tcache_t *tcache, bool is_internal,
 	if (config_stats && is_internal) {
 		arena_internal_sub(iaalloc(tsdn, ptr), isalloc(tsdn, ptr));
 	}
-
+	if (!is_internal && *tsd_reentrancy_levelp_get(tsdn_tsd(tsdn)) != 0) {
+		tcache = NULL;
+	}
 	arena_dalloc(tsdn, ptr, tcache, slow_path);
 }
 

--- a/include/jemalloc/internal/malloc_io.h
+++ b/include/jemalloc/internal/malloc_io.h
@@ -56,7 +56,7 @@ size_t malloc_snprintf(char *str, size_t size, const char *format, ...)
     JEMALLOC_FORMAT_PRINTF(3, 4);
 void malloc_vcprintf(void (*write_cb)(void *, const char *), void *cbopaque,
     const char *format, va_list ap);
-void malloc_cprintf(void (*write)(void *, const char *), void *cbopaque,
+void malloc_cprintf(void (*write_cb)(void *, const char *), void *cbopaque,
     const char *format, ...) JEMALLOC_FORMAT_PRINTF(3, 4);
 void malloc_printf(const char *format, ...) JEMALLOC_FORMAT_PRINTF(1, 2);
 

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -232,6 +232,7 @@ hash_rotl_64
 hash_x64_128
 hash_x86_128
 hash_x86_32
+hooks_arena_new_hook
 hooks_libc_hook
 iaalloc
 ialloc
@@ -537,6 +538,9 @@ tsd_init_head
 tsd_narenas_tdata_get
 tsd_narenas_tdata_set
 tsd_narenas_tdatap_get
+tsd_reentrancy_level_get
+tsd_reentrancy_level_set
+tsd_reentrancy_levelp_get
 tsd_wrapper_get
 tsd_wrapper_set
 tsd_nominal

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -232,6 +232,7 @@ hash_rotl_64
 hash_x64_128
 hash_x86_128
 hash_x86_32
+hooks_libc_hook
 iaalloc
 ialloc
 iallocztm

--- a/include/jemalloc/internal/stats_externs.h
+++ b/include/jemalloc/internal/stats_externs.h
@@ -3,7 +3,7 @@
 
 extern bool	opt_stats_print;
 
-void	stats_print(void (*write)(void *, const char *), void *cbopaque,
+void	stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
     const char *opts);
 
 #endif /* JEMALLOC_INTERNAL_STATS_EXTERNS_H */

--- a/include/jemalloc/internal/tsd_structs.h
+++ b/include/jemalloc/internal/tsd_structs.h
@@ -30,7 +30,8 @@ struct tsd_init_head_s {
     O(witnesses,		witness_list_t,	no,	no,	yes)	\
     O(rtree_leaf_elm_witnesses,	rtree_leaf_elm_witness_tsd_t,		\
 						no,	no,	no)	\
-    O(witness_fork,		bool,		yes,	no,	no)
+    O(witness_fork,		bool,		yes,	no,	no)	\
+    O(reentrancy_level,		int,		no,	no,	no)
 
 #define TSD_INITIALIZER {						\
     tsd_state_uninitialized,						\
@@ -47,7 +48,8 @@ struct tsd_init_head_s {
     RTREE_CTX_ZERO_INITIALIZER,						\
     ql_head_initializer(witnesses),					\
     RTREE_ELM_WITNESS_TSD_INITIALIZER,					\
-    false								\
+    false,								\
+    0									\
 }
 
 struct tsd_s {

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -1,0 +1,12 @@
+#include "jemalloc/internal/jemalloc_internal.h"
+
+/*
+ * The hooks are a little bit screwy -- they're not genuinely exported in the
+ * sense that we want them available to end-users, but we do want them visible
+ * from outside the generated library, so that we can use them in test code.
+ */
+JEMALLOC_EXPORT
+void (*hooks_arena_new_hook)() = NULL;
+
+JEMALLOC_EXPORT
+void (*hooks_libc_hook)() = NULL;

--- a/src/prof.c
+++ b/src/prof.c
@@ -8,7 +8,14 @@
 #endif
 
 #ifdef JEMALLOC_PROF_LIBGCC
+/*
+ * We have a circular dependency -- jemalloc_internal.h tells us if we should
+ * use libgcc's unwinding functionality, but after we've included that, we've
+ * already hooked _Unwind_Backtrace.  We'll temporarily disable hooking.
+ */
+#undef _Unwind_Backtrace
 #include <unwind.h>
+#define _Unwind_Backtrace JEMALLOC_HOOK(_Unwind_Backtrace, hooks_libc_hook)
 #endif
 
 /******************************************************************************/

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -149,6 +149,15 @@ _tls_callback(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
 	return true;
 }
 
+/*
+ * We need to be able to say "read" here (in the "pragma section"), but have
+ * hooked "read". We won't read for the rest of the file, so we can get away
+ * with unhooking.
+ */
+#ifdef read
+#  undef read
+#endif
+
 #ifdef _MSC_VER
 #  ifdef _M_IX86
 #    pragma comment(linker, "/INCLUDE:__tls_used")

--- a/test/include/test/jemalloc_test.h.in
+++ b/test/include/test/jemalloc_test.h.in
@@ -45,6 +45,7 @@ extern "C" {
 #  define JEMALLOC_MANGLE
 #  include "jemalloc/internal/jemalloc_internal.h"
 
+
 /******************************************************************************/
 /*
  * For integration tests, expose the public jemalloc interfaces, but only
@@ -68,6 +69,7 @@ static const bool config_debug =
 
 #  define JEMALLOC_N(n) @private_namespace@##n
 #  include "jemalloc/internal/private_namespace.h"
+#  include "jemalloc/internal/hooks.h"
 
 /* Hermetic headers. */
 #  include "jemalloc/internal/assert.h"

--- a/test/include/test/test.h
+++ b/test/include/test/test.h
@@ -310,6 +310,9 @@ label_test_end:								\
 #define test(...)							\
 	p_test(__VA_ARGS__, NULL)
 
+#define test_no_reentrancy(...)							\
+	p_test_no_reentrancy(__VA_ARGS__, NULL)
+
 #define test_no_malloc_init(...)					\
 	p_test_no_malloc_init(__VA_ARGS__, NULL)
 
@@ -321,11 +324,14 @@ label_test_end:								\
 	}								\
 } while (0)
 
+bool test_is_reentrant();
+
 void	test_skip(const char *format, ...) JEMALLOC_FORMAT_PRINTF(1, 2);
 void	test_fail(const char *format, ...) JEMALLOC_FORMAT_PRINTF(1, 2);
 
 /* For private use by macros. */
 test_status_t	p_test(test_t *t, ...);
+test_status_t	p_test_no_reentrancy(test_t *t, ...);
 test_status_t	p_test_no_malloc_init(test_t *t, ...);
 void	p_test_init(const char *name);
 void	p_test_fini(void);

--- a/test/stress/microbench.c
+++ b/test/stress/microbench.c
@@ -156,7 +156,7 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_malloc_vs_mallocx,
 	    test_free_vs_dallocx,
 	    test_dallocx_vs_sdallocx,

--- a/test/unit/hooks.c
+++ b/test/unit/hooks.c
@@ -1,0 +1,38 @@
+#include "test/jemalloc_test.h"
+
+static bool hook_called = false;
+
+static void
+hook() {
+	hook_called = true;
+}
+
+static int
+func_to_hook(int arg1, int arg2) {
+	return arg1 + arg2;
+}
+
+#define func_to_hook JEMALLOC_HOOK(func_to_hook, hooks_libc_hook)
+
+TEST_BEGIN(unhooked_call) {
+	hooks_libc_hook = NULL;
+	hook_called = false;
+	assert_d_eq(3, func_to_hook(1, 2), "Hooking changed return value.");
+	assert_false(hook_called, "Nulling out hook didn't take.");
+}
+TEST_END
+
+TEST_BEGIN(hooked_call) {
+	hooks_libc_hook = &hook;
+	hook_called = false;
+	assert_d_eq(3, func_to_hook(1, 2), "Hooking changed return value.");
+	assert_true(hook_called, "Hook should have executed.");
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    unhooked_call,
+	    hooked_call);
+}

--- a/test/unit/prof_accum.c
+++ b/test/unit/prof_accum.c
@@ -76,6 +76,6 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_idump);
 }

--- a/test/unit/prof_active.c
+++ b/test/unit/prof_active.c
@@ -112,6 +112,6 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_prof_active);
 }

--- a/test/unit/prof_gdump.c
+++ b/test/unit/prof_gdump.c
@@ -69,6 +69,6 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_gdump);
 }

--- a/test/unit/prof_reset.c
+++ b/test/unit/prof_reset.c
@@ -278,7 +278,7 @@ main(void) {
 	/* Intercept dumping prior to running any tests. */
 	prof_dump_open = prof_dump_open_intercept;
 
-	return test(
+	return test_no_reentrancy(
 	    test_prof_reset_basic,
 	    test_prof_reset_cleanup,
 	    test_prof_reset,

--- a/test/unit/prof_tctx.c
+++ b/test/unit/prof_tctx.c
@@ -41,6 +41,6 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_prof_realloc);
 }

--- a/test/unit/stats.c
+++ b/test/unit/stats.c
@@ -351,7 +351,7 @@ TEST_END
 
 int
 main(void) {
-	return test(
+	return test_no_reentrancy(
 	    test_stats_summary,
 	    test_stats_large,
 	    test_stats_arenas_summary,

--- a/test/unit/tsd.c
+++ b/test/unit/tsd.c
@@ -79,7 +79,6 @@ thd_start(void *arg) {
 }
 
 TEST_BEGIN(test_tsd_main_thread) {
-	test_skip_if(test_is_reentrant());
 	thd_start((void *)(uintptr_t)0xa5f3e329);
 }
 TEST_END
@@ -144,7 +143,7 @@ main(void) {
 	data_tsd_boot();
 	data_test_started = true;
 
-	return test(
+	return test_no_reentrancy(
 	    test_tsd_main_thread,
 	    test_tsd_sub_thread,
 	    test_tsd_reincarnation);

--- a/test/unit/tsd.c
+++ b/test/unit/tsd.c
@@ -79,6 +79,7 @@ thd_start(void *arg) {
 }
 
 TEST_BEGIN(test_tsd_main_thread) {
+	test_skip_if(test_is_reentrant());
 	thd_start((void *)(uintptr_t)0xa5f3e329);
 }
 TEST_END


### PR DESCRIPTION
This tests that we don't get into any libc- or arena_new- related reentrancy that we can't handle. If we detect reentrancy (using tsd), we'll force ourselves into arena 0, which we hope has already been initialized.