### PR TITLE
Use openat syscall if available

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -14,6 +14,11 @@
 #    if !defined(SYS_write) && defined(__NR_write)
 #      define SYS_write __NR_write
 #    endif
+#    if defined(SYS_open) && defined(__aarch64__)
+       /* Android headers may define SYS_open to __NR_open even though
+        * __NR_open may not exist on AArch64 (superseded by __NR_openat). */
+#      undef SYS_open
+#    endif
 #    include <sys/uio.h>
 #  endif
 #  include <pthread.h>

--- a/src/pages.c
+++ b/src/pages.c
@@ -265,6 +265,9 @@ os_overcommits_proc(void) {
 
 #if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_open)
 	fd = (int)syscall(SYS_open, "/proc/sys/vm/overcommit_memory", O_RDONLY);
+#elif defined(JEMALLOC_USE_SYSCALL) && defined(SYS_openat)
+	fd = (int)syscall(SYS_openat,
+	    AT_FDCWD, "/proc/sys/vm/overcommit_memory", O_RDONLY);
 #else
 	fd = open("/proc/sys/vm/overcommit_memory", O_RDONLY);
 #endif


### PR DESCRIPTION
Some architectures like AArch64 may not have the `open` syscall because it
was superseded by the `openat` syscall, so check and use `SYS_openat` if
`SYS_open` is not available.

Additionally, Android headers for AArch64 define `SYS_open` to `__NR_open`,
even though `__NR_open` is undefined. Undefine `SYS_open` in that case so
`SYS_openat` is used.