### PR TITLE
Get rid of tcache_enabled_t as we have runtime init support.

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/include/jemalloc/internal/jemalloc_internal.h.in
@@ -942,7 +942,7 @@ tcache_available(tsd_t *tsd) {
 	 * initialization, or 2) disabled through thread.tcache.enabled mallctl
 	 * or config options.  This check covers all cases.
 	 */
-	if (likely(tsd_tcache_enabled_get(tsd) == tcache_enabled_true)) {
+	if (likely(tsd_tcache_enabled_get(tsd) == true)) {
 		/* Associated arena == null implies tcache init in progress. */
 		if (tsd_tcachep_get(tsd)->arena != NULL) {
 			assert(tsd_tcachep_get(tsd)->tbins[0].avail != NULL);

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -22,30 +22,24 @@ tcache_t	*tcaches_get(tsd_t *tsd, unsigned ind);
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_TCACHE_C_))
 JEMALLOC_INLINE bool
 tcache_enabled_get(tsd_t *tsd) {
-	tcache_enabled_t tcache_enabled;
-
 	cassert(config_tcache);
 
-	tcache_enabled = tsd_tcache_enabled_get(tsd);
-	assert(tcache_enabled != tcache_enabled_default);
-
-	return (bool)tcache_enabled;
+	return tsd_tcache_enabled_get(tsd);
 }
 
 JEMALLOC_INLINE void
 tcache_enabled_set(tsd_t *tsd, bool enabled) {
 	cassert(config_tcache);
 
-	tcache_enabled_t old = tsd_tcache_enabled_get(tsd);
+	bool was_enabled = tsd_tcache_enabled_get(tsd);
 
-	if ((old != tcache_enabled_true) && enabled) {
+	if (!was_enabled && enabled) {
 		tsd_tcache_data_init(tsd);
-	} else if ((old == tcache_enabled_true) && !enabled) {
+	} else if (was_enabled && !enabled) {
 		tcache_cleanup(tsd);
 	}
 	/* Commit the state last.  Above calls check current state. */
-	tcache_enabled_t tcache_enabled = (tcache_enabled_t)enabled;
-	tsd_tcache_enabled_set(tsd, tcache_enabled);
+	tsd_tcache_enabled_set(tsd, enabled);
 }
 
 JEMALLOC_ALWAYS_INLINE void

--- a/include/jemalloc/internal/tcache_structs.h
+++ b/include/jemalloc/internal/tcache_structs.h
@@ -1,12 +1,6 @@
 #ifndef JEMALLOC_INTERNAL_TCACHE_STRUCTS_H
 #define JEMALLOC_INTERNAL_TCACHE_STRUCTS_H
 
-typedef enum {
-	tcache_enabled_false   = 0, /* Enable cast to/from bool. */
-	tcache_enabled_true    = 1,
-	tcache_enabled_default = 2
-} tcache_enabled_t;
-
 /*
  * Read-only information associated with each element of tcache_t's tbins array
  * is stored separately, mainly to reduce memory usage.

--- a/include/jemalloc/internal/tcache_types.h
+++ b/include/jemalloc/internal/tcache_types.h
@@ -50,4 +50,7 @@ typedef struct tcaches_s tcaches_t;
 /* Used in TSD static initializer only. Real init in tcache_data_init(). */
 #define TCACHE_ZERO_INITIALIZER {{NULL}}
 
+/* Used in TSD static initializer only. Will be initialized to opt_tcache. */
+#define TCACHE_ENABLED_DEFAULT false
+
 #endif /* JEMALLOC_INTERNAL_TCACHE_TYPES_H */

--- a/include/jemalloc/internal/tsd_structs.h
+++ b/include/jemalloc/internal/tsd_structs.h
@@ -25,8 +25,7 @@ struct tsd_init_head_s {
     O(arenas_tdata,		arena_tdata_t *,yes,	no,	yes)	\
     O(narenas_tdata,		unsigned,	yes,	no,	no)	\
     O(arenas_tdata_bypass,	bool,		no,	no,	no)	\
-    O(tcache_enabled,		tcache_enabled_t,			\
-						yes,	yes,	no)	\
+    O(tcache_enabled,		bool,		yes,	yes,	no)	\
     O(rtree_ctx,		rtree_ctx_t,	no,	yes,	no)	\
     O(witnesses,		witness_list_t,	no,	no,	yes)	\
     O(rtree_leaf_elm_witnesses,	rtree_leaf_elm_witness_tsd_t,		\
@@ -44,7 +43,7 @@ struct tsd_init_head_s {
     NULL,								\
     0,									\
     false,								\
-    tcache_enabled_default,						\
+    TCACHE_ENABLED_DEFAULT,						\
     RTREE_CTX_ZERO_INITIALIZER,						\
     ql_head_initializer(witnesses),					\
     RTREE_ELM_WITNESS_TSD_INITIALIZER,					\

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -326,7 +326,7 @@ tcache_arena_reassociate(tsdn_t *tsdn, tcache_t *tcache, arena_t *arena) {
 bool
 tsd_tcache_enabled_data_init(tsd_t *tsd) {
 	/* Called upon tsd initialization. */
-	tsd_tcache_enabled_set(tsd, (tcache_enabled_t)opt_tcache);
+	tsd_tcache_enabled_set(tsd, opt_tcache);
 	if (opt_tcache) {
 		/* Trigger tcache init. */
 		tsd_tcache_data_init(tsd);
@@ -501,13 +501,13 @@ tcache_cleanup(tsd_t *tsd) {
 
 	tcache_t *tcache = tsd_tcachep_get(tsd);
 	if (!tcache_available(tsd)) {
-		assert(tsd_tcache_enabled_get(tsd) == tcache_enabled_false);
+		assert(tsd_tcache_enabled_get(tsd) == false);
 		if (config_debug) {
 			assert(tcache->tbins[0].avail == NULL);
 		}
 		return;
 	}
-	assert(tsd_tcache_enabled_get(tsd) == tcache_enabled_true);
+	assert(tsd_tcache_enabled_get(tsd));
 	assert(tcache->tbins[0].avail != NULL);
 
 	tcache_destroy(tsd, tcache, true);


### PR DESCRIPTION
This removes tcache_enabled_t, which was used to initialize tsd->tcache_enabled to opt_tcache.  Since now we have init function support for tsd members, we can get rid of this type.