### PR TITLE
Fix # of unpurged pages in decay algorithm.

### DIFF
--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -103,6 +103,8 @@ struct arena_decay_s {
 	 *
 	 * Synchronization: Same as associated arena's stats field. */
 	decay_stats_t		*stats;
+	/* Peak number of pages in associated extents.  Used for debug only. */
+	uint64_t		ceil_npages;
 };
 
 struct arena_bin_s {


### PR DESCRIPTION
When # of dirty pages move below npages_limit (e.g. they are reused), we should
not lower number of unpurged pages because that would cause the reused pages to
be double counted in the backlog (as a result, decay happen slower than it
should).  Instead, set number of unpurged to the greater of current npages and
npages_limit.
    
Added an assertion: peak # of pages should be greater than npages_limit.

This resolves #813.