### PR TITLE
extent_avail

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -2691,14 +2691,14 @@ struct extent_hooks_s {
         counters</link>.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="stats.arenas.i.mutexes.extent_freelist">
+      <varlistentry id="stats.arenas.i.mutexes.extent_avail">
         <term>
-          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extent_freelist.{counter}</mallctl>
+          <mallctl>stats.arenas.&lt;i&gt;.mutexes.extent_avail.{counter}</mallctl>
           (<type>counter specific type</type>) <literal>r-</literal>
           [<option>--enable-stats</option>]
         </term>
-        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extent_freelist
-        </varname> mutex (arena scope; extent freelist related).
+        <listitem><para>Statistics on <varname>arena.&lt;i&gt;.extent_avail
+        </varname> mutex (arena scope; extent avail related).
         <mallctl>{counter}</mallctl> is one of the counters in <link
         linkend="mutex_counters">mutex profiling
         counters</link>.</para></listitem>

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -233,12 +233,13 @@ struct arena_s {
 	atomic_u_t		extent_grow_next;
 
 	/*
-	 * Freelist of extent structures that were allocated via base_alloc().
+	 * Available extent structures that were allocated via
+	 * base_alloc_extent().
 	 *
-	 * Synchronization: extent_freelist_mtx.
+	 * Synchronization: extent_avail_mtx.
 	 */
-	extent_list_t		extent_freelist;
-	malloc_mutex_t		extent_freelist_mtx;
+	extent_tree_t		extent_avail;
+	malloc_mutex_t		extent_avail_mtx;
 
 	/*
 	 * bins is used to store heaps of free regions.

--- a/include/jemalloc/internal/base_externs.h
+++ b/include/jemalloc/internal/base_externs.h
@@ -1,18 +1,19 @@
 #ifndef JEMALLOC_INTERNAL_BASE_EXTERNS_H
 #define JEMALLOC_INTERNAL_BASE_EXTERNS_H
 
-base_t	*b0get(void);
-base_t	*base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
-void	base_delete(base_t *base);
-extent_hooks_t	*base_extent_hooks_get(base_t *base);
-extent_hooks_t	*base_extent_hooks_set(base_t *base,
+base_t *b0get(void);
+base_t *base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+void base_delete(base_t *base);
+extent_hooks_t *base_extent_hooks_get(base_t *base);
+extent_hooks_t *base_extent_hooks_set(base_t *base,
     extent_hooks_t *extent_hooks);
-void	*base_alloc(tsdn_t *tsdn, base_t *base, size_t size, size_t alignment);
-void	base_stats_get(tsdn_t *tsdn, base_t *base, size_t *allocated,
+void *base_alloc(tsdn_t *tsdn, base_t *base, size_t size, size_t alignment);
+extent_t *base_alloc_extent(tsdn_t *tsdn, base_t *base);
+void base_stats_get(tsdn_t *tsdn, base_t *base, size_t *allocated,
     size_t *resident, size_t *mapped);
-void	base_prefork(tsdn_t *tsdn, base_t *base);
-void	base_postfork_parent(tsdn_t *tsdn, base_t *base);
-void	base_postfork_child(tsdn_t *tsdn, base_t *base);
-bool	base_boot(tsdn_t *tsdn);
+void base_prefork(tsdn_t *tsdn, base_t *base);
+void base_postfork_parent(tsdn_t *tsdn, base_t *base);
+void base_postfork_child(tsdn_t *tsdn, base_t *base);
+bool base_boot(tsdn_t *tsdn);
 
 #endif /* JEMALLOC_INTERNAL_BASE_EXTERNS_H */

--- a/include/jemalloc/internal/base_structs.h
+++ b/include/jemalloc/internal/base_structs.h
@@ -21,10 +21,17 @@ struct base_s {
 	 * User-configurable extent hook functions.  Points to an
 	 * extent_hooks_t.
 	 */
-	atomic_p_t extent_hooks;
+	atomic_p_t	extent_hooks;
 
 	/* Protects base_alloc() and base_stats_get() operations. */
 	malloc_mutex_t	mtx;
+
+	/*
+	 * Most recent size class in the series of increasingly large base
+	 * extents.  Logarithmic spacing between subsequent allocations ensures
+	 * that the total number of distinct mappings remains small.
+	 */
+	pszind_t	pind_last;
 
 	/* Serial number generation state. */
 	size_t		extent_sn_next;

--- a/include/jemalloc/internal/ctl_types.h
+++ b/include/jemalloc/internal/ctl_types.h
@@ -14,7 +14,7 @@ typedef enum {
 
 #define ARENA_PROF_MUTEXES						\
     OP(large)								\
-    OP(extent_freelist)							\
+    OP(extent_avail)							\
     OP(extents_dirty)							\
     OP(extents_muzzy)							\
     OP(extents_retained)						\

--- a/include/jemalloc/internal/extent_externs.h
+++ b/include/jemalloc/internal/extent_externs.h
@@ -1,6 +1,7 @@
 #ifndef JEMALLOC_INTERNAL_EXTENT_EXTERNS_H
 #define JEMALLOC_INTERNAL_EXTENT_EXTERNS_H
 
+#include "jemalloc/internal/rb.h"
 #include "jemalloc/internal/ph.h"
 
 extern rtree_t			extents_rtree;
@@ -17,6 +18,7 @@ size_t extent_size_quantize_floor(size_t size);
 size_t extent_size_quantize_ceil(size_t size);
 #endif
 
+rb_proto(, extent_avail_, extent_tree_t, extent_t)
 ph_proto(, extent_heap_, extent_heap_t, extent_t)
 
 bool extents_init(tsdn_t *tsdn, extents_t *extents, extent_state_t state,

--- a/include/jemalloc/internal/extent_inlines.h
+++ b/include/jemalloc/internal/extent_inlines.h
@@ -53,8 +53,10 @@ void extent_list_replace(extent_list_t *list, extent_t *to_remove,
     extent_t *to_insert);
 void extent_list_remove(extent_list_t *list, extent_t *extent);
 int extent_sn_comp(const extent_t *a, const extent_t *b);
+int extent_esn_comp(const extent_t *a, const extent_t *b);
 int extent_ad_comp(const extent_t *a, const extent_t *b);
 int extent_snad_comp(const extent_t *a, const extent_t *b);
+int extent_esnead_comp(const extent_t *a, const extent_t *b);
 #endif
 
 #if (defined(JEMALLOC_ENABLE_INLINE) || defined(JEMALLOC_EXTENT_C_))
@@ -379,11 +381,27 @@ extent_sn_comp(const extent_t *a, const extent_t *b) {
 }
 
 JEMALLOC_INLINE int
+extent_esn_comp(const extent_t *a, const extent_t *b) {
+	size_t a_esn = extent_esn_get(a);
+	size_t b_esn = extent_esn_get(b);
+
+	return (a_esn > b_esn) - (a_esn < b_esn);
+}
+
+JEMALLOC_INLINE int
 extent_ad_comp(const extent_t *a, const extent_t *b) {
 	uintptr_t a_addr = (uintptr_t)extent_addr_get(a);
 	uintptr_t b_addr = (uintptr_t)extent_addr_get(b);
 
 	return (a_addr > b_addr) - (a_addr < b_addr);
+}
+
+JEMALLOC_INLINE int
+extent_ead_comp(const extent_t *a, const extent_t *b) {
+	uintptr_t a_eaddr = (uintptr_t)a;
+	uintptr_t b_eaddr = (uintptr_t)b;
+
+	return (a_eaddr > b_eaddr) - (a_eaddr < b_eaddr);
 }
 
 JEMALLOC_INLINE int
@@ -396,6 +414,19 @@ extent_snad_comp(const extent_t *a, const extent_t *b) {
 	}
 
 	ret = extent_ad_comp(a, b);
+	return ret;
+}
+
+JEMALLOC_INLINE int
+extent_esnead_comp(const extent_t *a, const extent_t *b) {
+	int ret;
+
+	ret = extent_esn_comp(a, b);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = extent_ead_comp(a, b);
 	return ret;
 }
 #endif

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -23,8 +23,8 @@ struct extent_s {
 	 * z: zeroed
 	 * t: state
 	 * i: szind
-	 * n: sn
 	 * f: nfree
+	 * n: sn
 	 *
 	 * nnnnnnnn ... nnnnnfff fffffffi iiiiiiit tzcbaaaa aaaaaaaa
 	 *
@@ -102,8 +102,20 @@ struct extent_s {
 	/* Pointer to the extent that this structure is responsible for. */
 	void			*e_addr;
 
-	/* Extent size. */
-	size_t			e_size;
+	union {
+		/*
+		 * Extent size and serial number associated with the extent
+		 * structure (different than the serial number for the extent at
+		 * e_addr).
+		 *
+		 * ssssssss [...] ssssssss ssssnnnn nnnnnnnn
+		 */
+		size_t			e_size_esn;
+	#define EXTENT_SIZE_MASK	((size_t)~(PAGE-1))
+	#define EXTENT_ESN_MASK		((size_t)PAGE-1)
+		/* Base extent size, which may not be a multiple of PAGE. */
+		size_t			e_bsize;
+	};
 
 	/*
 	 * List linkage, used by a variety of lists:

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -160,8 +160,11 @@ extent_dss_boot
 extent_dss_mergeable
 extent_dss_prec_get
 extent_dss_prec_set
+extent_ead_comp
+extent_esn_comp
 extent_esn_get
 extent_esn_set
+extent_esnead_comp
 extent_heap_empty
 extent_heap_first
 extent_heap_insert

--- a/include/jemalloc/internal/private_symbols.txt
+++ b/include/jemalloc/internal/private_symbols.txt
@@ -86,6 +86,7 @@ b0get
 base_alloc
 base_boot
 base_delete
+base_extent_alloc
 base_extent_hooks_get
 base_extent_hooks_set
 base_ind_get
@@ -143,6 +144,9 @@ extent_arena_set
 extent_base_get
 extent_before_get
 extent_boot
+extent_binit
+extent_bsize_get
+extent_bsize_set
 extent_commit_wrapper
 extent_committed_get
 extent_committed_set
@@ -156,6 +160,8 @@ extent_dss_boot
 extent_dss_mergeable
 extent_dss_prec_get
 extent_dss_prec_set
+extent_esn_get
+extent_esn_set
 extent_heap_empty
 extent_heap_first
 extent_heap_insert

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2475,7 +2475,7 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 			continue;
 		}
 		MUTEX_PROF_RESET(arena->large_mtx);
-		MUTEX_PROF_RESET(arena->extent_freelist_mtx);
+		MUTEX_PROF_RESET(arena->extent_avail_mtx);
 		MUTEX_PROF_RESET(arena->extents_dirty.mtx);
 		MUTEX_PROF_RESET(arena->extents_muzzy.mtx);
 		MUTEX_PROF_RESET(arena->extents_retained.mtx);

--- a/src/extent.c
+++ b/src/extent.c
@@ -98,8 +98,7 @@ extent_alloc(tsdn_t *tsdn, arena_t *arena) {
 	extent = extent_list_last(&arena->extent_freelist);
 	if (extent == NULL) {
 		malloc_mutex_unlock(tsdn, &arena->extent_freelist_mtx);
-		return base_alloc(tsdn, arena->base, sizeof(extent_t),
-		    CACHELINE);
+		return base_alloc_extent(tsdn, arena->base);
 	}
 	extent_list_remove(&arena->extent_freelist, extent);
 	malloc_mutex_unlock(tsdn, &arena->extent_freelist_mtx);

--- a/test/unit/base.c
+++ b/test/unit/base.c
@@ -154,10 +154,10 @@ TEST_BEGIN(test_base_hooks_not_null) {
 	 * that the first block's remaining space is considered for subsequent
 	 * allocation.
 	 */
-	assert_zu_ge(extent_size_get(&base->blocks->extent), QUANTUM,
+	assert_zu_ge(extent_bsize_get(&base->blocks->extent), QUANTUM,
 	    "Remainder insufficient for test");
 	/* Use up all but one quantum of block. */
-	while (extent_size_get(&base->blocks->extent) > QUANTUM) {
+	while (extent_bsize_get(&base->blocks->extent) > QUANTUM) {
 		p = base_alloc(tsdn, base, QUANTUM, QUANTUM);
 		assert_ptr_not_null(p, "Unexpected base_alloc() failure");
 	}


### PR DESCRIPTION
The first two diffs are worthwhile on their own; the second reduces the number of base blocks, and therefore extent structure serial numbers, which makes it feasible to encode the extent serial number in the low bits of the extent size field, under the assumption that the extent size is a multiple of ```PAGE```.  Unfortunately those bits are actually used by the base code for tracking available base block remainders, so we need a union for ```e_size_esn``` and ```e_bsize```.  It's not very pretty, and a bit more brittle than I'd like, but the approach seems sound.  Ideally we'd get some idea as to whether the extent structure reuse policy is important, but it may be hard to get a clear signal, and additionally this optimization may help more once we explicitly use huge pages for base blocks.