### PR TITLE
Trim before commit in extent_recycle().

### DIFF
--- a/src/extent_mmap.c
+++ b/src/extent_mmap.c
@@ -15,7 +15,9 @@ extent_alloc_mmap(void *new_addr, size_t size, size_t alignment, bool *zero,
 		return NULL;
 	}
 	assert(ret != NULL);
-	*zero = true;
+	if (*commit) {
+		*zero = true;
+	}
 	return ret;
 }
 


### PR DESCRIPTION
This avoids creating clean committed pages as a side effect of aligned
allocation.  For configurations that decommit memory, purged pages are
decommitted, and decommitted extents cannot be coalesced with committed
extents.  Unless the clean committed pages happen to be selected during
allocation, they cause unnecessary permanent extent fragmentation.

This resolves #766.