### PR TITLE
Only abort on dlsym when necessary.

### DIFF
--- a/include/jemalloc/internal/background_thread_externs.h
+++ b/include/jemalloc/internal/background_thread_externs.h
@@ -6,6 +6,7 @@ extern malloc_mutex_t background_thread_lock;
 extern atomic_b_t background_thread_enabled_state;
 extern size_t n_background_threads;
 extern background_thread_info_t *background_thread_info;
+extern bool can_enable_background_thread;
 
 bool background_thread_create(tsd_t *tsd, unsigned arena_ind);
 bool background_threads_enable(tsd_t *tsd);

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1522,6 +1522,13 @@ background_thread_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 
 		background_thread_enabled_set(tsd_tsdn(tsd), newval);
 		if (newval) {
+			if (!can_enable_background_thread) {
+				malloc_printf("<jemalloc>: Error in dlsym("
+			            "RTLD_NEXT, \"pthread_create\"). Cannot "
+				    "enable background_thread\n");
+				ret = EFAULT;
+				goto label_return;
+			}
 			if (background_threads_enable(tsd)) {
 				ret = EFAULT;
 				goto label_return;


### PR DESCRIPTION
If neither background_thread nor lazy_lock is in use, do not abort on dlsym
errors.

Part of the solution to #907.