### PR TITLE
Remove --disable-cc-silence.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -96,11 +96,6 @@ any of the following arguments (not a definitive list) to 'configure':
 
       --with-malloc-conf=decay_time:30
 
---disable-cc-silence
-    Disable code that silences non-useful compiler warnings.  This is mainly
-    useful during development when auditing the set of warnings that are being
-    silenced.
-
 --enable-debug
     Enable assertions and validation code.  This incurs a substantial
     performance hit, but is very useful during application development.

--- a/configure.ac
+++ b/configure.ac
@@ -258,12 +258,10 @@ if test "x$je_cv_cray" = "xyes" ; then
     JE_CFLAGS_ADD([-hipa2])
     JE_CFLAGS_ADD([-hnognu])
   fi
-  if test "x$enable_cc_silence" != "xno" ; then
-    dnl ignore unreachable code warning
-    JE_CFLAGS_ADD([-hnomessage=128])
-    dnl ignore redefinition of "malloc", "free", etc warning
-    JE_CFLAGS_ADD([-hnomessage=1357])
-  fi
+  dnl ignore unreachable code warning
+  JE_CFLAGS_ADD([-hnomessage=128])
+  dnl ignore redefinition of "malloc", "free", etc warning
+  JE_CFLAGS_ADD([-hnomessage=1357])
 fi
 AC_SUBST([CONFIGURE_CFLAGS])
 AC_SUBST([SPECIFIED_CFLAGS])
@@ -941,22 +939,6 @@ cfghdrs_out="${cfghdrs_out} test/include/test/jemalloc_test_defs.h"
 cfghdrs_tup="include/jemalloc/jemalloc_defs.h:include/jemalloc/jemalloc_defs.h.in"
 cfghdrs_tup="${cfghdrs_tup} include/jemalloc/internal/jemalloc_internal_defs.h:include/jemalloc/internal/jemalloc_internal_defs.h.in"
 cfghdrs_tup="${cfghdrs_tup} test/include/test/jemalloc_test_defs.h:test/include/test/jemalloc_test_defs.h.in"
-
-dnl Silence irrelevant compiler warnings by default.
-AC_ARG_ENABLE([cc-silence],
-  [AS_HELP_STRING([--disable-cc-silence],
-                  [Do not silence irrelevant compiler warnings])],
-[if test "x$enable_cc_silence" = "xno" ; then
-  enable_cc_silence="0"
-else
-  enable_cc_silence="1"
-fi
-],
-[enable_cc_silence="1"]
-)
-if test "x$enable_cc_silence" = "x1" ; then
-  AC_DEFINE([JEMALLOC_CC_SILENCE], [ ])
-fi
 
 dnl Do not compile with debugging by default.
 AC_ARG_ENABLE([debug],
@@ -2110,7 +2092,6 @@ AC_MSG_RESULT([                   : ${JEMALLOC_PRIVATE_NAMESPACE}])
 AC_MSG_RESULT([install_suffix     : ${install_suffix}])
 AC_MSG_RESULT([malloc_conf        : ${config_malloc_conf}])
 AC_MSG_RESULT([autogen            : ${enable_autogen}])
-AC_MSG_RESULT([cc-silence         : ${enable_cc_silence}])
 AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([code-coverage      : ${enable_code_coverage}])
 AC_MSG_RESULT([stats              : ${enable_stats}])

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -127,9 +127,6 @@
 /* Non-empty if the tls_model attribute is supported. */
 #undef JEMALLOC_TLS_MODEL
 
-/* JEMALLOC_CC_SILENCE enables code that silences unuseful compiler warnings. */
-#undef JEMALLOC_CC_SILENCE
-
 /* JEMALLOC_CODE_COVERAGE enables test code coverage analysis. */
 #undef JEMALLOC_CODE_COVERAGE
 

--- a/include/jemalloc/internal/jemalloc_internal_macros.h
+++ b/include/jemalloc/internal/jemalloc_internal_macros.h
@@ -10,11 +10,7 @@
 #  define inline _inline
 #endif
 
-#ifdef JEMALLOC_CC_SILENCE
-#  define UNUSED JEMALLOC_ATTR(unused)
-#else
-#  define UNUSED
-#endif
+#define UNUSED JEMALLOC_ATTR(unused)
 
 #define ZU(z)	((size_t)z)
 #define ZD(z)	((ssize_t)z)

--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -26,11 +26,7 @@
  * wherever the compiler fails to recognize that the variable is never used
  * uninitialized.
  */
-#ifdef JEMALLOC_CC_SILENCE
-#  define JEMALLOC_CC_SILENCE_INIT(v) = v
-#else
-#  define JEMALLOC_CC_SILENCE_INIT(v)
-#endif
+#define JEMALLOC_CC_SILENCE_INIT(v) = v
 
 #ifdef __GNUC__
 #  define likely(x)   __builtin_expect(!!(x), 1)


### PR DESCRIPTION
The explicit compiler warning suppression controlled by this option is
universally desirable, so remove the ability to disable suppression.

This partially resolves #580.