### PR TITLE
Set reentrancy when invoking customized extent hooks.

### DIFF
--- a/include/jemalloc/internal/base_externs.h
+++ b/include/jemalloc/internal/base_externs.h
@@ -3,7 +3,7 @@
 
 base_t *b0get(void);
 base_t *base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
-void base_delete(base_t *base);
+void base_delete(tsdn_t *tsdn, base_t *base);
 extent_hooks_t *base_extent_hooks_get(base_t *base);
 extent_hooks_t *base_extent_hooks_set(base_t *base,
     extent_hooks_t *extent_hooks);

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -91,8 +91,7 @@ typedef struct ctl_arenas_s {
 
 int ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
     void *newp, size_t newlen);
-int ctl_nametomib(tsdn_t *tsdn, const char *name, size_t *mibp,
-    size_t *miblenp);
+int ctl_nametomib(tsd_t *tsd, const char *name, size_t *mibp, size_t *miblenp);
 
 int ctl_bymib(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
     size_t *oldlenp, void *newp, size_t newlen);

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -146,7 +146,10 @@ tcache_get(tsd_t *tsd) {
 }
 
 static inline void
-pre_reentrancy(tsd_t *tsd) {
+pre_reentrancy(tsd_t *tsd, arena_t *arena) {
+	/* arena is the current context.  Reentry from a0 is not allowed. */
+	assert(arena != arena_get(tsd_tsdn(tsd), 0, false));
+
 	bool fast = tsd_fast(tsd);
 	++*tsd_reentrancy_levelp_get(tsd);
 	if (fast) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -1257,7 +1257,7 @@ arena_destroy(tsd_t *tsd, arena_t *arena) {
 	 * Destroy the base allocator, which manages all metadata ever mapped by
 	 * this arena.
 	 */
-	base_delete(arena->base);
+	base_delete(tsd_tsdn(tsd), arena->base);
 }
 
 static extent_t *
@@ -2061,7 +2061,7 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	return arena;
 label_error:
 	if (ind != 0) {
-		base_delete(base);
+		base_delete(tsdn, base);
 	}
 	return NULL;
 }

--- a/src/arena.c
+++ b/src/arena.c
@@ -2051,7 +2051,7 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		 * is done enough that we should have tsd.
 		 */
 		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		pre_reentrancy(tsdn_tsd(tsdn), arena);
 		if (hooks_arena_new_hook) {
 			hooks_arena_new_hook();
 		}

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -316,7 +316,7 @@ background_threads_disable_single(tsd_t *tsd, background_thread_info_t *info) {
 		    &background_thread_lock);
 	}
 
-	pre_reentrancy(tsd);
+	pre_reentrancy(tsd, NULL);
 	malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
 	bool has_thread;
 	assert(info->state != background_thread_paused);
@@ -408,7 +408,7 @@ label_restart:
 		 */
 		malloc_mutex_unlock(tsd_tsdn(tsd), &background_thread_lock);
 
-		pre_reentrancy(tsd);
+		pre_reentrancy(tsd, NULL);
 		int err = background_thread_create_signals_masked(&info->thread,
 		    NULL, background_thread_entry, (void *)(uintptr_t)i);
 		post_reentrancy(tsd);
@@ -555,7 +555,7 @@ background_thread_create(tsd_t *tsd, unsigned arena_ind) {
 		return false;
 	}
 
-	pre_reentrancy(tsd);
+	pre_reentrancy(tsd, NULL);
 	/*
 	 * To avoid complications (besides reentrancy), create internal
 	 * background threads with the underlying pthread_create.

--- a/src/base.c
+++ b/src/base.c
@@ -15,7 +15,7 @@ static base_t	*b0;
 /******************************************************************************/
 
 static void *
