### PR TITLE
Refactor *decay_time into *decay_ms.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,7 +116,7 @@ any of the following arguments (not a definitive list) to 'configure':
     MALLOC_CONF environment variable.  For example, to change the default decay
     time to 30 seconds:
 
-      --with-malloc-conf=decay_time:30
+      --with-malloc-conf=decay_ms:30000
 
 * `--enable-debug`
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -475,8 +475,8 @@ ifeq ($(enable_prof), 1)
 	$(MALLOC_CONF)="prof:true,prof_active:false" $(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
 endif
 check_integration_decay: tests_integration check_integration_dir
-	$(MALLOC_CONF)="dirty_decay_time:-1,muzzy_decay_time:-1" $(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
-	$(MALLOC_CONF)="dirty_decay_time:0,muzzy_decay_time:0" $(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
+	$(MALLOC_CONF)="dirty_decay_ms:-1,muzzy_decay_ms:-1" $(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
+	$(MALLOC_CONF)="dirty_decay_ms:0,muzzy_decay_ms:0" $(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
 check_integration: tests_integration check_integration_dir
 	$(SHELL) $(objroot)test/test.sh $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%)
 stress: tests_stress stress_dir

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -937,15 +937,15 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         <quote>percpu</quote>. </para></listitem>
       </varlistentry>
 
-      <varlistentry id="opt.dirty_decay_time">
+      <varlistentry id="opt.dirty_decay_ms">
         <term>
-          <mallctl>opt.dirty_decay_time</mallctl>
+          <mallctl>opt.dirty_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>r-</literal>
         </term>
-        <listitem><para>Approximate time in seconds from the creation of a set
-        of unused dirty pages until an equivalent set of unused dirty pages is
-        purged (i.e. converted to muzzy via e.g.
+        <listitem><para>Approximate time in milliseconds from the creation of a
+        set of unused dirty pages until an equivalent set of unused dirty pages
+        is purged (i.e. converted to muzzy via e.g.
         <function>madvise(<parameter>...</parameter><parameter><constant>MADV_FREE</constant></parameter>)</function>
         if supported by the operating system, or converted to clean otherwise)
         and/or reused.  Dirty pages are defined as previously having been
@@ -955,35 +955,35 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         zero purge rate.  A decay time of 0 causes all unused dirty pages to be
         purged immediately upon creation.  A decay time of -1 disables purging.
         The default decay time is 10 seconds.  See <link
-        linkend="arenas.dirty_decay_time"><mallctl>arenas.dirty_decay_time</mallctl></link>
+        linkend="arenas.dirty_decay_ms"><mallctl>arenas.dirty_decay_ms</mallctl></link>
         and <link
-        linkend="arena.i.muzzy_decay_time"><mallctl>arena.&lt;i&gt;.muzzy_decay_time</mallctl></link>
+        linkend="arena.i.muzzy_decay_ms"><mallctl>arena.&lt;i&gt;.muzzy_decay_ms</mallctl></link>
         for related dynamic control options.  See <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzzy_decay_time</mallctl></link>
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzzy_decay_ms</mallctl></link>
         for a description of muzzy pages.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="opt.muzzy_decay_time">
+      <varlistentry id="opt.muzzy_decay_ms">
         <term>
-          <mallctl>opt.muzzy_decay_time</mallctl>
+          <mallctl>opt.muzzy_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>r-</literal>
         </term>
-        <listitem><para>Approximate time in seconds from the creation of a set
-        of unused muzzy pages until an equivalent set of unused muzzy pages is
-        purged (i.e. converted to clean) and/or reused.  Muzzy pages are defined
-        as previously having been unused dirty pages that were subsequently
-        purged in a manner that left them subject to the reclamation whims of
-        the operating system (e.g.
+        <listitem><para>Approximate time in milliseconds from the creation of a
+        set of unused muzzy pages until an equivalent set of unused muzzy pages
+        is purged (i.e. converted to clean) and/or reused.  Muzzy pages are
+        defined as previously having been unused dirty pages that were
+        subsequently purged in a manner that left them subject to the
+        reclamation whims of the operating system (e.g.
         <function>madvise(<parameter>...</parameter><parameter><constant>MADV_FREE</constant></parameter>)</function>),
         and therefore in an indeterminate state.  The pages are incrementally
         purged according to a sigmoidal decay curve that starts and ends with
         zero purge rate.  A decay time of 0 causes all unused muzzy pages to be
         purged immediately upon creation.  A decay time of -1 disables purging.
         The default decay time is 10 seconds.  See <link
-        linkend="arenas.muzzy_decay_time"><mallctl>arenas.muzzy_decay_time</mallctl></link>
+        linkend="arenas.muzzy_decay_ms"><mallctl>arenas.muzzy_decay_ms</mallctl></link>
         and <link
-        linkend="arena.i.muzzy_decay_time"><mallctl>arena.&lt;i&gt;.muzzy_decay_time</mallctl></link>
+        linkend="arena.i.muzzy_decay_ms"><mallctl>arena.&lt;i&gt;.muzzy_decay_ms</mallctl></link>
         for related dynamic control options.</para></listitem>
       </varlistentry>
 
@@ -1486,9 +1486,9 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         for arena &lt;i&gt;, or for all arenas if &lt;i&gt; equals
         <constant>MALLCTL_ARENAS_ALL</constant>.  The proportion of unused
         dirty/muzzy pages to be purged depends on the current time; see <link
-        linkend="opt.dirty_decay_time"><mallctl>opt.dirty_decay_time</mallctl></link>
+        linkend="opt.dirty_decay_ms"><mallctl>opt.dirty_decay_ms</mallctl></link>
         and <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzy_decay_time</mallctl></link>
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzy_decay_ms</mallctl></link>
         for details.</para></listitem>
       </varlistentry>
 
@@ -1550,35 +1550,35 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         settings.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="arena.i.dirty_decay_time">
+      <varlistentry id="arena.i.dirty_decay_ms">
         <term>
-          <mallctl>arena.&lt;i&gt;.dirty_decay_time</mallctl>
+          <mallctl>arena.&lt;i&gt;.dirty_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>rw</literal>
         </term>
-        <listitem><para>Current per-arena approximate time in seconds from the
-        creation of a set of unused dirty pages until an equivalent set of
+        <listitem><para>Current per-arena approximate time in milliseconds from
+        the creation of a set of unused dirty pages until an equivalent set of
         unused dirty pages is purged and/or reused.  Each time this interface is
         set, all currently unused dirty pages are considered to have fully
         decayed, which causes immediate purging of all unused dirty pages unless
         the decay time is set to -1 (i.e. purging disabled).  See <link
-        linkend="opt.dirty_decay_time"><mallctl>opt.dirty_decay_time</mallctl></link>
+        linkend="opt.dirty_decay_ms"><mallctl>opt.dirty_decay_ms</mallctl></link>
         for additional information.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="arena.i.muzzy_decay_time">
+      <varlistentry id="arena.i.muzzy_decay_ms">
         <term>
-          <mallctl>arena.&lt;i&gt;.muzzy_decay_time</mallctl>
+          <mallctl>arena.&lt;i&gt;.muzzy_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>rw</literal>
         </term>
-        <listitem><para>Current per-arena approximate time in seconds from the
-        creation of a set of unused muzzy pages until an equivalent set of
+        <listitem><para>Current per-arena approximate time in milliseconds from
+        the creation of a set of unused muzzy pages until an equivalent set of
         unused muzzy pages is purged and/or reused.  Each time this interface is
         set, all currently unused muzzy pages are considered to have fully
         decayed, which causes immediate purging of all unused muzzy pages unless
         the decay time is set to -1 (i.e. purging disabled).  See <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzzy_decay_time</mallctl></link>
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzzy_decay_ms</mallctl></link>
         for additional information.</para></listitem>
       </varlistentry>
 
@@ -1825,33 +1825,35 @@ struct extent_hooks_s {
         <listitem><para>Current limit on number of arenas.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="arenas.dirty_decay_time">
+      <varlistentry id="arenas.dirty_decay_ms">
         <term>
-          <mallctl>arenas.dirty_decay_time</mallctl>
+          <mallctl>arenas.dirty_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>rw</literal>
         </term>
-        <listitem><para>Current default per-arena approximate time in seconds
-        from the creation of a set of unused dirty pages until an equivalent set
-        of unused dirty pages is purged and/or reused, used to initialize <link
-        linkend="arena.i.dirty_decay_time"><mallctl>arena.&lt;i&gt;.dirty_decay_time</mallctl></link>
+        <listitem><para>Current default per-arena approximate time in
+        milliseconds from the creation of a set of unused dirty pages until an
+        equivalent set of unused dirty pages is purged and/or reused, used to
+        initialize <link
+        linkend="arena.i.dirty_decay_ms"><mallctl>arena.&lt;i&gt;.dirty_decay_ms</mallctl></link>
         during arena creation.  See <link
-        linkend="opt.dirty_decay_time"><mallctl>opt.dirty_decay_time</mallctl></link>
+        linkend="opt.dirty_decay_ms"><mallctl>opt.dirty_decay_ms</mallctl></link>
         for additional information.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="arenas.muzzy_decay_time">
+      <varlistentry id="arenas.muzzy_decay_ms">
         <term>
-          <mallctl>arenas.muzzy_decay_time</mallctl>
+          <mallctl>arenas.muzzy_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>rw</literal>
         </term>
-        <listitem><para>Current default per-arena approximate time in seconds
-        from the creation of a set of unused muzzy pages until an equivalent set
-        of unused muzzy pages is purged and/or reused, used to initialize <link
-        linkend="arena.i.muzzy_decay_time"><mallctl>arena.&lt;i&gt;.muzzy_decay_time</mallctl></link>
+        <listitem><para>Current default per-arena approximate time in
+        milliseconds from the creation of a set of unused muzzy pages until an
+        equivalent set of unused muzzy pages is purged and/or reused, used to
+        initialize <link
+        linkend="arena.i.muzzy_decay_ms"><mallctl>arena.&lt;i&gt;.muzzy_decay_ms</mallctl></link>
         during arena creation.  See <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzzy_decay_time</mallctl></link>
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzzy_decay_ms</mallctl></link>
         for additional information.</para></listitem>
       </varlistentry>
 
@@ -2244,29 +2246,29 @@ struct extent_hooks_s {
         </para></listitem>
       </varlistentry>
 
-      <varlistentry id="stats.arenas.i.dirty_decay_time">
+      <varlistentry id="stats.arenas.i.dirty_decay_ms">
         <term>
-          <mallctl>stats.arenas.&lt;i&gt;.dirty_decay_time</mallctl>
+          <mallctl>stats.arenas.&lt;i&gt;.dirty_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>r-</literal>
         </term>
-        <listitem><para>Approximate time in seconds from the creation of a set
-        of unused dirty pages until an equivalent set of unused dirty pages is
-        purged and/or reused.  See <link
-        linkend="opt.dirty_decay_time"><mallctl>opt.dirty_decay_time</mallctl></link>
+        <listitem><para>Approximate time in milliseconds from the creation of a
+        set of unused dirty pages until an equivalent set of unused dirty pages
+        is purged and/or reused.  See <link
+        linkend="opt.dirty_decay_ms"><mallctl>opt.dirty_decay_ms</mallctl></link>
         for details.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="stats.arenas.i.muzzy_decay_time">
+      <varlistentry id="stats.arenas.i.muzzy_decay_ms">
         <term>
-          <mallctl>stats.arenas.&lt;i&gt;.muzzy_decay_time</mallctl>
+          <mallctl>stats.arenas.&lt;i&gt;.muzzy_decay_ms</mallctl>
           (<type>ssize_t</type>)
           <literal>r-</literal>
         </term>
-        <listitem><para>Approximate time in seconds from the creation of a set
-        of unused muzzy pages until an equivalent set of unused muzzy pages is
-        purged and/or reused.  See <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzzy_decay_time</mallctl></link>
+        <listitem><para>Approximate time in milliseconds from the creation of a
+        set of unused muzzy pages until an equivalent set of unused muzzy pages
+        is purged and/or reused.  See <link
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzzy_decay_ms</mallctl></link>
         for details.</para></listitem>
       </varlistentry>
 
@@ -2298,7 +2300,7 @@ struct extent_hooks_s {
         <listitem><para>Number of pages within unused extents that are
         potentially dirty, and for which <function>madvise()</function> or
         similar has not been called.  See <link
-        linkend="opt.dirty_decay_time"><mallctl>opt.dirty_decay_time</mallctl></link>
+        linkend="opt.dirty_decay_ms"><mallctl>opt.dirty_decay_ms</mallctl></link>
         for a description of dirty pages.</para></listitem>
       </varlistentry>
 
@@ -2310,7 +2312,7 @@ struct extent_hooks_s {
         </term>
         <listitem><para>Number of pages within unused extents that are muzzy.
         See <link
-        linkend="opt.muzzy_decay_time"><mallctl>opt.muzzy_decay_time</mallctl></link>
+        linkend="opt.muzzy_decay_ms"><mallctl>opt.muzzy_decay_ms</mallctl></link>
         for a description of muzzy pages.</para></listitem>
       </varlistentry>
 

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -13,8 +13,8 @@ static const size_t	large_pad =
 #endif
     ;
 
-extern ssize_t		opt_dirty_decay_time;
-extern ssize_t		opt_muzzy_decay_time;
+extern ssize_t		opt_dirty_decay_ms;
+extern ssize_t		opt_muzzy_decay_ms;
 
 extern const arena_bin_info_t	arena_bin_info[NBINS];
 
@@ -27,10 +27,10 @@ void arena_stats_large_nrequests_add(tsdn_t *tsdn, arena_stats_t *arena_stats,
 void arena_stats_mapped_add(tsdn_t *tsdn, arena_stats_t *arena_stats,
     size_t size);
 void	arena_basic_stats_merge(tsdn_t *tsdn, arena_t *arena,
-    unsigned *nthreads, const char **dss, ssize_t *dirty_decay_time,
-    ssize_t *muzzy_decay_time, size_t *nactive, size_t *ndirty, size_t *nmuzzy);
+    unsigned *nthreads, const char **dss, ssize_t *dirty_decay_ms,
+    ssize_t *muzzy_decay_ms, size_t *nactive, size_t *ndirty, size_t *nmuzzy);
 void arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
-    const char **dss, ssize_t *dirty_decay_time, ssize_t *muzzy_decay_time,
+    const char **dss, ssize_t *dirty_decay_ms, ssize_t *muzzy_decay_ms,
     size_t *nactive, size_t *ndirty, size_t *nmuzzy, arena_stats_t *astats,
     malloc_bin_stats_t *bstats, malloc_large_stats_t *lstats);
 void	arena_extents_dirty_dalloc(tsdn_t *tsdn, arena_t *arena,
@@ -46,12 +46,10 @@ void	arena_extent_ralloc_large_shrink(tsdn_t *tsdn, arena_t *arena,
     extent_t *extent, size_t oldsize);
 void	arena_extent_ralloc_large_expand(tsdn_t *tsdn, arena_t *arena,
     extent_t *extent, size_t oldsize);
-ssize_t arena_dirty_decay_time_get(arena_t *arena);
-bool arena_dirty_decay_time_set(tsdn_t *tsdn, arena_t *arena,
-    ssize_t decay_time);
-ssize_t arena_muzzy_decay_time_get(arena_t *arena);
-bool arena_muzzy_decay_time_set(tsdn_t *tsdn, arena_t *arena,
-    ssize_t decay_time);
+ssize_t arena_dirty_decay_ms_get(arena_t *arena);
+bool arena_dirty_decay_ms_set(tsdn_t *tsdn, arena_t *arena, ssize_t decay_ms);
+ssize_t arena_muzzy_decay_ms_get(arena_t *arena);
+bool arena_muzzy_decay_ms_set(tsdn_t *tsdn, arena_t *arena, ssize_t decay_ms);
 void arena_decay(tsdn_t *tsdn, arena_t *arena, bool all);
 void	arena_reset(tsd_t *tsd, arena_t *arena);
 void	arena_destroy(tsd_t *tsd, arena_t *arena);
@@ -79,10 +77,10 @@ void *arena_ralloc(tsdn_t *tsdn, arena_t *arena, void *ptr, size_t oldsize,
     size_t size, size_t alignment, bool zero, tcache_t *tcache);
 dss_prec_t	arena_dss_prec_get(arena_t *arena);
 bool	arena_dss_prec_set(arena_t *arena, dss_prec_t dss_prec);
-ssize_t arena_dirty_decay_time_default_get(void);
-bool arena_dirty_decay_time_default_set(ssize_t decay_time);
-ssize_t arena_muzzy_decay_time_default_get(void);
-bool arena_muzzy_decay_time_default_set(ssize_t decay_time);
+ssize_t arena_dirty_decay_ms_default_get(void);
+bool arena_dirty_decay_ms_default_set(ssize_t decay_ms);
+ssize_t arena_muzzy_decay_ms_default_get(void);
+bool arena_muzzy_decay_ms_default_set(ssize_t decay_ms);
 unsigned	arena_nthreads_get(arena_t *arena, bool internal);
 void	arena_nthreads_inc(arena_t *arena, bool internal);
 void	arena_nthreads_dec(arena_t *arena, bool internal);

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -56,11 +56,11 @@ struct arena_decay_s {
 	 */
 	bool			purging;
 	/*
-	 * Approximate time in seconds from the creation of a set of unused
+	 * Approximate time in milliseconds from the creation of a set of unused
 	 * dirty pages until an equivalent set of unused dirty pages is purged
 	 * and/or reused.
 	 */
-	atomic_zd_t		time;
+	atomic_zd_t		time_ms;
 	/* time / SMOOTHSTEP_NSTEPS. */
 	nstime_t		interval;
 	/*

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -7,9 +7,9 @@
 #define LG_SLAB_MAXREGS		(LG_PAGE - LG_TINY_MIN)
 #define SLAB_MAXREGS		(1U << LG_SLAB_MAXREGS)
 
-/* Default decay times in seconds. */
-#define DIRTY_DECAY_TIME_DEFAULT	10
-#define MUZZY_DECAY_TIME_DEFAULT	10
+/* Default decay times in milliseconds. */
+#define DIRTY_DECAY_MS_DEFAULT	ZD(10 * 1000)
+#define MUZZY_DECAY_MS_DEFAULT	ZD(10 * 1000)
 /* Number of event ticks between time checks. */
 #define DECAY_NTICKS_PER_UPDATE	1000
 

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -64,8 +64,8 @@ struct ctl_arena_s {
 	/* Basic stats, supported even if !config_stats. */
 	unsigned nthreads;
 	const char *dss;
-	ssize_t dirty_decay_time;
-	ssize_t muzzy_decay_time;
+	ssize_t dirty_decay_ms;
+	ssize_t muzzy_decay_ms;
 	size_t pactive;
 	size_t pdirty;
 	size_t pmuzzy;

--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -41,6 +41,9 @@
 #ifndef SIZE_T_MAX
 #  define SIZE_T_MAX	SIZE_MAX
 #endif
+#ifndef SSIZE_MAX
+#  define SSIZE_MAX	((ssize_t)(SIZE_T_MAX >> 1))
+#endif
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -78,8 +78,8 @@ CTL_PROTO(opt_retain)
 CTL_PROTO(opt_dss)
 CTL_PROTO(opt_narenas)
 CTL_PROTO(opt_percpu_arena)
-CTL_PROTO(opt_dirty_decay_time)
-CTL_PROTO(opt_muzzy_decay_time)
+CTL_PROTO(opt_dirty_decay_ms)
+CTL_PROTO(opt_muzzy_decay_ms)
 CTL_PROTO(opt_stats_print)
 CTL_PROTO(opt_junk)
 CTL_PROTO(opt_zero)
@@ -106,8 +106,8 @@ CTL_PROTO(arena_i_purge)
 CTL_PROTO(arena_i_reset)
 CTL_PROTO(arena_i_destroy)
 CTL_PROTO(arena_i_dss)
-CTL_PROTO(arena_i_dirty_decay_time)
-CTL_PROTO(arena_i_muzzy_decay_time)
+CTL_PROTO(arena_i_dirty_decay_ms)
+CTL_PROTO(arena_i_muzzy_decay_ms)
 CTL_PROTO(arena_i_extent_hooks)
 INDEX_PROTO(arena_i)
 CTL_PROTO(arenas_bin_i_size)
@@ -117,8 +117,8 @@ INDEX_PROTO(arenas_bin_i)
 CTL_PROTO(arenas_lextent_i_size)
 INDEX_PROTO(arenas_lextent_i)
 CTL_PROTO(arenas_narenas)
-CTL_PROTO(arenas_dirty_decay_time)
-CTL_PROTO(arenas_muzzy_decay_time)
+CTL_PROTO(arenas_dirty_decay_ms)
+CTL_PROTO(arenas_muzzy_decay_ms)
 CTL_PROTO(arenas_quantum)
 CTL_PROTO(arenas_page)
 CTL_PROTO(arenas_tcache_max)
@@ -158,8 +158,8 @@ CTL_PROTO(stats_arenas_i_lextents_j_curlextents)
 INDEX_PROTO(stats_arenas_i_lextents_j)
 CTL_PROTO(stats_arenas_i_nthreads)
 CTL_PROTO(stats_arenas_i_dss)
-CTL_PROTO(stats_arenas_i_dirty_decay_time)
-CTL_PROTO(stats_arenas_i_muzzy_decay_time)
+CTL_PROTO(stats_arenas_i_dirty_decay_ms)
+CTL_PROTO(stats_arenas_i_muzzy_decay_ms)
 CTL_PROTO(stats_arenas_i_pactive)
 CTL_PROTO(stats_arenas_i_pdirty)
 CTL_PROTO(stats_arenas_i_pmuzzy)
@@ -264,8 +264,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("dss"),		CTL(opt_dss)},
 	{NAME("narenas"),	CTL(opt_narenas)},
 	{NAME("percpu_arena"),	CTL(opt_percpu_arena)},
-	{NAME("dirty_decay_time"), CTL(opt_dirty_decay_time)},
-	{NAME("muzzy_decay_time"), CTL(opt_muzzy_decay_time)},
+	{NAME("dirty_decay_ms"), CTL(opt_dirty_decay_ms)},
+	{NAME("muzzy_decay_ms"), CTL(opt_muzzy_decay_ms)},
 	{NAME("stats_print"),	CTL(opt_stats_print)},
 	{NAME("junk"),		CTL(opt_junk)},
 	{NAME("zero"),		CTL(opt_zero)},
@@ -298,8 +298,8 @@ static const ctl_named_node_t arena_i_node[] = {
 	{NAME("reset"),		CTL(arena_i_reset)},
 	{NAME("destroy"),	CTL(arena_i_destroy)},
 	{NAME("dss"),		CTL(arena_i_dss)},
-	{NAME("dirty_decay_time"), CTL(arena_i_dirty_decay_time)},
-	{NAME("muzzy_decay_time"), CTL(arena_i_muzzy_decay_time)},
+	{NAME("dirty_decay_ms"), CTL(arena_i_dirty_decay_ms)},
+	{NAME("muzzy_decay_ms"), CTL(arena_i_muzzy_decay_ms)},
 	{NAME("extent_hooks"),	CTL(arena_i_extent_hooks)}
 };
 static const ctl_named_node_t super_arena_i_node[] = {
@@ -336,8 +336,8 @@ static const ctl_indexed_node_t arenas_lextent_node[] = {
 
 static const ctl_named_node_t arenas_node[] = {
 	{NAME("narenas"),	CTL(arenas_narenas)},
-	{NAME("dirty_decay_time"), CTL(arenas_dirty_decay_time)},
-	{NAME("muzzy_decay_time"), CTL(arenas_muzzy_decay_time)},
+	{NAME("dirty_decay_ms"), CTL(arenas_dirty_decay_ms)},
+	{NAME("muzzy_decay_ms"), CTL(arenas_muzzy_decay_ms)},
 	{NAME("quantum"),	CTL(arenas_quantum)},
 	{NAME("page"),		CTL(arenas_page)},
 	{NAME("tcache_max"),	CTL(arenas_tcache_max)},
@@ -442,8 +442,8 @@ MUTEX_PROF_ARENA_MUTEXES
 static const ctl_named_node_t stats_arenas_i_node[] = {
 	{NAME("nthreads"),	CTL(stats_arenas_i_nthreads)},
 	{NAME("dss"),		CTL(stats_arenas_i_dss)},
-	{NAME("dirty_decay_time"), CTL(stats_arenas_i_dirty_decay_time)},
-	{NAME("muzzy_decay_time"), CTL(stats_arenas_i_muzzy_decay_time)},
+	{NAME("dirty_decay_ms"), CTL(stats_arenas_i_dirty_decay_ms)},
+	{NAME("muzzy_decay_ms"), CTL(stats_arenas_i_muzzy_decay_ms)},
 	{NAME("pactive"),	CTL(stats_arenas_i_pactive)},
 	{NAME("pdirty"),	CTL(stats_arenas_i_pdirty)},
 	{NAME("pmuzzy"),	CTL(stats_arenas_i_pmuzzy)},
@@ -642,8 +642,8 @@ static void
 ctl_arena_clear(ctl_arena_t *ctl_arena) {
 	ctl_arena->nthreads = 0;
 	ctl_arena->dss = dss_prec_names[dss_prec_limit];
-	ctl_arena->dirty_decay_time = -1;
-	ctl_arena->muzzy_decay_time = -1;
+	ctl_arena->dirty_decay_ms = -1;
+	ctl_arena->muzzy_decay_ms = -1;
 	ctl_arena->pactive = 0;
 	ctl_arena->pdirty = 0;
 	ctl_arena->pmuzzy = 0;
@@ -666,8 +666,8 @@ ctl_arena_stats_amerge(tsdn_t *tsdn, ctl_arena_t *ctl_arena, arena_t *arena) {
 
 	if (config_stats) {
 		arena_stats_merge(tsdn, arena, &ctl_arena->nthreads,
-		    &ctl_arena->dss, &ctl_arena->dirty_decay_time,
-		    &ctl_arena->muzzy_decay_time, &ctl_arena->pactive,
+		    &ctl_arena->dss, &ctl_arena->dirty_decay_ms,
+		    &ctl_arena->muzzy_decay_ms, &ctl_arena->pactive,
 		    &ctl_arena->pdirty, &ctl_arena->pmuzzy,
 		    &ctl_arena->astats->astats, ctl_arena->astats->bstats,
 		    ctl_arena->astats->lstats);
@@ -685,8 +685,8 @@ ctl_arena_stats_amerge(tsdn_t *tsdn, ctl_arena_t *ctl_arena, arena_t *arena) {
 		}
 	} else {
 		arena_basic_stats_merge(tsdn, arena, &ctl_arena->nthreads,
-		    &ctl_arena->dss, &ctl_arena->dirty_decay_time,
-		    &ctl_arena->muzzy_decay_time, &ctl_arena->pactive,
+		    &ctl_arena->dss, &ctl_arena->dirty_decay_ms,
+		    &ctl_arena->muzzy_decay_ms, &ctl_arena->pactive,
 		    &ctl_arena->pdirty, &ctl_arena->pmuzzy);
 	}
 }
@@ -1459,8 +1459,8 @@ CTL_RO_NL_GEN(opt_retain, opt_retain, bool)
 CTL_RO_NL_GEN(opt_dss, opt_dss, const char *)
 CTL_RO_NL_GEN(opt_narenas, opt_narenas, unsigned)
 CTL_RO_NL_GEN(opt_percpu_arena, opt_percpu_arena, const char *)
-CTL_RO_NL_GEN(opt_dirty_decay_time, opt_dirty_decay_time, ssize_t)
-CTL_RO_NL_GEN(opt_muzzy_decay_time, opt_muzzy_decay_time, ssize_t)
+CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
+CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)
 CTL_RO_NL_CGEN(config_fill, opt_junk, opt_junk, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_zero, opt_zero, bool)
@@ -1949,7 +1949,7 @@ label_return:
 }
 
 static int
-arena_i_decay_time_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arena_i_decay_ms_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen, bool dirty) {
 	int ret;
 	unsigned arena_ind;
@@ -1963,8 +1963,8 @@ arena_i_decay_time_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
 	}
 
 	if (oldp != NULL && oldlenp != NULL) {
-		size_t oldval = dirty ? arena_dirty_decay_time_get(arena) :
-		    arena_muzzy_decay_time_get(arena);
+		size_t oldval = dirty ? arena_dirty_decay_ms_get(arena) :
+		    arena_muzzy_decay_ms_get(arena);
 		READ(oldval, ssize_t);
 	}
 	if (newp != NULL) {
@@ -1972,10 +1972,9 @@ arena_i_decay_time_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
 			ret = EINVAL;
 			goto label_return;
 		}
-		if (dirty ? arena_dirty_decay_time_set(tsd_tsdn(tsd), arena,
-		    *(ssize_t *)newp) :
-		    arena_muzzy_decay_time_set(tsd_tsdn(tsd), arena,
-		    *(ssize_t *)newp)) {
+		if (dirty ? arena_dirty_decay_ms_set(tsd_tsdn(tsd), arena,
+		    *(ssize_t *)newp) : arena_muzzy_decay_ms_set(tsd_tsdn(tsd),
+		    arena, *(ssize_t *)newp)) {
 			ret = EFAULT;
 			goto label_return;
 		}
@@ -1987,17 +1986,17 @@ label_return:
 }
 
 static int
-arena_i_dirty_decay_time_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arena_i_dirty_decay_ms_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
-	return arena_i_decay_time_ctl_impl(tsd, mib, miblen, oldp, oldlenp,
-	    newp, newlen, true);
+	return arena_i_decay_ms_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
+	    newlen, true);
 }
 
 static int
-arena_i_muzzy_decay_time_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arena_i_muzzy_decay_ms_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
-	return arena_i_decay_time_ctl_impl(tsd, mib, miblen, oldp, oldlenp,
-	    newp, newlen, false);
+	return arena_i_decay_ms_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
+	    newlen, false);
 }
 
 static int
@@ -2081,13 +2080,13 @@ label_return:
 }
 
 static int
-arenas_decay_time_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arenas_decay_ms_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen, bool dirty) {
 	int ret;
 
 	if (oldp != NULL && oldlenp != NULL) {
-		size_t oldval = (dirty ? arena_dirty_decay_time_default_get() :
-		    arena_muzzy_decay_time_default_get());
+		size_t oldval = (dirty ? arena_dirty_decay_ms_default_get() :
+		    arena_muzzy_decay_ms_default_get());
 		READ(oldval, ssize_t);
 	}
 	if (newp != NULL) {
@@ -2095,8 +2094,8 @@ arenas_decay_time_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
 			ret = EINVAL;
 			goto label_return;
 		}
-		if (dirty ? arena_dirty_decay_time_default_set(*(ssize_t *)newp)
-		    : arena_muzzy_decay_time_default_set(*(ssize_t *)newp)) {
+		if (dirty ?  arena_dirty_decay_ms_default_set(*(ssize_t *)newp)
+		    : arena_muzzy_decay_ms_default_set(*(ssize_t *)newp)) {
 			ret = EFAULT;
 			goto label_return;
 		}
@@ -2108,16 +2107,16 @@ label_return:
 }
 
 static int
-arenas_dirty_decay_time_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arenas_dirty_decay_ms_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
-	return arenas_decay_time_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
+	return arenas_decay_ms_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
 	    newlen, true);
 }
 
 static int
-arenas_muzzy_decay_time_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
+arenas_muzzy_decay_ms_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
-	return arenas_decay_time_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
+	return arenas_decay_ms_ctl_impl(tsd, mib, miblen, oldp, oldlenp, newp,
 	    newlen, false);
 }
 
@@ -2312,9 +2311,9 @@ CTL_RO_CGEN(config_stats, stats_mapped, ctl_stats->mapped, size_t)
 CTL_RO_CGEN(config_stats, stats_retained, ctl_stats->retained, size_t)
 
 CTL_RO_GEN(stats_arenas_i_dss, arenas_i(mib[2])->dss, const char *)
-CTL_RO_GEN(stats_arenas_i_dirty_decay_time, arenas_i(mib[2])->dirty_decay_time,
+CTL_RO_GEN(stats_arenas_i_dirty_decay_ms, arenas_i(mib[2])->dirty_decay_ms,
     ssize_t)
-CTL_RO_GEN(stats_arenas_i_muzzy_decay_time, arenas_i(mib[2])->muzzy_decay_time,
+CTL_RO_GEN(stats_arenas_i_muzzy_decay_ms, arenas_i(mib[2])->muzzy_decay_ms,
     ssize_t)
 CTL_RO_GEN(stats_arenas_i_nthreads, arenas_i(mib[2])->nthreads, unsigned)
 CTL_RO_GEN(stats_arenas_i_pactive, arenas_i(mib[2])->pactive, size_t)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1070,10 +1070,14 @@ malloc_conf_init(void) {
 			}
 			CONF_HANDLE_UNSIGNED(opt_narenas, "narenas", 1,
 			    UINT_MAX, yes, no, false)
-			CONF_HANDLE_SSIZE_T(opt_dirty_decay_time,
-			    "dirty_decay_time", -1, NSTIME_SEC_MAX);
-			CONF_HANDLE_SSIZE_T(opt_muzzy_decay_time,
-			    "muzzy_decay_time", -1, NSTIME_SEC_MAX);
+			CONF_HANDLE_SSIZE_T(opt_dirty_decay_ms,
+			    "dirty_decay_ms", -1, NSTIME_SEC_MAX * KQU(1000) <
+			    QU(SSIZE_MAX) ? NSTIME_SEC_MAX * KQU(1000) :
+			    SSIZE_MAX);
+			CONF_HANDLE_SSIZE_T(opt_muzzy_decay_ms,
+			    "muzzy_decay_ms", -1, NSTIME_SEC_MAX * KQU(1000) <
+			    QU(SSIZE_MAX) ? NSTIME_SEC_MAX * KQU(1000) :
+			    SSIZE_MAX);
 			CONF_HANDLE_BOOL(opt_stats_print, "stats_print")
 			if (config_fill) {
 				if (CONF_MATCH("junk")) {

--- a/test/unit/decay.sh
+++ b/test/unit/decay.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="dirty_decay_time:1,muzzy_decay_time:1,lg_tcache_max:0"
+export MALLOC_CONF="dirty_decay_ms:1000,muzzy_decay_ms:1000,lg_tcache_max:0"

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -161,8 +161,8 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(const char *, dss, always);
 	TEST_MALLCTL_OPT(unsigned, narenas, always);
 	TEST_MALLCTL_OPT(const char *, percpu_arena, always);
-	TEST_MALLCTL_OPT(ssize_t, dirty_decay_time, always);
-	TEST_MALLCTL_OPT(ssize_t, muzzy_decay_time, always);
+	TEST_MALLCTL_OPT(ssize_t, dirty_decay_ms, always);
+	TEST_MALLCTL_OPT(ssize_t, muzzy_decay_ms, always);
 	TEST_MALLCTL_OPT(bool, stats_print, always);
 	TEST_MALLCTL_OPT(const char *, junk, fill);
 	TEST_MALLCTL_OPT(bool, zero, fill);
@@ -398,68 +398,66 @@ TEST_BEGIN(test_arena_i_initialized) {
 }
 TEST_END
 
-TEST_BEGIN(test_arena_i_dirty_decay_time) {
-	ssize_t dirty_decay_time, orig_dirty_decay_time, prev_dirty_decay_time;
+TEST_BEGIN(test_arena_i_dirty_decay_ms) {
+	ssize_t dirty_decay_ms, orig_dirty_decay_ms, prev_dirty_decay_ms;
 	size_t sz = sizeof(ssize_t);
 
-	assert_d_eq(mallctl("arena.0.dirty_decay_time",
-	    (void *)&orig_dirty_decay_time, &sz, NULL, 0), 0,
+	assert_d_eq(mallctl("arena.0.dirty_decay_ms",
+	    (void *)&orig_dirty_decay_ms, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 
-	dirty_decay_time = -2;
-	assert_d_eq(mallctl("arena.0.dirty_decay_time", NULL, NULL,
-	    (void *)&dirty_decay_time, sizeof(ssize_t)), EFAULT,
+	dirty_decay_ms = -2;
+	assert_d_eq(mallctl("arena.0.dirty_decay_ms", NULL, NULL,
+	    (void *)&dirty_decay_ms, sizeof(ssize_t)), EFAULT,
 	    "Unexpected mallctl() success");
 
-	dirty_decay_time = 0x7fffffff;
-	assert_d_eq(mallctl("arena.0.dirty_decay_time", NULL, NULL,
-	    (void *)&dirty_decay_time, sizeof(ssize_t)), 0,
+	dirty_decay_ms = 0x7fffffff;
+	assert_d_eq(mallctl("arena.0.dirty_decay_ms", NULL, NULL,
+	    (void *)&dirty_decay_ms, sizeof(ssize_t)), 0,
 	    "Unexpected mallctl() failure");
 
-	for (prev_dirty_decay_time = dirty_decay_time, dirty_decay_time = -1;
-	    dirty_decay_time < 20; prev_dirty_decay_time = dirty_decay_time,
-	    dirty_decay_time++) {
-		ssize_t old_dirty_decay_time;
+	for (prev_dirty_decay_ms = dirty_decay_ms, dirty_decay_ms = -1;
+	    dirty_decay_ms < 20; prev_dirty_decay_ms = dirty_decay_ms,
+	    dirty_decay_ms++) {
+		ssize_t old_dirty_decay_ms;
 
-		assert_d_eq(mallctl("arena.0.dirty_decay_time",
-		    (void *)&old_dirty_decay_time, &sz,
-		    (void *)&dirty_decay_time, sizeof(ssize_t)), 0,
-		    "Unexpected mallctl() failure");
-		assert_zd_eq(old_dirty_decay_time, prev_dirty_decay_time,
-		    "Unexpected old arena.0.dirty_decay_time");
+		assert_d_eq(mallctl("arena.0.dirty_decay_ms",
+		    (void *)&old_dirty_decay_ms, &sz, (void *)&dirty_decay_ms,
+		    sizeof(ssize_t)), 0, "Unexpected mallctl() failure");
+		assert_zd_eq(old_dirty_decay_ms, prev_dirty_decay_ms,
+		    "Unexpected old arena.0.dirty_decay_ms");
 	}
 }
 TEST_END
 
-TEST_BEGIN(test_arena_i_muzzy_decay_time) {
-	ssize_t muzzy_decay_time, orig_muzzy_decay_time, prev_muzzy_decay_time;
+TEST_BEGIN(test_arena_i_muzzy_decay_ms) {
+	ssize_t muzzy_decay_ms, orig_muzzy_decay_ms, prev_muzzy_decay_ms;
 	size_t sz = sizeof(ssize_t);
 
-	assert_d_eq(mallctl("arena.0.muzzy_decay_time",
-	    (void *)&orig_muzzy_decay_time, &sz, NULL, 0), 0,
+	assert_d_eq(mallctl("arena.0.muzzy_decay_ms",
+	    (void *)&orig_muzzy_decay_ms, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 
-	muzzy_decay_time = -2;
-	assert_d_eq(mallctl("arena.0.muzzy_decay_time", NULL, NULL,
-	    (void *)&muzzy_decay_time, sizeof(ssize_t)), EFAULT,
+	muzzy_decay_ms = -2;
+	assert_d_eq(mallctl("arena.0.muzzy_decay_ms", NULL, NULL,
+	    (void *)&muzzy_decay_ms, sizeof(ssize_t)), EFAULT,
 	    "Unexpected mallctl() success");
 
-	muzzy_decay_time = 0x7fffffff;
-	assert_d_eq(mallctl("arena.0.muzzy_decay_time", NULL, NULL,
-	    (void *)&muzzy_decay_time, sizeof(ssize_t)), 0,
+	muzzy_decay_ms = 0x7fffffff;
+	assert_d_eq(mallctl("arena.0.muzzy_decay_ms", NULL, NULL,
+	    (void *)&muzzy_decay_ms, sizeof(ssize_t)), 0,
 	    "Unexpected mallctl() failure");
 
-	for (prev_muzzy_decay_time = muzzy_decay_time, muzzy_decay_time = -1;
-	    muzzy_decay_time < 20; prev_muzzy_decay_time = muzzy_decay_time,
-	    muzzy_decay_time++) {
-		ssize_t old_muzzy_decay_time;
+	for (prev_muzzy_decay_ms = muzzy_decay_ms, muzzy_decay_ms = -1;
+	    muzzy_decay_ms < 20; prev_muzzy_decay_ms = muzzy_decay_ms,
+	    muzzy_decay_ms++) {
+		ssize_t old_muzzy_decay_ms;
 
-		assert_d_eq(mallctl("arena.0.muzzy_decay_time",
-		    (void *)&old_muzzy_decay_time, &sz,
-		    (void *)&muzzy_decay_time, sizeof(ssize_t)), 0,
-		    "Unexpected mallctl() failure");
-		assert_zd_eq(old_muzzy_decay_time, prev_muzzy_decay_time,
-		    "Unexpected old arena.0.muzzy_decay_time");
+		assert_d_eq(mallctl("arena.0.muzzy_decay_ms",
+		    (void *)&old_muzzy_decay_ms, &sz, (void *)&muzzy_decay_ms,
+		    sizeof(ssize_t)), 0, "Unexpected mallctl() failure");
+		assert_zd_eq(old_muzzy_decay_ms, prev_muzzy_decay_ms,
+		    "Unexpected old arena.0.muzzy_decay_ms");
 	}
 }
 TEST_END
@@ -555,68 +553,66 @@ TEST_BEGIN(test_arena_i_dss) {
 }
 TEST_END
 
-TEST_BEGIN(test_arenas_dirty_decay_time) {
-	ssize_t dirty_decay_time, orig_dirty_decay_time, prev_dirty_decay_time;
+TEST_BEGIN(test_arenas_dirty_decay_ms) {
+	ssize_t dirty_decay_ms, orig_dirty_decay_ms, prev_dirty_decay_ms;
 	size_t sz = sizeof(ssize_t);
 
-	assert_d_eq(mallctl("arenas.dirty_decay_time",
-	    (void *)&orig_dirty_decay_time, &sz, NULL, 0), 0,
+	assert_d_eq(mallctl("arenas.dirty_decay_ms",
+	    (void *)&orig_dirty_decay_ms, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 
-	dirty_decay_time = -2;
-	assert_d_eq(mallctl("arenas.dirty_decay_time", NULL, NULL,
-	    (void *)&dirty_decay_time, sizeof(ssize_t)), EFAULT,
+	dirty_decay_ms = -2;
+	assert_d_eq(mallctl("arenas.dirty_decay_ms", NULL, NULL,
+	    (void *)&dirty_decay_ms, sizeof(ssize_t)), EFAULT,
 	    "Unexpected mallctl() success");
 
-	dirty_decay_time = 0x7fffffff;
-	assert_d_eq(mallctl("arenas.dirty_decay_time", NULL, NULL,
-	    (void *)&dirty_decay_time, sizeof(ssize_t)), 0,
+	dirty_decay_ms = 0x7fffffff;
+	assert_d_eq(mallctl("arenas.dirty_decay_ms", NULL, NULL,
+	    (void *)&dirty_decay_ms, sizeof(ssize_t)), 0,
 	    "Expected mallctl() failure");
 
-	for (prev_dirty_decay_time = dirty_decay_time, dirty_decay_time = -1;
-	    dirty_decay_time < 20; prev_dirty_decay_time = dirty_decay_time,
-	    dirty_decay_time++) {
-		ssize_t old_dirty_decay_time;
+	for (prev_dirty_decay_ms = dirty_decay_ms, dirty_decay_ms = -1;
+	    dirty_decay_ms < 20; prev_dirty_decay_ms = dirty_decay_ms,
+	    dirty_decay_ms++) {
+		ssize_t old_dirty_decay_ms;
 
-		assert_d_eq(mallctl("arenas.dirty_decay_time",
-		    (void *)&old_dirty_decay_time, &sz,
-		    (void *)&dirty_decay_time, sizeof(ssize_t)), 0,
-		    "Unexpected mallctl() failure");
-		assert_zd_eq(old_dirty_decay_time, prev_dirty_decay_time,
-		    "Unexpected old arenas.dirty_decay_time");
+		assert_d_eq(mallctl("arenas.dirty_decay_ms",
+		    (void *)&old_dirty_decay_ms, &sz, (void *)&dirty_decay_ms,
+		    sizeof(ssize_t)), 0, "Unexpected mallctl() failure");
+		assert_zd_eq(old_dirty_decay_ms, prev_dirty_decay_ms,
+		    "Unexpected old arenas.dirty_decay_ms");
 	}
 }
 TEST_END
 
-TEST_BEGIN(test_arenas_muzzy_decay_time) {
-	ssize_t muzzy_decay_time, orig_muzzy_decay_time, prev_muzzy_decay_time;
+TEST_BEGIN(test_arenas_muzzy_decay_ms) {
+	ssize_t muzzy_decay_ms, orig_muzzy_decay_ms, prev_muzzy_decay_ms;
 	size_t sz = sizeof(ssize_t);
 
-	assert_d_eq(mallctl("arenas.muzzy_decay_time",
-	    (void *)&orig_muzzy_decay_time, &sz, NULL, 0), 0,
+	assert_d_eq(mallctl("arenas.muzzy_decay_ms",
+	    (void *)&orig_muzzy_decay_ms, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 
-	muzzy_decay_time = -2;
-	assert_d_eq(mallctl("arenas.muzzy_decay_time", NULL, NULL,
-	    (void *)&muzzy_decay_time, sizeof(ssize_t)), EFAULT,
+	muzzy_decay_ms = -2;
+	assert_d_eq(mallctl("arenas.muzzy_decay_ms", NULL, NULL,
+	    (void *)&muzzy_decay_ms, sizeof(ssize_t)), EFAULT,
 	    "Unexpected mallctl() success");
 
-	muzzy_decay_time = 0x7fffffff;
-	assert_d_eq(mallctl("arenas.muzzy_decay_time", NULL, NULL,
-	    (void *)&muzzy_decay_time, sizeof(ssize_t)), 0,
+	muzzy_decay_ms = 0x7fffffff;
+	assert_d_eq(mallctl("arenas.muzzy_decay_ms", NULL, NULL,
+	    (void *)&muzzy_decay_ms, sizeof(ssize_t)), 0,
 	    "Expected mallctl() failure");
 
-	for (prev_muzzy_decay_time = muzzy_decay_time, muzzy_decay_time = -1;
-	    muzzy_decay_time < 20; prev_muzzy_decay_time = muzzy_decay_time,
-	    muzzy_decay_time++) {
-		ssize_t old_muzzy_decay_time;
+	for (prev_muzzy_decay_ms = muzzy_decay_ms, muzzy_decay_ms = -1;
+	    muzzy_decay_ms < 20; prev_muzzy_decay_ms = muzzy_decay_ms,
+	    muzzy_decay_ms++) {
+		ssize_t old_muzzy_decay_ms;
 
-		assert_d_eq(mallctl("arenas.muzzy_decay_time",
-		    (void *)&old_muzzy_decay_time, &sz,
-		    (void *)&muzzy_decay_time, sizeof(ssize_t)), 0,
-		    "Unexpected mallctl() failure");
-		assert_zd_eq(old_muzzy_decay_time, prev_muzzy_decay_time,
-		    "Unexpected old arenas.muzzy_decay_time");
+		assert_d_eq(mallctl("arenas.muzzy_decay_ms",
+		    (void *)&old_muzzy_decay_ms, &sz, (void *)&muzzy_decay_ms,
+		    sizeof(ssize_t)), 0, "Unexpected mallctl() failure");
+		assert_zd_eq(old_muzzy_decay_ms, prev_muzzy_decay_ms,
+		    "Unexpected old arenas.muzzy_decay_ms");
 	}
 }
 TEST_END
@@ -699,8 +695,8 @@ TEST_BEGIN(test_stats_arenas) {
 
 	TEST_STATS_ARENAS(unsigned, nthreads);
 	TEST_STATS_ARENAS(const char *, dss);
-	TEST_STATS_ARENAS(ssize_t, dirty_decay_time);
-	TEST_STATS_ARENAS(ssize_t, muzzy_decay_time);
+	TEST_STATS_ARENAS(ssize_t, dirty_decay_ms);
+	TEST_STATS_ARENAS(ssize_t, muzzy_decay_ms);
 	TEST_STATS_ARENAS(size_t, pactive);
 	TEST_STATS_ARENAS(size_t, pdirty);
 
@@ -723,13 +719,13 @@ main(void) {
 	    test_tcache,
 	    test_thread_arena,
 	    test_arena_i_initialized,
-	    test_arena_i_dirty_decay_time,
-	    test_arena_i_muzzy_decay_time,
+	    test_arena_i_dirty_decay_ms,
+	    test_arena_i_muzzy_decay_ms,
 	    test_arena_i_purge,
 	    test_arena_i_decay,
 	    test_arena_i_dss,
-	    test_arenas_dirty_decay_time,
-	    test_arenas_muzzy_decay_time,
+	    test_arenas_dirty_decay_ms,
+	    test_arenas_muzzy_decay_ms,
 	    test_arenas_constants,
 	    test_arenas_bin_constants,
 	    test_arenas_lextent_constants,

--- a/test/unit/pack.sh
+++ b/test/unit/pack.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Immediately purge to minimize fragmentation.
-export MALLOC_CONF="dirty_decay_time:0,muzzy_decay_time:0"
+export MALLOC_CONF="dirty_decay_ms:0,muzzy_decay_ms:0"


### PR DESCRIPTION
Support millisecond resolution for decay times.  Among other use cases
this makes it possible to specify a short initial dirty-->muzzy decay
phase, followed by a longer muzzy-->clean decay phase.

This resolves #812.