### PR TITLE
Test with background_thread:true.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: osx
       env: CC=clang CXX=clang++ COMPILER_FLAGS="" CONFIGURE_FLAGS="" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: osx
@@ -54,6 +56,8 @@ matrix:
       env: CC=clang CXX=clang++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=clang CXX=clang++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      env: CC=clang CXX=clang++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="-m32" CONFIGURE_FLAGS="--enable-debug" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
       addons:
@@ -91,6 +95,12 @@ matrix:
           packages:
             - gcc-multilib
     - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="-m32" CONFIGURE_FLAGS="--with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-debug --enable-prof" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-debug --disable-stats" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
@@ -101,6 +111,8 @@ matrix:
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-debug --with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-debug --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-prof --disable-stats" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-prof --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
@@ -109,17 +121,27 @@ matrix:
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-prof --with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--enable-prof --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--disable-stats --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--disable-stats --with-malloc-conf=dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--disable-stats --with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--disable-stats --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=tcache:false,dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=tcache:false,percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=tcache:false,background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
       env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=dss:primary,percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=dss:primary,background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      env: CC=gcc CXX=g++ COMPILER_FLAGS="" CONFIGURE_FLAGS="--with-malloc-conf=percpu_arena:percpu,background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
 
 
 before_script:

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -11,9 +11,8 @@ extern ssize_t opt_muzzy_decay_ms;
 
 extern const arena_bin_info_t arena_bin_info[NBINS];
 
-extern percpu_arena_mode_t percpu_arena_mode;
-extern const char	*opt_percpu_arena;
-extern const char	*percpu_arena_mode_names[];
+extern percpu_arena_mode_t opt_percpu_arena;
+extern const char *percpu_arena_mode_names[];
 
 extern const uint64_t h_steps[SMOOTHSTEP_NSTEPS];
 

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -20,14 +20,26 @@ typedef struct arena_tdata_s arena_tdata_t;
 typedef struct alloc_ctx_s alloc_ctx_t;
 
 typedef enum {
-	percpu_arena_disabled = 0,
-	percpu_arena = 1,
-	per_phycpu_arena = 2, /* i.e. hyper threads share arena. */
+	percpu_arena_mode_names_base   = 0, /* Used for options processing. */
 
-	percpu_arena_mode_limit = 3
+	/*
+	 * *_uninit are used only during bootstrapping, and must correspond
+	 * to initialized variant plus percpu_arena_mode_enabled_base.
+	 */
+	percpu_arena_uninit            = 0,
+	per_phycpu_arena_uninit        = 1,
+
+	/* All non-disabled modes must come after percpu_arena_disabled. */
+	percpu_arena_disabled          = 2,
+
+	percpu_arena_mode_names_limit  = 3, /* Used for options processing. */
+	percpu_arena_mode_enabled_base = 3,
+
+	percpu_arena                   = 3,
+	per_phycpu_arena               = 4  /* Hyper threads share arena. */
 } percpu_arena_mode_t;
 
-#define PERCPU_ARENA_MODE_DEFAULT	percpu_arena_disabled
-#define OPT_PERCPU_ARENA_DEFAULT	"disabled"
+#define PERCPU_ARENA_ENABLED(m)	((m) >= percpu_arena_mode_enabled_base)
+#define PERCPU_ARENA_DEFAULT	percpu_arena_disabled
 
 #endif /* JEMALLOC_INTERNAL_ARENA_TYPES_H */

--- a/include/jemalloc/internal/background_thread_externs.h
+++ b/include/jemalloc/internal/background_thread_externs.h
@@ -8,7 +8,6 @@ extern size_t n_background_threads;
 extern background_thread_info_t *background_thread_info;
 
 bool background_thread_create(tsd_t *tsd, unsigned arena_ind);
