### PR TITLE
Port CPU_SPINWAIT to __powerpc64__

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,8 +398,9 @@ case "${host_cpu}" in
 	    fi
 	fi
 	;;
-  powerpc)
+  powerpc*)
 	AC_DEFINE_UNQUOTED([HAVE_ALTIVEC], [ ])
+	CPU_SPINWAIT='__asm__ volatile("or 31,31,31")'
 	;;
   *)
 	;;


### PR DESCRIPTION
Hyper-threaded CPUs may need a special instruction inside spin loops in
order to yield to another virtual CPU. The 'pause' instruction that is
available for x86 is not supported on Power.
Apparently the extended mnemonics like yield, mdoio, and mdoom are not
actually implemented on POWER8, although mentioned in the ISA 2.07
document. The recommended magic bits are an 'or 31,31,31'.