### PR TITLE
Improve rtree cache with a two-level cache design.

### DIFF
--- a/include/jemalloc/internal/rtree_structs.h
+++ b/include/jemalloc/internal/rtree_structs.h
@@ -55,7 +55,10 @@ struct rtree_ctx_cache_elm_s {
 };
 
 struct rtree_ctx_s {
+	/* Direct mapped cache. */
 	rtree_ctx_cache_elm_t	cache[RTREE_CTX_NCACHE];
+	/* L2 LRU cache. */
+	rtree_ctx_cache_elm_t	l2_cache[RTREE_CTX_NCACHE_L2];
 };
 
 struct rtree_s {

--- a/src/prof.c
+++ b/src/prof.c
@@ -310,6 +310,7 @@ prof_leave(tsd_t *tsd, prof_tdata_t *tdata) {
 }
 
 #ifdef JEMALLOC_PROF_LIBUNWIND
+JEMALLOC_ALIGNED(CACHELINE)
 void
 prof_backtrace(prof_bt_t *bt) {
 	int nframes;


### PR DESCRIPTION
Two levels of rcache is implemented: a direct mapped cache as L1, combined with
a LRU cache as L2.  The L1 cache offers low cost on cache hit, but could suffer
collision under circumstances.  This is complemented by the L2 LRU cache, which
is slower on cache access (overhead from linear search + reordering), but solves
collison of L1 rather well.

The current config is set to 16 L1 entries, and 8 L2 entires. Production benchmark shows favorable results comparing to LRU cache only (>10% cost reduction for free()). Comparing to a 8 L1+ 8 L2 setting, this showed a better cost in free() and tcache_bin_flush(). /test/stress/microbench is slightly slower with this (~2%), as comparing best case this needs a "&" operation (compute cache index).