-bool background_threads_init(tsd_t *tsd);
 bool background_threads_enable(tsd_t *tsd);
 bool background_threads_disable(tsd_t *tsd);
 bool background_threads_disable_single(tsd_t *tsd,
@@ -22,10 +21,11 @@ void background_thread_postfork_child(tsdn_t *tsdn);
 bool background_thread_stats_read(tsdn_t *tsdn,
     background_thread_stats_t *stats);
 
-#if defined(JEMALLOC_BACKGROUND_THREAD) || defined(JEMALLOC_LAZY_LOCK)
-extern int (*pthread_create_fptr)(pthread_t *__restrict, const pthread_attr_t *,
+#ifdef JEMALLOC_PTHREAD_CREATE_WRAPPER
+extern int pthread_create_wrapper(pthread_t *__restrict, const pthread_attr_t *,
     void *(*)(void *), void *__restrict);
-void *load_pthread_create_fptr(void);
 #endif
+bool background_thread_boot0(void);
+bool background_thread_boot1(tsdn_t *tsdn);
 
 #endif /* JEMALLOC_INTERNAL_BACKGROUND_THREAD_EXTERNS_H */

--- a/include/jemalloc/internal/background_thread_structs.h
+++ b/include/jemalloc/internal/background_thread_structs.h
@@ -3,6 +3,10 @@
 
 /* This file really combines "structs" and "types", but only transitionally. */
 
+#if defined(JEMALLOC_BACKGROUND_THREAD) || defined(JEMALLOC_LAZY_LOCK)
+#  define JEMALLOC_PTHREAD_CREATE_WRAPPER
+#endif
+
 #define BACKGROUND_THREAD_INDEFINITE_SLEEP UINT64_MAX
 
 struct background_thread_info_s {

--- a/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -43,9 +43,10 @@ arena_choose_impl(tsd_t *tsd, arena_t *arena, bool internal) {
 	 * auto percpu arena range, (i.e. thread is assigned to a manually
 	 * managed arena), then percpu arena is skipped.
 	 */
-	if (have_percpu_arena && (percpu_arena_mode != percpu_arena_disabled) &&
-	    !internal && (arena_ind_get(ret) < percpu_arena_ind_limit()) &&
-	    (ret->last_thd != tsd_tsdn(tsd))) {
+	if (have_percpu_arena && PERCPU_ARENA_ENABLED(opt_percpu_arena) &&
+	    !internal && (arena_ind_get(ret) <
+	    percpu_arena_ind_limit(opt_percpu_arena)) && (ret->last_thd !=
+	    tsd_tsdn(tsd))) {
 		unsigned ind = percpu_arena_choose();
 		if (arena_ind_get(ret) != ind) {
 			percpu_arena_update(tsd, ind);

--- a/scripts/gen_run_tests.py
+++ b/scripts/gen_run_tests.py
@@ -28,6 +28,7 @@ possible_malloc_conf_opts = [
     'tcache:false',
     'dss:primary',
     'percpu_arena:percpu',
+    'background_thread:true',
 ]
 
 print 'set -e'
@@ -57,7 +58,8 @@ for cc, cxx in possible_compilers:
                 )
 
                 # Per CPU arenas are only supported on Linux.
-                linux_supported = ('percpu_arena:percpu' in malloc_conf_opts)
+                linux_supported = ('percpu_arena:percpu' in malloc_conf_opts \
+                  or 'background_thread:true' in malloc_conf_opts)
                 # Heap profiling and dss are not supported on OS X.
                 darwin_unsupported = ('--enable-prof' in config_opts or \
                   'dss:primary' in malloc_conf_opts)

--- a/scripts/gen_travis.py
+++ b/scripts/gen_travis.py
@@ -49,6 +49,7 @@ malloc_conf_unusuals = [
     'tcache:false',
     'dss:primary',
     'percpu_arena:percpu',
+    'background_thread:true',
 ]
 
 all_unusuals = (
@@ -80,7 +81,8 @@ for unusual_combination in unusual_combinations_to_test:
         x for x in unusual_combination if x in malloc_conf_unusuals]
     # Filter out unsupported configurations on OS X.
     if os == 'osx' and ('dss:primary' in malloc_conf or \
-      'percpu_arena:percpu' in malloc_conf):
+      'percpu_arena:percpu' in malloc_conf or 'background_thread:true' \
+      in malloc_conf):
         continue
     if len(malloc_conf) > 0:
         configure_flags.append('--with-malloc-conf=' + ",".join(malloc_conf))

--- a/src/arena.c
+++ b/src/arena.c
@@ -13,13 +13,18 @@
 /******************************************************************************/
 /* Data. */
 
+/*
+ * Define names for both unininitialized and initialized phases, so that
+ * options and mallctl processing are straightforward.
+ */
 const char *percpu_arena_mode_names[] = {
+	"percpu",
+	"phycpu",
 	"disabled",
 	"percpu",
 	"phycpu"
 };
-const char *opt_percpu_arena = OPT_PERCPU_ARENA_DEFAULT;
-percpu_arena_mode_t percpu_arena_mode = PERCPU_ARENA_MODE_DEFAULT;
+percpu_arena_mode_t opt_percpu_arena = PERCPU_ARENA_DEFAULT;
 
 ssize_t opt_dirty_decay_ms = DIRTY_DECAY_MS_DEFAULT;
 ssize_t opt_muzzy_decay_ms = MUZZY_DECAY_MS_DEFAULT;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1559,7 +1559,8 @@ CTL_RO_NL_GEN(opt_abort_conf, opt_abort_conf, bool)
 CTL_RO_NL_GEN(opt_retain, opt_retain, bool)
 CTL_RO_NL_GEN(opt_dss, opt_dss, const char *)
 CTL_RO_NL_GEN(opt_narenas, opt_narenas, unsigned)
-CTL_RO_NL_GEN(opt_percpu_arena, opt_percpu_arena, const char *)
+CTL_RO_NL_GEN(opt_percpu_arena, percpu_arena_mode_names[opt_percpu_arena],
+    const char *)
 CTL_RO_NL_GEN(opt_background_thread, opt_background_thread, bool)
 CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
@@ -1610,8 +1611,8 @@ thread_arena_ctl(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 		}
 
 		if (have_percpu_arena &&
-		    (percpu_arena_mode != percpu_arena_disabled)) {
-			if (newind < percpu_arena_ind_limit()) {
+		    PERCPU_ARENA_ENABLED(opt_percpu_arena)) {
+			if (newind < percpu_arena_ind_limit(opt_percpu_arena)) {
 				/*
 				 * If perCPU arena is enabled, thread_arena
 				 * control is not allowed for the auto arena

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -27,21 +27,11 @@ static malloc_mutex_t	*postponed_mutexes = NULL;
  */
 
 #if defined(JEMALLOC_LAZY_LOCK) && !defined(_WIN32)
-static void
-pthread_create_once(void) {
-	pthread_create_fptr = load_pthread_create_fptr();
-	assert(isthreaded);
-}
-
 JEMALLOC_EXPORT int
 pthread_create(pthread_t *__restrict thread,
     const pthread_attr_t *__restrict attr, void *(*start_routine)(void *),
     void *__restrict arg) {
-	static pthread_once_t once_control = PTHREAD_ONCE_INIT;
-
-	pthread_once(&once_control, pthread_create_once);
-
-	return pthread_create_fptr(thread, attr, start_routine, arg);
+	return pthread_create_wrapper(thread, attr, start_routine, arg);
 }
 #endif
 

--- a/test/unit/junk.c
+++ b/test/unit/junk.c
@@ -96,12 +96,15 @@ test_junk(size_t sz_min, size_t sz_max) {
 			t = (uint8_t *)rallocx(s, sz+1, 0);
 			assert_ptr_not_null((void *)t,
 			    "Unexpected rallocx() failure");
-			assert_ptr_ne(s, t, "Unexpected in-place rallocx()");
 			assert_zu_ge(sallocx(t, 0), sz+1,
 			    "Unexpectedly small rallocx() result");
-			assert_true(!opt_junk_free || saw_junking,
-			    "Expected region of size %zu to be junk-filled",
-			    sz);
+			if (!background_thread_enabled()) {
+				assert_ptr_ne(s, t,
+				    "Unexpected in-place rallocx()");
+				assert_true(!opt_junk_free || saw_junking,
+				    "Expected region of size %zu to be "
+				    "junk-filled", sz);
+			}
 			s = t;
 		}
 	}

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -327,18 +327,18 @@ TEST_END
 
 TEST_BEGIN(test_thread_arena) {
 	unsigned old_arena_ind, new_arena_ind, narenas;
-	const char *opt_percpu_arena;
 
-	size_t sz = sizeof(opt_percpu_arena);
-	assert_d_eq(mallctl("opt.percpu_arena", &opt_percpu_arena, &sz, NULL,
-	    0), 0, "Unexpected mallctl() failure");
+	const char *opa;
+	size_t sz = sizeof(opa);
+	assert_d_eq(mallctl("opt.percpu_arena", &opa, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
 
 	sz = sizeof(unsigned);
 	assert_d_eq(mallctl("arenas.narenas", (void *)&narenas, &sz, NULL, 0),
 	    0, "Unexpected mallctl() failure");
 	assert_u_eq(narenas, opt_narenas, "Number of arenas incorrect");
 
-	if (strcmp(opt_percpu_arena, "disabled") == 0) {
+	if (strcmp(opa, "disabled") == 0) {
 		new_arena_ind = narenas - 1;
 		assert_d_eq(mallctl("thread.arena", (void *)&old_arena_ind, &sz,
 		    (void *)&new_arena_ind, sizeof(unsigned)), 0,
@@ -350,7 +350,7 @@ TEST_BEGIN(test_thread_arena) {
 	} else {
 		assert_d_eq(mallctl("thread.arena", (void *)&old_arena_ind, &sz,
 		    NULL, 0), 0, "Unexpected mallctl() failure");
-		new_arena_ind = percpu_arena_ind_limit() - 1;
+		new_arena_ind = percpu_arena_ind_limit(opt_percpu_arena) - 1;
 		if (old_arena_ind != new_arena_ind) {
 			assert_d_eq(mallctl("thread.arena",
 			    (void *)&old_arena_ind, &sz, (void *)&new_arena_ind,

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -210,12 +210,12 @@ TEST_BEGIN(test_manpage_example) {
 TEST_END
 
 TEST_BEGIN(test_tcache_none) {
-	void *p0, *q, *p1;
+	test_skip_if(!opt_tcache);
 
 	/* Allocate p and q. */
-	p0 = mallocx(42, 0);
+	void *p0 = mallocx(42, 0);
 	assert_ptr_not_null(p0, "Unexpected mallocx() failure");
-	q = mallocx(42, 0);
+	void *q = mallocx(42, 0);
 	assert_ptr_not_null(q, "Unexpected mallocx() failure");
 
 	/* Deallocate p and q, but bypass the tcache for q. */
@@ -223,7 +223,7 @@ TEST_BEGIN(test_tcache_none) {
 	dallocx(q, MALLOCX_TCACHE_NONE);
 
 	/* Make sure that tcache-based allocation returns p, not q. */
-	p1 = mallocx(42, 0);
+	void *p1 = mallocx(42, 0);
 	assert_ptr_not_null(p1, "Unexpected mallocx() failure");
 	assert_ptr_eq(p0, p1, "Expected tcache to allocate cached region");
 


### PR DESCRIPTION
Add testing for background_thread:true, and condition a xallocx() -->
rallocx() escalation assertion to allow for spurious in-place rallocx()
following xallocx() failure.