-base_map(extent_hooks_t *extent_hooks, unsigned ind, size_t size) {
+base_map(tsdn_t *tsdn, extent_hooks_t *extent_hooks, unsigned ind, size_t size) {
 	void *addr;
 	bool zero = true;
 	bool commit = true;
@@ -25,15 +25,18 @@ base_map(extent_hooks_t *extent_hooks, unsigned ind, size_t size) {
 	if (extent_hooks == &extent_hooks_default) {
 		addr = extent_alloc_mmap(NULL, size, PAGE, &zero, &commit);
 	} else {
+		assert(!tsdn_null(tsdn));
+		pre_reentrancy(tsdn_tsd(tsdn));
 		addr = extent_hooks->alloc(extent_hooks, NULL, size, PAGE,
 		    &zero, &commit, ind);
+		post_reentrancy(tsdn_tsd(tsdn));
 	}
 
 	return addr;
 }
 
 static void
-base_unmap(extent_hooks_t *extent_hooks, unsigned ind, void *addr,
+base_unmap(tsdn_t *tsdn, extent_hooks_t *extent_hooks, unsigned ind, void *addr,
     size_t size) {
 	/*
 	 * Cascade through dalloc, decommit, purge_forced, and purge_lazy,
@@ -61,27 +64,32 @@ base_unmap(extent_hooks_t *extent_hooks, unsigned ind, void *addr,
 		/* Nothing worked.  This should never happen. */
 		not_reached();
 	} else {
+		assert(!tsdn_null(tsdn));
+		pre_reentrancy(tsdn_tsd(tsdn));
 		if (extent_hooks->dalloc != NULL &&
 		    !extent_hooks->dalloc(extent_hooks, addr, size, true,
 		    ind)) {
-			return;
+			goto label_done;
 		}
 		if (extent_hooks->decommit != NULL &&
 		    !extent_hooks->decommit(extent_hooks, addr, size, 0, size,
 		    ind)) {
-			return;
+			goto label_done;
 		}
 		if (extent_hooks->purge_forced != NULL &&
 		    !extent_hooks->purge_forced(extent_hooks, addr, size, 0,
 		    size, ind)) {
-			return;
+			goto label_done;
 		}
 		if (extent_hooks->purge_lazy != NULL &&
 		    !extent_hooks->purge_lazy(extent_hooks, addr, size, 0, size,
 		    ind)) {
-			return;
+			goto label_done;
 		}
 		/* Nothing worked.  That's the application's problem. */
+	label_done:
+		post_reentrancy(tsdn_tsd(tsdn));
+		return;
 	}
 }
 
@@ -157,7 +165,7 @@ base_extent_bump_alloc(tsdn_t *tsdn, base_t *base, extent_t *extent,
  * On success a pointer to the initialized base_block_t header is returned.
  */
 static base_block_t *
-base_block_alloc(extent_hooks_t *extent_hooks, unsigned ind,
+base_block_alloc(tsdn_t *tsdn, extent_hooks_t *extent_hooks, unsigned ind,
     pszind_t *pind_last, size_t *extent_sn_next, size_t size,
     size_t alignment) {
 	alignment = ALIGNMENT_CEILING(alignment, QUANTUM);
@@ -179,7 +187,7 @@ base_block_alloc(extent_hooks_t *extent_hooks, unsigned ind,
 	size_t next_block_size = HUGEPAGE_CEILING(sz_pind2sz(pind_next));
 	size_t block_size = (min_block_size > next_block_size) ? min_block_size
 	    : next_block_size;
-	base_block_t *block = (base_block_t *)base_map(extent_hooks, ind,
+	base_block_t *block = (base_block_t *)base_map(tsdn, extent_hooks, ind,
 	    block_size);
 	if (block == NULL) {
 		return NULL;
@@ -207,8 +215,9 @@ base_extent_alloc(tsdn_t *tsdn, base_t *base, size_t size, size_t alignment) {
 	 * called.
 	 */
 	malloc_mutex_unlock(tsdn, &base->mtx);
-	base_block_t *block = base_block_alloc(extent_hooks, base_ind_get(base),
-	    &base->pind_last, &base->extent_sn_next, size, alignment);
+	base_block_t *block = base_block_alloc(tsdn, extent_hooks,
+	    base_ind_get(base), &base->pind_last, &base->extent_sn_next, size,
+	    alignment);
 	malloc_mutex_lock(tsdn, &base->mtx);
 	if (block == NULL) {
 		return NULL;
@@ -234,8 +243,8 @@ base_t *
 base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	pszind_t pind_last = 0;
 	size_t extent_sn_next = 0;
-	base_block_t *block = base_block_alloc(extent_hooks, ind, &pind_last,
-	    &extent_sn_next, sizeof(base_t), QUANTUM);
+	base_block_t *block = base_block_alloc(tsdn, extent_hooks, ind,
+	    &pind_last, &extent_sn_next, sizeof(base_t), QUANTUM);
 	if (block == NULL) {
 		return NULL;
 	}
@@ -249,7 +258,7 @@ base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	atomic_store_p(&base->extent_hooks, extent_hooks, ATOMIC_RELAXED);
 	if (malloc_mutex_init(&base->mtx, "base", WITNESS_RANK_BASE,
 	    malloc_mutex_rank_exclusive)) {
-		base_unmap(extent_hooks, ind, block, block->size);
+		base_unmap(tsdn, extent_hooks, ind, block, block->size);
 		return NULL;
 	}
 	base->pind_last = pind_last;
@@ -272,13 +281,13 @@ base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 }
 
 void
-base_delete(base_t *base) {
+base_delete(tsdn_t *tsdn, base_t *base) {
 	extent_hooks_t *extent_hooks = base_extent_hooks_get(base);
 	base_block_t *next = base->blocks;
 	do {
 		base_block_t *block = next;
 		next = block->next;
-		base_unmap(extent_hooks, base_ind_get(base), block,
+		base_unmap(tsdn, extent_hooks, base_ind_get(base), block,
 		    block->size);
 	} while (next != NULL);
 }

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -622,7 +622,7 @@ arenas_i2a(size_t i) {
 }
 
 static ctl_arena_t *
-arenas_i_impl(tsdn_t *tsdn, size_t i, bool compat, bool init) {
+arenas_i_impl(tsd_t *tsd, size_t i, bool compat, bool init) {
 	ctl_arena_t *ret;
 
 	assert(!compat || !init);
@@ -635,15 +635,15 @@ arenas_i_impl(tsdn_t *tsdn, size_t i, bool compat, bool init) {
 				ctl_arena_stats_t	astats;
 			};
 			struct container_s *cont =
-			    (struct container_s *)base_alloc(tsdn, b0get(),
-			    sizeof(struct container_s), QUANTUM);
+			    (struct container_s *)base_alloc(tsd_tsdn(tsd),
+			    b0get(), sizeof(struct container_s), QUANTUM);
 			if (cont == NULL) {
 				return NULL;
 			}
 			ret = &cont->ctl_arena;
 			ret->astats = &cont->astats;
 		} else {
-			ret = (ctl_arena_t *)base_alloc(tsdn, b0get(),
+			ret = (ctl_arena_t *)base_alloc(tsd_tsdn(tsd), b0get(),
 			    sizeof(ctl_arena_t), QUANTUM);
 			if (ret == NULL) {
 				return NULL;
@@ -659,7 +659,7 @@ arenas_i_impl(tsdn_t *tsdn, size_t i, bool compat, bool init) {
 
 static ctl_arena_t *
 arenas_i(size_t i) {
-	ctl_arena_t *ret = arenas_i_impl(TSDN_NULL, i, true, false);
+	ctl_arena_t *ret = arenas_i_impl(tsd_fetch(), i, true, false);
 	assert(ret != NULL);
 	return ret;
 }
@@ -863,7 +863,7 @@ ctl_arena_refresh(tsdn_t *tsdn, arena_t *arena, ctl_arena_t *ctl_sdarena,
 }
 
 static unsigned
-ctl_arena_init(tsdn_t *tsdn, extent_hooks_t *extent_hooks) {
+ctl_arena_init(tsd_t *tsd, extent_hooks_t *extent_hooks) {
 	unsigned arena_ind;
 	ctl_arena_t *ctl_arena;
 
@@ -876,12 +876,12 @@ ctl_arena_init(tsdn_t *tsdn, extent_hooks_t *extent_hooks) {
 	}
 
 	/* Trigger stats allocation. */
-	if (arenas_i_impl(tsdn, arena_ind, false, true) == NULL) {
+	if (arenas_i_impl(tsd, arena_ind, false, true) == NULL) {
 		return UINT_MAX;
 	}
 
 	/* Initialize new arena. */
-	if (arena_init(tsdn, arena_ind, extent_hooks) == NULL) {
+	if (arena_init(tsd_tsdn(tsd), arena_ind, extent_hooks) == NULL) {
 		return UINT_MAX;
 	}
 
@@ -975,8 +975,9 @@ ctl_refresh(tsdn_t *tsdn) {
 }
 
 static bool
-ctl_init(tsdn_t *tsdn) {
+ctl_init(tsd_t *tsd) {
 	bool ret;
+	tsdn_t *tsdn = tsd_tsdn(tsd);
 
 	malloc_mutex_lock(tsdn, &ctl_mtx);
 	if (!ctl_initialized) {
@@ -1010,14 +1011,14 @@ ctl_init(tsdn_t *tsdn) {
 		 * here rather than doing it lazily elsewhere, in order
 		 * to limit when OOM-caused errors can occur.
 		 */
-		if ((ctl_sarena = arenas_i_impl(tsdn, MALLCTL_ARENAS_ALL, false,
+		if ((ctl_sarena = arenas_i_impl(tsd, MALLCTL_ARENAS_ALL, false,
 		    true)) == NULL) {
 			ret = true;
 			goto label_return;
 		}
 		ctl_sarena->initialized = true;
 
-		if ((ctl_darena = arenas_i_impl(tsdn, MALLCTL_ARENAS_DESTROYED,
+		if ((ctl_darena = arenas_i_impl(tsd, MALLCTL_ARENAS_DESTROYED,
 		    false, true)) == NULL) {
 			ret = true;
 			goto label_return;
@@ -1031,7 +1032,7 @@ ctl_init(tsdn_t *tsdn) {
 
 		ctl_arenas->narenas = narenas_total_get();
 		for (i = 0; i < ctl_arenas->narenas; i++) {
-			if (arenas_i_impl(tsdn, i, false, true) == NULL) {
+			if (arenas_i_impl(tsd, i, false, true) == NULL) {
 				ret = true;
 				goto label_return;
 			}
@@ -1156,7 +1157,7 @@ ctl_byname(tsd_t *tsd, const char *name, void *oldp, size_t *oldlenp,
 	size_t mib[CTL_MAX_DEPTH];
 	const ctl_named_node_t *node;
 
-	if (!ctl_initialized && ctl_init(tsd_tsdn(tsd))) {
+	if (!ctl_initialized && ctl_init(tsd)) {
 		ret = EAGAIN;
 		goto label_return;
 	}
@@ -1180,15 +1181,15 @@ label_return:
 }
 
 int
-ctl_nametomib(tsdn_t *tsdn, const char *name, size_t *mibp, size_t *miblenp) {
+ctl_nametomib(tsd_t *tsd, const char *name, size_t *mibp, size_t *miblenp) {
 	int ret;
 
-	if (!ctl_initialized && ctl_init(tsdn)) {
+	if (!ctl_initialized && ctl_init(tsd)) {
 		ret = EAGAIN;
 		goto label_return;
 	}
 
-	ret = ctl_lookup(tsdn, name, NULL, mibp, miblenp);
+	ret = ctl_lookup(tsd_tsdn(tsd), name, NULL, mibp, miblenp);
 label_return:
 	return(ret);
 }
@@ -1200,7 +1201,7 @@ ctl_bymib(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 	const ctl_named_node_t *node;
 	size_t i;
 
-	if (!ctl_initialized && ctl_init(tsd_tsdn(tsd))) {
+	if (!ctl_initialized && ctl_init(tsd)) {
 		ret = EAGAIN;
 		goto label_return;
 	}
@@ -2312,8 +2313,7 @@ arenas_create_ctl(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 
 	extent_hooks = (extent_hooks_t *)&extent_hooks_default;
 	WRITE(extent_hooks, extent_hooks_t *);
-	if ((arena_ind = ctl_arena_init(tsd_tsdn(tsd), extent_hooks)) ==
-	    UINT_MAX) {
+	if ((arena_ind = ctl_arena_init(tsd, extent_hooks)) == UINT_MAX) {
 		ret = EAGAIN;
 		goto label_return;
 	}

--- a/src/extent.c
+++ b/src/extent.c
@@ -1025,6 +1025,18 @@ extent_alloc_default(extent_hooks_t *extent_hooks, void *new_addr, size_t size,
 	    alignment, zero, commit);
 }
 
+static void
+extent_hook_pre_reentrancy(tsdn_t *tsdn, arena_t *arena) {
+	tsd_t *tsd = tsdn_null(tsdn) ? tsd_fetch() : tsdn_tsd(tsdn);
+	pre_reentrancy(tsd, arena);
+}
+
+static void
+extent_hook_post_reentrancy(tsdn_t *tsdn) {
+	tsd_t *tsd = tsdn_null(tsdn) ? tsd_fetch() : tsdn_tsd(tsdn);
+	post_reentrancy(tsd);
+}
+
 /*
  * If virtual memory is retained, create increasingly larger extents from which
  * to split requested extents in order to limit the total number of disjoint
@@ -1073,12 +1085,11 @@ extent_grow_retained(tsdn_t *tsdn, arena_t *arena,
 		    &zeroed, &committed, (dss_prec_t)atomic_load_u(
 		    &arena->dss_prec, ATOMIC_RELAXED));
 	} else {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 		ptr = (*r_extent_hooks)->alloc(*r_extent_hooks, NULL,
 		    alloc_size, PAGE, &zeroed, &committed,
 		    arena_ind_get(arena));
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 
 	extent_init(extent, arena, ptr, alloc_size, false, NSIZES,
@@ -1250,11 +1261,10 @@ extent_alloc_wrapper_hard(tsdn_t *tsdn, arena_t *arena,
 		addr = extent_alloc_default_impl(tsdn, arena, new_addr, esize,
 		    alignment, zero, commit);
 	} else {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 		addr = (*r_extent_hooks)->alloc(*r_extent_hooks, new_addr,
 		    esize, alignment, zero, commit, arena_ind_get(arena));
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	if (addr == NULL) {
 		extent_dalloc(tsdn, arena, extent);
@@ -1492,13 +1502,12 @@ extent_dalloc_wrapper_try(tsdn_t *tsdn, arena_t *arena,
 		err = extent_dalloc_default_impl(extent_base_get(extent),
 		    extent_size_get(extent));
 	} else {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 		err = ((*r_extent_hooks)->dalloc == NULL ||
 		    (*r_extent_hooks)->dalloc(*r_extent_hooks,
 		    extent_base_get(extent), extent_size_get(extent),
 		    extent_committed_get(extent), arena_ind_get(arena)));
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 
 	if (!err) {
@@ -1525,8 +1534,7 @@ extent_dalloc_wrapper(tsdn_t *tsdn, arena_t *arena,
 
 	extent_reregister(tsdn, extent);
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	/* Try to decommit; purge if that fails. */
 	bool zeroed;
@@ -1550,7 +1558,7 @@ extent_dalloc_wrapper(tsdn_t *tsdn, arena_t *arena,
 		zeroed = false;
 	}
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	extent_zeroed_set(extent, zeroed);
 
@@ -1595,12 +1603,11 @@ extent_destroy_wrapper(tsdn_t *tsdn, arena_t *arena,
 		extent_destroy_default_impl(extent_base_get(extent),
 		    extent_size_get(extent));
 	} else if ((*r_extent_hooks)->destroy != NULL) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 		(*r_extent_hooks)->destroy(*r_extent_hooks,
 		    extent_base_get(extent), extent_size_get(extent),
 		    extent_committed_get(extent), arena_ind_get(arena));
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 
 	extent_dalloc(tsdn, arena, extent);
@@ -1622,14 +1629,13 @@ extent_commit_impl(tsdn_t *tsdn, arena_t *arena,
 
 	extent_hooks_assure_initialized(arena, r_extent_hooks);
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	bool err = ((*r_extent_hooks)->commit == NULL ||
 	    (*r_extent_hooks)->commit(*r_extent_hooks, extent_base_get(extent),
 	    extent_size_get(extent), offset, length, arena_ind_get(arena)));
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	extent_committed_set(extent, extent_committed_get(extent) || !err);
 	return err;
@@ -1660,15 +1666,14 @@ extent_decommit_wrapper(tsdn_t *tsdn, arena_t *arena,
 	extent_hooks_assure_initialized(arena, r_extent_hooks);
 
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	bool err = ((*r_extent_hooks)->decommit == NULL ||
 	    (*r_extent_hooks)->decommit(*r_extent_hooks,
 	    extent_base_get(extent), extent_size_get(extent), offset, length,
 	    arena_ind_get(arena)));
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	extent_committed_set(extent, extent_committed_get(extent) && err);
 	return err;
@@ -1700,16 +1705,14 @@ extent_purge_lazy_impl(tsdn_t *tsdn, arena_t *arena,
 	if ((*r_extent_hooks)->purge_lazy == NULL) {
 		return true;
 	}
-
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	bool err = (*r_extent_hooks)->purge_lazy(*r_extent_hooks,
 	    extent_base_get(extent), extent_size_get(extent), offset, length,
 	    arena_ind_get(arena));
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 
 	return err;
@@ -1750,14 +1753,13 @@ extent_purge_forced_impl(tsdn_t *tsdn, arena_t *arena,
 		return true;
 	}
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	bool err = (*r_extent_hooks)->purge_forced(*r_extent_hooks,
 	    extent_base_get(extent), extent_size_get(extent), offset, length,
 	    arena_ind_get(arena));
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	return err;
 }
@@ -1829,14 +1831,13 @@ extent_split_impl(tsdn_t *tsdn, arena_t *arena,
 	extent_lock2(tsdn, extent, trail);
 
 	if (*r_extent_hooks != &extent_hooks_default) {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 	}
 	bool err = (*r_extent_hooks)->split(*r_extent_hooks, extent_base_get(extent),
 	    size_a + size_b, size_a, size_b, extent_committed_get(extent),
 	    arena_ind_get(arena));
 	if (*r_extent_hooks != &extent_hooks_default) {
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 	if (err) {
 		goto label_error_c;
@@ -1908,13 +1909,12 @@ extent_merge_impl(tsdn_t *tsdn, arena_t *arena,
 		err = extent_merge_default_impl(extent_base_get(a),
 		    extent_base_get(b));
 	} else {
-		assert(!tsdn_null(tsdn));
-		pre_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_pre_reentrancy(tsdn, arena);
 		err = (*r_extent_hooks)->merge(*r_extent_hooks,
 		    extent_base_get(a), extent_size_get(a), extent_base_get(b),
 		    extent_size_get(b), extent_committed_get(a),
 		    arena_ind_get(arena));
-		post_reentrancy(tsdn_tsd(tsdn));
+		extent_hook_post_reentrancy(tsdn);
 	}
 
 	if (err) {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2918,16 +2918,15 @@ je_mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp,
 JEMALLOC_EXPORT int JEMALLOC_NOTHROW
 je_mallctlnametomib(const char *name, size_t *mibp, size_t *miblenp) {
 	int ret;
-	tsdn_t *tsdn;
 
 	if (unlikely(malloc_init())) {
 		return EAGAIN;
 	}
 
-	tsdn = tsdn_fetch();
-	check_entry_exit_locking(tsdn);
-	ret = ctl_nametomib(tsdn, name, mibp, miblenp);
-	check_entry_exit_locking(tsdn);
+	tsd_t *tsd = tsd_fetch();
+	check_entry_exit_locking(tsd_tsdn(tsd));
+	ret = ctl_nametomib(tsd, name, mibp, miblenp);
+	check_entry_exit_locking(tsd_tsdn(tsd));
 	return ret;
 }
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1476,7 +1476,7 @@ malloc_init_hard(void) {
 
 	malloc_mutex_lock(tsd_tsdn(tsd), &init_lock);
 	/* Set reentrancy level to 1 during init. */
-	pre_reentrancy(tsd);
+	pre_reentrancy(tsd, NULL);
 	/* Initialize narenas before prof_boot2 (for allocation). */
 	if (malloc_init_narenas() || background_thread_boot1(tsd_tsdn(tsd))) {
 		UNLOCK_RETURN(tsd_tsdn(tsd), true, true)

--- a/src/prof.c
+++ b/src/prof.c
@@ -1633,7 +1633,7 @@ prof_dump(tsd_t *tsd, bool propagate_err, const char *filename,
 		return true;
 	}
 
-	pre_reentrancy(tsd);
+	pre_reentrancy(tsd, NULL);
 	malloc_mutex_lock(tsd_tsdn(tsd), &prof_dump_mtx);
 
 	prof_gctx_tree_t gctxs;

--- a/test/unit/base.c
+++ b/test/unit/base.c
@@ -27,11 +27,10 @@ static extent_hooks_t hooks_not_null = {
 };
 
 TEST_BEGIN(test_base_hooks_default) {
-	tsdn_t *tsdn;
 	base_t *base;
 	size_t allocated0, allocated1, resident, mapped;
 
-	tsdn = tsdn_fetch();
+	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	base = base_new(tsdn, 0, (extent_hooks_t *)&extent_hooks_default);
 
 	if (config_stats) {
@@ -49,13 +48,12 @@ TEST_BEGIN(test_base_hooks_default) {
 		    "At least 42 bytes were allocated by base_alloc()");
 	}
 
-	base_delete(base);
+	base_delete(tsdn, base);
 }
 TEST_END
 
 TEST_BEGIN(test_base_hooks_null) {
 	extent_hooks_t hooks_orig;
-	tsdn_t *tsdn;
 	base_t *base;
 	size_t allocated0, allocated1, resident, mapped;
 
@@ -68,7 +66,7 @@ TEST_BEGIN(test_base_hooks_null) {
 	memcpy(&hooks_orig, &hooks, sizeof(extent_hooks_t));
 	memcpy(&hooks, &hooks_null, sizeof(extent_hooks_t));
 
-	tsdn = tsdn_fetch();
+	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	base = base_new(tsdn, 0, &hooks);
 	assert_ptr_not_null(base, "Unexpected base_new() failure");
 
@@ -87,7 +85,7 @@ TEST_BEGIN(test_base_hooks_null) {
 		    "At least 42 bytes were allocated by base_alloc()");
 	}
 
-	base_delete(base);
+	base_delete(tsdn, base);
 
 	memcpy(&hooks, &hooks_orig, sizeof(extent_hooks_t));
 }
@@ -95,7 +93,6 @@ TEST_END
 
 TEST_BEGIN(test_base_hooks_not_null) {
 	extent_hooks_t hooks_orig;
-	tsdn_t *tsdn;
 	base_t *base;
 	void *p, *q, *r, *r_exp;
 
@@ -108,7 +105,7 @@ TEST_BEGIN(test_base_hooks_not_null) {
 	memcpy(&hooks_orig, &hooks, sizeof(extent_hooks_t));
 	memcpy(&hooks, &hooks_not_null, sizeof(extent_hooks_t));
 
-	tsdn = tsdn_fetch();
+	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	did_alloc = false;
 	base = base_new(tsdn, 0, &hooks);
 	assert_ptr_not_null(base, "Unexpected base_new() failure");
@@ -200,7 +197,7 @@ TEST_BEGIN(test_base_hooks_not_null) {
 
 	called_dalloc = called_destroy = called_decommit = called_purge_lazy =
 	    called_purge_forced = false;
-	base_delete(base);
+	base_delete(tsdn, base);
 	assert_true(called_dalloc, "Expected dalloc call");
 	assert_true(!called_destroy, "Unexpected destroy call");
 	assert_true(called_decommit, "Expected decommit call");


### PR DESCRIPTION
Customized extent hooks may malloc / free thus trigger reentry.  Support this
behavior by adding reentrancy on hook functions.

This resolves #923.