### PR TITLE
Switch to fine-grained reentrancy support

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -16,7 +16,7 @@ arena_choose_impl(tsd_t *tsd, arena_t *arena, bool internal) {
 	}
 
 	/* During reentrancy, arena 0 is the safest bet. */
-	if (*tsd_reentrancy_levelp_get(tsd) > 1) {
+	if (unlikely(tsd_reentrancy_level_get(tsd) > 0)) {
 		return arena_get(tsd_tsdn(tsd), 0, true);
 	}
 

--- a/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -117,8 +117,8 @@ idalloctm(tsdn_t *tsdn, void *ptr, tcache_t *tcache, alloc_ctx_t *alloc_ctx,
 	if (config_stats && is_internal) {
 		arena_internal_sub(iaalloc(tsdn, ptr), isalloc(tsdn, ptr));
 	}
-	if (!is_internal && *tsd_reentrancy_levelp_get(tsdn_tsd(tsdn)) != 0) {
-		tcache = NULL;
+	if (!is_internal && tsd_reentrancy_level_get(tsdn_tsd(tsdn)) != 0) {
+		assert(tcache == NULL);
 	}
 	arena_dalloc(tsdn, ptr, tcache, alloc_ctx, slow_path);
 }

--- a/include/jemalloc/internal/tsd_inlines.h
+++ b/include/jemalloc/internal/tsd_inlines.h
@@ -20,7 +20,7 @@ tsd_t *tsdn_tsd(tsdn_t *tsdn);
 rtree_ctx_t *tsd_rtree_ctx(tsd_t *tsd);
 rtree_ctx_t *tsdn_rtree_ctx(tsdn_t *tsdn, rtree_ctx_t *fallback);
 bool tsd_fast(tsd_t *tsd);
-void tsd_assert_fast(tsd_t *tsd);
+bool tsd_assert_fast(tsd_t *tsd);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_TSD_C_))
@@ -52,9 +52,11 @@ MALLOC_TSD
 #undef MALLOC_TSD_getset_no
 #undef O
 
-JEMALLOC_ALWAYS_INLINE void
+JEMALLOC_ALWAYS_INLINE bool
 tsd_assert_fast(tsd_t *tsd) {
-	assert(!malloc_slow && tsd_tcache_enabled_get(tsd));
+	assert(!malloc_slow && tsd_tcache_enabled_get(tsd) &&
+	    tsd_reentrancy_level_get(tsd) == 0);
+	return true;
 }
 
 JEMALLOC_ALWAYS_INLINE bool

--- a/include/jemalloc/internal/tsd_structs.h
+++ b/include/jemalloc/internal/tsd_structs.h
@@ -55,7 +55,7 @@ struct tsd_init_head_s {
 /*  O(name,			type,		[gs]et,	init,	cleanup) */ \
     O(tcache_enabled,		bool,		yes,	yes,	no)	\
     O(arenas_tdata_bypass,	bool,		no,	no,	no)	\
-    O(reentrancy_level,		int8_t,		no,	no,	no)	\
+    O(reentrancy_level,		int8_t,		yes,	no,	no)	\
     O(narenas_tdata,		uint32_t,	yes,	no,	no)	\
     O(thread_allocated,		uint64_t,	yes,	no,	no)	\
     O(thread_deallocated,	uint64_t,	yes,	no,	no)	\

--- a/src/arena.c
+++ b/src/arena.c
@@ -1966,11 +1966,9 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		 * If we're here, then arena 0 already exists, so bootstrapping
 		 * is done enough that we should have tsd.
 		 */
-		int8_t *reentrancy_level = tsd_reentrancy_levelp_get(tsdn_tsd(
-		    tsdn));
-		++*reentrancy_level;
+		pre_reentrancy(tsdn_tsd(tsdn));
 		hooks_arena_new_hook();
-		--*reentrancy_level;
+		post_reentrancy(tsdn_tsd(tsdn));
 	}
 
 	return arena;

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -15,7 +15,8 @@ malloc_tsd_data(, , tsd_t, TSD_INITIALIZER)
 void
 tsd_slow_update(tsd_t *tsd) {
 	if (tsd_nominal(tsd)) {
-		if (malloc_slow || !tsd->tcache_enabled) {
+		if (malloc_slow || !tsd->tcache_enabled ||
+		    tsd_reentrancy_level_get(tsd) > 0) {
 			tsd->state = tsd_state_nominal_slow;
 		} else {
 			tsd->state = tsd_state_nominal;
@@ -28,6 +29,7 @@ tsd_fetch_slow(tsd_t *tsd) {
 	if (tsd->state == tsd_state_nominal_slow) {
 		/* On slow path but no work needed. */
 		assert(malloc_slow || !tsd_tcache_enabled_get(tsd) ||
+		    tsd_reentrancy_level_get(tsd) > 0 ||
 		    *tsd_arenas_tdata_bypassp_get(tsd));
 	} else if (tsd->state == tsd_state_uninitialized) {
 		tsd->state = tsd_state_nominal;


### PR DESCRIPTION
Previously we had a general detection and support of reentrancy, at the cost of
having branches and inc / dec operations on fast paths.  To avoid taxing fast
paths, we move the reentrancy operations onto tsd slow state, and only modify
reentrancy level around external calls (that might trigger reentrancy).

This resolves #753.