### PR TITLE
Remove the function alignment of prof_backtrace.

### DIFF
--- a/src/prof.c
+++ b/src/prof.c
@@ -310,7 +310,6 @@ prof_leave(tsd_t *tsd, prof_tdata_t *tdata) {
 }
 
 #ifdef JEMALLOC_PROF_LIBUNWIND
-JEMALLOC_ALIGNED(CACHELINE)
 void
 prof_backtrace(prof_bt_t *bt) {
 	int nframes;


### PR DESCRIPTION
This was an attempt to avoid triggering slow path in libunwind, however turns
out to be ineffective.