### PR TITLE
Add opt.stats_print_opts.

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -410,6 +410,8 @@ for (i = 0; i < nbins; i++) {
 	/* Do something with bin_size... */
 }]]></programlisting></para>
 
+      <varlistentry id="malloc_stats_print_opts">
+      </varlistentry>
       <para>The <function>malloc_stats_print()</function> function writes
       summary statistics via the <parameter>write_cb</parameter> callback
       function pointer and <parameter>cbopaque</parameter> data passed to
@@ -1046,7 +1048,9 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         enabled, the <function>malloc_stats_print()</function>
         function is called at program exit via an
         <citerefentry><refentrytitle>atexit</refentrytitle>
-        <manvolnum>3</manvolnum></citerefentry> function.  If
+        <manvolnum>3</manvolnum></citerefentry> function.  <link
+        linkend="opt.stats_print_opts"><mallctl>opt.stats_print_opts</mallctl></link>
+        can be combined to specify output options. If
         <option>--enable-stats</option> is specified during configuration, this
         has the potential to cause deadlock for a multi-threaded process that
         exits while one or more threads are executing in the memory allocation
@@ -1059,6 +1063,23 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         functionality).  Therefore, this option should only be used with care;
         it is primarily intended as a performance tuning aid during application
         development.  This option is disabled by default.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="opt.stats_print_opts">
+        <term>
+          <mallctl>opt.stats_print_opts</mallctl>
+          (<type>const char *</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Options (the <parameter>opts</parameter> string) to pass
+        to the <function>malloc_stats_print()</function> at exit (enabled
+        through <link
+        linkend="opt.stats_print"><mallctl>opt.stats_print</mallctl></link>). See
+        available options in <link
+        linkend="malloc_stats_print_opts"><function>malloc_stats_print()</function></link>.
+        Has no effect unless <link
+        linkend="opt.stats_print"><mallctl>opt.stats_print</mallctl></link> is
+        enabled.  The default is <quote></quote>.</para></listitem>
       </varlistentry>
 
       <varlistentry id="opt.junk">

--- a/include/jemalloc/internal/stats.h
+++ b/include/jemalloc/internal/stats.h
@@ -7,8 +7,27 @@
 #include "jemalloc/internal/size_classes.h"
 #include "jemalloc/internal/stats_tsd.h"
 
-/* The opt.stats_print storage. */
+/*  OPTION(opt,		var_name,	default,	set_value_to) */
+#define STATS_PRINT_OPTIONS						\
+    OPTION('J',		json,		false,		true)		\
+    OPTION('g',		general,	true,		false)		\
+    OPTION('m',		merged,		config_stats,	false)		\
+    OPTION('d',		destroyed,	config_stats,	false)		\
+    OPTION('a',		unmerged,	config_stats,	false)		\
+    OPTION('b',		bins,		true,		false)		\
+    OPTION('l',		large,		true,		false)		\
+    OPTION('x',		mutex,		true,		false)
+
+enum {
+#define OPTION(o, v, d, s) stats_print_option_num_##v,
+    STATS_PRINT_OPTIONS
+#undef OPTION
+    stats_print_tot_num_options
+};
+
+/* Options for stats_print. */
 extern bool opt_stats_print;
+extern char opt_stats_print_opts[stats_print_tot_num_options+1];
 
 /* Implements je_malloc_stats_print. */
 void stats_print(void (*write_cb)(void *, const char *), void *cbopaque,

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -85,6 +85,7 @@ CTL_PROTO(opt_background_thread)
 CTL_PROTO(opt_dirty_decay_ms)
 CTL_PROTO(opt_muzzy_decay_ms)
 CTL_PROTO(opt_stats_print)
+CTL_PROTO(opt_stats_print_opts)
 CTL_PROTO(opt_junk)
 CTL_PROTO(opt_zero)
 CTL_PROTO(opt_utrace)
@@ -277,6 +278,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("dirty_decay_ms"), CTL(opt_dirty_decay_ms)},
 	{NAME("muzzy_decay_ms"), CTL(opt_muzzy_decay_ms)},
 	{NAME("stats_print"),	CTL(opt_stats_print)},
+	{NAME("stats_print_opts"),	CTL(opt_stats_print_opts)},
 	{NAME("junk"),		CTL(opt_junk)},
 	{NAME("zero"),		CTL(opt_zero)},
 	{NAME("utrace"),	CTL(opt_utrace)},
@@ -1557,6 +1559,7 @@ CTL_RO_NL_GEN(opt_background_thread, opt_background_thread, bool)
 CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)
+CTL_RO_NL_GEN(opt_stats_print_opts, opt_stats_print_opts, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_junk, opt_junk, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_zero, opt_zero, bool)
 CTL_RO_NL_CGEN(config_utrace, opt_utrace, opt_utrace, bool)


### PR DESCRIPTION
The value is passed to atexit(3)-triggered malloc_stats_print() calls.

This resolves #698