### PR TITLE
Improve the build on CloudABI

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -11,7 +11,7 @@
 #    include <sys/param.h>
 #  endif
 #  include <sys/mman.h>
-#  if !defined(__pnacl__) && !defined(__native_client__)
+#  if !defined(__CloudABI__) && !defined(__pnacl__) && !defined(__native_client__)
 #    include <sys/syscall.h>
 #    if !defined(SYS_write) && defined(__NR_write)
 #      define SYS_write __NR_write

--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -7,7 +7,9 @@
 #  include "msvc_compat/windows_extra.h"
 
 #else
-#  include <sys/param.h>
+#  ifndef __CloudABI__
+#    include <sys/param.h>
+#  endif
 #  include <sys/mman.h>
 #  if !defined(__pnacl__) && !defined(__native_client__)
 #    include <sys/syscall.h>

--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -35,6 +35,9 @@
 #include <sys/types.h>
 
 #include <limits.h>
+#ifndef PATH_MAX
+#  define PATH_MAX 1024
+#endif
 #ifndef SIZE_T_MAX
 #  define SIZE_T_MAX	SIZE_MAX
 #endif
@@ -53,7 +56,6 @@
 #ifdef _MSC_VER
 #  include <io.h>
 typedef intptr_t ssize_t;
-#  define PATH_MAX 1024
 #  define STDERR_FILENO 2
 #  define __func__ __FUNCTION__
 #  ifdef JEMALLOC_HAS_RESTRICT

--- a/src/prof.c
+++ b/src/prof.c
@@ -1399,7 +1399,7 @@ label_return:
 	return ret;
 }
 
-#ifndef _WIN32
+#if !defined(__CloudABI__) && !defined(_WIN32)
 JEMALLOC_FORMAT_PRINTF(1, 2)
 static int
 prof_open_maps(const char *format, ...) {
@@ -1433,7 +1433,7 @@ prof_dump_maps(bool propagate_err) {
 	cassert(config_prof);
 #ifdef __FreeBSD__
 	mfd = prof_open_maps("/proc/curproc/map");
-#elif defined(_WIN32)
+#elif defined(__CloudABI__) || defined(_WIN32)
 	mfd = -1; // Not implemented
 #else
 	{


### PR DESCRIPTION
[CloudABI](https://nuxi.nl/) has been using jemalloc for quite some time as part of [its C library](https://github.com/NuxiNL/cloudlibc). These are some of the local changes I had to apply to get jemalloc to build cleanly.