### PR TITLE
Fix extent_hooks in extent_grow_retained().

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -1066,9 +1066,18 @@ extent_grow_retained(tsdn_t *tsdn, arena_t *arena,
 	}
 	bool zeroed = false;
 	bool committed = false;
-	void *ptr = extent_alloc_core(tsdn, arena, NULL, alloc_size, PAGE,
-	    &zeroed, &committed, (dss_prec_t)atomic_load_u(&arena->dss_prec,
-	    ATOMIC_RELAXED));
+
+	void *ptr;
+	if (*r_extent_hooks == &extent_hooks_default) {
+		ptr = extent_alloc_core(tsdn, arena, NULL, alloc_size, PAGE,
+		    &zeroed, &committed, (dss_prec_t)atomic_load_u(
+		    &arena->dss_prec, ATOMIC_RELAXED));
+	} else {
+		ptr = (*r_extent_hooks)->alloc(*r_extent_hooks, NULL,
+		    alloc_size, PAGE, &zeroed, &committed,
+		    arena_ind_get(arena));
+	}
+
 	extent_init(extent, arena, ptr, alloc_size, false, NSIZES,
 	    arena_extent_sn_next(arena), extent_state_active, zeroed,
 	    committed);

--- a/test/integration/extent.c
+++ b/test/integration/extent.c
@@ -39,10 +39,13 @@ test_extent_body(unsigned arena_ind) {
 	assert_d_eq(mallctlnametomib("arena.0.purge", purge_mib, &purge_miblen),
 	    0, "Unexpected mallctlnametomib() failure");
 	purge_mib[1] = (size_t)arena_ind;
+	called_alloc = false;
+	try_alloc = true;
 	try_dalloc = false;
 	try_decommit = false;
 	p = mallocx(large0 * 2, flags);
 	assert_ptr_not_null(p, "Unexpected mallocx() error");
+	assert_true(called_alloc, "Expected alloc call");
 	called_dalloc = false;
 	called_decommit = false;
 	did_purge_lazy = false;


### PR DESCRIPTION
Fix extent_hooks in extent_grow_retained().
    
This issue caused the default extent alloc function to be incorrectly
used even when ```arena.<i>.extent_hooks``` is set.  This bug was introduced
by 411697adcda2fd75e135cdcdafb95f2bd295dc7f (Use exponential series to
size extents.), which was first released in 5.0.0.