### PR TITLE
Remove mutex_prof_data_t redeclaration.

### DIFF
--- a/include/jemalloc/internal/mutex_prof.h
+++ b/include/jemalloc/internal/mutex_prof.h
@@ -50,7 +50,7 @@ typedef enum {
 	mutex_prof_num_counters
 } mutex_prof_counter_ind_t;
 
-typedef struct mutex_prof_data_s {
+typedef struct {
 	/*
 	 * Counters touched on the slow path, i.e. when there is lock
 	 * contention.  We update them once we have the lock.

--- a/include/jemalloc/internal/mutex_types.h
+++ b/include/jemalloc/internal/mutex_types.h
@@ -1,7 +1,6 @@
 #ifndef JEMALLOC_INTERNAL_MUTEX_TYPES_H
 #define JEMALLOC_INTERNAL_MUTEX_TYPES_H
 
-typedef struct mutex_prof_data_s mutex_prof_data_t;
 typedef struct malloc_mutex_s malloc_mutex_t;
 
 /*


### PR DESCRIPTION
Redeclaration causes compilations failures with e.g. gcc 4.2.1 on
FreeBSD.  This regression was introduced by
89e2d3c12b573310e60b97beaf178007a71d83a3 (Header refactoring: ctl -
unify and remove from catchall.).