### PR TITLE
Skip percpu arena when choosing iarena.

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -47,7 +47,7 @@ arena_choose_impl(tsd_t *tsd, arena_t *arena, bool internal) {
 	 * managed arena), then percpu arena is skipped.
 	 */
 	if (have_percpu_arena && (percpu_arena_mode != percpu_arena_disabled) &&
-	    (arena_ind_get(ret) < percpu_arena_ind_limit()) &&
+	    !internal && (arena_ind_get(ret) < percpu_arena_ind_limit()) &&
 	    (ret->last_thd != tsd_tsdn(tsd))) {
 		unsigned ind = percpu_arena_choose();
 		if (arena_ind_get(ret) != ind) {


### PR DESCRIPTION
This fixs an intermittent test failure (test/unit/decay). 