### PR TITLE
Revert "Use try_flush first in tcache_dalloc."

### DIFF
--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -201,11 +201,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	tbin = tcache_small_bin_get(tcache, binind);
 	tbin_info = &tcache_bin_info[binind];
 	if (unlikely(tbin->ncached == tbin_info->ncached_max)) {
-		if (tcache_bin_try_flush_small(tsd, tcache, tbin, binind,
-		    (tbin_info->ncached_max >> 1)) == 0) {
-			tcache_bin_flush_small(tsd, tcache, tbin, binind,
-			    (tbin_info->ncached_max >> 1));
-		}
+		tcache_bin_flush_small(tsd, tcache, tbin, binind,
+		    (tbin_info->ncached_max >> 1));
 	}
 	assert(tbin->ncached < tbin_info->ncached_max);
 	tbin->ncached++;
@@ -230,11 +227,8 @@ tcache_dalloc_large(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	tbin = tcache_large_bin_get(tcache, binind);
 	tbin_info = &tcache_bin_info[binind];
 	if (unlikely(tbin->ncached == tbin_info->ncached_max)) {
-		if (tcache_bin_try_flush_large(tsd, tcache, tbin, binind,
-		    (tbin_info->ncached_max >> 1)) == 0) {
-			tcache_bin_flush_large(tsd, tcache, tbin, binind,
-			    (tbin_info->ncached_max >> 1));
-		}
+		tcache_bin_flush_large(tsd, tcache, tbin, binind,
+		    (tbin_info->ncached_max >> 1));
 	}
 	assert(tbin->ncached < tbin_info->ncached_max);
 	tbin->ncached++;


### PR DESCRIPTION
This reverts commit b0c2a28280d363fc85aa8b4fdbe7814ef46cb17b.  Production
benchmark shows this caused significant regression in both CPU and memory
consumption.  Will investigate separately later on.