### PR TITLE
Take extents mutex around the extent_evict loops.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -387,7 +387,7 @@ extents_evict(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 	rtree_ctx_t rtree_ctx_fallback;
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
-	malloc_mutex_lock(tsdn, &extents->mtx);
+	malloc_mutex_assert_owner(tsdn, &extents->mtx);
 
 	/*
 	 * Get the LRU coalesced extent, if any.  If coalescing was delayed,
@@ -442,7 +442,6 @@ extents_evict(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 	}
 
 label_return:
-	malloc_mutex_unlock(tsdn, &extents->mtx);
 	return extent;
 }
 


### PR DESCRIPTION
Extents mutexes are the hottest locks in a prod workload.  Instead of taking the
extents mutex multiple times for evictions, this changes it to take it only once
for the extents_evict loop.  Since the eviction during decay is guarded by the
decay mutex, we do not expect heavy contention on this mutex here.  Plus we
avoid any expensive operations (such as madvise) while holding the extents lock.
Reduce # of lock ops to lower overhead on the mutex.