### PR TITLE
Implement address-based size-class computations.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -112,6 +112,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/rtree.c \
 	$(srcroot)src/stats.c \
 	$(srcroot)src/spin.c \
+	$(srcroot)src/sized_alloc_region.c \
 	$(srcroot)src/sz.c \
 	$(srcroot)src/tcache.c \
 	$(srcroot)src/ticker.c \
@@ -194,6 +195,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/rtree.c \
 	$(srcroot)test/unit/SFMT.c \
 	$(srcroot)test/unit/size_classes.c \
+	$(srcroot)test/unit/sized_alloc_region.c \
 	$(srcroot)test/unit/slab.c \
 	$(srcroot)test/unit/smoothstep.c \
 	$(srcroot)test/unit/spin.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1120,6 +1120,22 @@ if test "x$enable_prof" = "x1" ; then
 fi
 AC_SUBST([enable_prof])
 
+dnl Do not enable the sized alloc region by default.
+AC_ARG_ENABLE([sized-alloc-region],
+  [AS_HELP_STRING([--enable-sized-alloc-region], [Enable sized alloc region])],
+[if test "x$enable_sized_alloc_region" = "xno" ; then
+  enable_sized_alloc_region="0"
+else
+  enable_sized_alloc_region="1"
+fi
+],
+[enable_sized_alloc_region="0"]
+)
+if test "x$enable_sized_alloc_region" = "x1" ; then
+  AC_DEFINE([JEMALLOC_SIZED_ALLOC_REGION], [ ])
+fi
+AC_SUBST(enable_sized_alloc_region)
+
 dnl Indicate whether adjacent virtual memory mappings automatically coalesce
 dnl (and fragment on demand).
 if test "x${maps_coalesce}" = "x1" ; then

--- a/include/jemalloc/internal/alloc_ctx.h
+++ b/include/jemalloc/internal/alloc_ctx.h
@@ -1,0 +1,11 @@
+#ifndef JEMALLOC_INTERNAL_ALLOC_CTX_H
+#define JEMALLOC_INTERNAL_ALLOC_CTX_H
+
+/* Used to pass rtree lookup context down the path. */
+typedef struct alloc_ctx_s alloc_ctx_t;
+struct alloc_ctx_s {
+	szind_t szind;
+	bool slab;
+};
+
+#endif /* JEMALLOC_INTERNAL_ALLOC_CTX_H */

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_ARENA_INLINES_B_H
 
 #include "jemalloc/internal/jemalloc_internal_types.h"
+#include "jemalloc/internal/alloc_ctx.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/size_classes.h"

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -275,10 +275,4 @@ struct arena_tdata_s {
 	ticker_t		decay_ticker;
 };
 
-/* Used to pass rtree lookup context down the path. */
-struct alloc_ctx_s {
-	szind_t szind;
-	bool slab;
-};
-
 #endif /* JEMALLOC_INTERNAL_ARENA_STRUCTS_B_H */

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -17,7 +17,6 @@ typedef struct arena_decay_s arena_decay_t;
 typedef struct arena_bin_s arena_bin_t;
 typedef struct arena_s arena_t;
 typedef struct arena_tdata_s arena_tdata_t;
-typedef struct alloc_ctx_s alloc_ctx_t;
 
 typedef enum {
 	percpu_arena_mode_names_base   = 0, /* Used for options processing. */

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -160,6 +160,9 @@
 /* Use gcc intrinsics for profile backtracing if defined. */
 #undef JEMALLOC_PROF_GCC
 
+/* Use the sized-alloc region */
+#undef JEMALLOC_SIZED_ALLOC_REGION
+
 /*
  * JEMALLOC_DSS enables use of sbrk(2) to allocate extents from the data storage
  * segment (DSS).

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -111,6 +111,13 @@ static const bool config_stats =
     false
 #endif
     ;
+static const bool config_sized_alloc_region =
+#ifdef JEMALLOC_SIZED_ALLOC_REGION
+    true
+#else
+    false
+#endif
+    ;
 static const bool config_thp =
 #ifdef JEMALLOC_THP
     true

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -58,6 +58,7 @@ static const bool pages_can_purge_forced =
 #endif
     ;
 
+/* addr may be NULL, alignment must be at least PAGE, commit may not be NULL. */
 void *pages_map(void *addr, size_t size, size_t alignment, bool *commit);
 void pages_unmap(void *addr, size_t size);
 bool pages_commit(void *addr, size_t size);

--- a/include/jemalloc/internal/sized_alloc_region.h
+++ b/include/jemalloc/internal/sized_alloc_region.h
@@ -1,0 +1,143 @@
+#ifndef JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H
+#define JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H
+
+#include "jemalloc/internal/assert.h"
+#include "jemalloc/internal/atomic.h"
+#include "jemalloc/internal/pages.h"
+
+/*
+ * This file defines sized alloc regions.  These regions have portions of memory
+ * dedicated to a particular size class.  When allocations come out of these
+ * regions, we can quickly determine their size based only on their address and
+ * a little bit of global metadata, thus avoiding any rtree lookups or (if we're
+ * lucky) any other cache-unfriendly lookups at all.
+ *
+ * We orchestrate it so that zero-initialization is a valid state for the
+ * sized_alloc_region_t.  This lets us avoid branching on
+ * opt_sized_alloc_region.
+ */
+
+/*
+ * SIZED_ALLOC_REGION_LG_NUM_SCS:
+ *     The log of the number of size classes that can come out of the
+ *     sized-alloc region.
+ * SIZED_ALLOC_REGION_LG_SC_SIZE:
+ *     The log of the size of virtual address space that we allocate to each
+ *     size class within the sized-alloc region.
+ */
+#if LG_SIZEOF_PTR == 2
+#  define SIZED_ALLOC_REGION_LG_NUM_SCS 4
+#  define SIZED_ALLOC_REGION_LG_SC_SIZE 25
+#elif LG_SIZEOF_PTR == 3
+#  define SIZED_ALLOC_REGION_LG_NUM_SCS 5
+#  define SIZED_ALLOC_REGION_LG_SC_SIZE 32
+#else
+#  error Got a weird value of LG_SIZEOF_PTR
+#endif
+
+/*
+ * SIZED_ALLOC_REGION_LG_SIZE:
+ *     The log of the total amount of space we allocate for the region.
+ *
+ * SIZED_ALLOC_REGION_NUM_SCS:
+ * SIZED_ALLOC_REGION_SC_SIZE:
+ * SIZED_ALLOC_REGION_SIZE:
+ *     These correspond to the LG_ equivalents, but are converted out of log
+ *     space.
+ */
+#define SIZED_ALLOC_REGION_LG_SIZE \
+    (SIZED_ALLOC_REGION_LG_NUM_SCS + SIZED_ALLOC_REGION_LG_SC_SIZE)
+#define SIZED_ALLOC_REGION_NUM_SCS (ZU(1) << SIZED_ALLOC_REGION_LG_NUM_SCS)
+#define SIZED_ALLOC_REGION_SC_SIZE (ZU(1) << SIZED_ALLOC_REGION_LG_SC_SIZE)
+#define SIZED_ALLOC_REGION_SIZE (ZU(1) << SIZED_ALLOC_REGION_LG_SIZE)
+
+typedef struct sized_alloc_region_s sized_alloc_region_t;
+struct sized_alloc_region_s {
+	JEMALLOC_ALIGNED(CACHELINE)
+	uintptr_t region_start;
+	/*
+	 * This is always either 0 (if uninitialized, or if initialization
+	 * failed), or SIZED_ALLOC_REGION_SIZE.  Doing it this way, instead of
+	 * having "bool initialized;", allows us to fold the initialization and
+	 * range checking branches into one.
+	 */
+	size_t region_size;
+	bool committed;
+
+	/* How much space is used in each size class. */
+	JEMALLOC_ALIGNED(CACHELINE)
+	atomic_zu_t size_class_space_used[SIZED_ALLOC_REGION_NUM_SCS];
+};
+
+extern bool opt_sized_alloc_region;
+extern sized_alloc_region_t sized_alloc_region_global;
+
+void sized_alloc_region_init(sized_alloc_region_t *region);
+#ifdef JEMALLOC_JET
+/*
+ * We need this only during testing, when we might spin up multiple of these,
+ * and should be considerate of virtual address space.
+ */
+void sized_alloc_region_destroy(sized_alloc_region_t *region);
+#endif
+
+/*
+ * Returns true if we found the address.  If alloc_ctx is non-null, we fill it
+ * in.  Safe to call on zero-initialized regions.
+ */
+static inline bool
+sized_alloc_region_lookup(sized_alloc_region_t *region, void *addrp,
+    alloc_ctx_t *alloc_ctx) {
+	uintptr_t addr = (uintptr_t)addrp;
+
+	/* Note: wraparound possible if addr < region. */
+	uintptr_t addr_offset = addr - region->region_start;
+
+	if (unlikely(addr_offset >= region->region_size)) {
+		return false;
+	}
+	if (alloc_ctx != NULL) {
+		alloc_ctx->szind = (szind_t)(
+		    addr_offset >> SIZED_ALLOC_REGION_LG_SC_SIZE);
+		alloc_ctx->slab = true;
+	}
+	return true;
+}
+
+/*
+ * This is safe to call on zero-initialized region, or one for whom
+ * initialization failed.
+ */
+static inline void *
+sized_alloc_region_bump_alloc(sized_alloc_region_t *region, size_t size,
+    szind_t szind, bool slab, bool *zero, bool *commit) {
+	assert(PAGE_CEILING(size) == size);
+	/* Only slab allocations allowed in the sized-alloc region. */
+	assert(slab);
+
+	if (region->region_size == 0 || szind >= SIZED_ALLOC_REGION_NUM_SCS) {
+		return NULL;
+	}
+
+	size_t prev = atomic_fetch_add_zu(&region->size_class_space_used[szind],
+	    size, ATOMIC_RELAXED);
+
+	if (unlikely(prev + size >= SIZED_ALLOC_REGION_SC_SIZE)) {
+		return NULL;
+	}
+	void *ret = (void *)(region->region_start
+	    + (szind * SIZED_ALLOC_REGION_SC_SIZE) + prev);
+	if (*commit) {
+		if (pages_commit(ret, size)) {
+			/* Just leak the virtual address space here. */
+			return NULL;
+		}
+	} else {
+		*commit = region->committed;
+	}
+	/* We get our memory straight from the OS, and never reuse it. */
+	*zero = true;
+	return ret;
+}
+
+#endif /* JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H */

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -9,6 +9,7 @@
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/size_classes.h"
+#include "jemalloc/internal/sized_alloc_region.h"
 #include "jemalloc/internal/util.h"
 
 /******************************************************************************/
@@ -105,6 +106,7 @@ CTL_PROTO(opt_prof_gdump)
 CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_accum)
+CTL_PROTO(opt_sized_alloc_region)
 CTL_PROTO(tcache_create)
 CTL_PROTO(tcache_flush)
 CTL_PROTO(tcache_destroy)
@@ -298,7 +300,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_gdump"),	CTL(opt_prof_gdump)},
 	{NAME("prof_final"),	CTL(opt_prof_final)},
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
-	{NAME("prof_accum"),	CTL(opt_prof_accum)}
+	{NAME("prof_accum"),	CTL(opt_prof_accum)},
+	{NAME("sized_alloc_region"),	CTL(opt_sized_alloc_region)}
 };
 
 static const ctl_named_node_t	tcache_node[] = {
@@ -1577,6 +1580,7 @@ CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)
 CTL_RO_NL_GEN(opt_stats_print_opts, opt_stats_print_opts, const char *)
+CTL_RO_NL_GEN(opt_sized_alloc_region, opt_sized_alloc_region, bool)
 CTL_RO_NL_CGEN(config_fill, opt_junk, opt_junk, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_zero, opt_zero, bool)
 CTL_RO_NL_CGEN(config_utrace, opt_utrace, opt_utrace, bool)

--- a/src/extent.c
+++ b/src/extent.c
@@ -9,6 +9,7 @@
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/mutex_pool.h"
+#include "jemalloc/internal/sized_alloc_region.h"
 
 /******************************************************************************/
 /* Data. */
@@ -965,14 +966,27 @@ extent_recycle(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
  * memory, in which case *zero is toggled to true.  arena_extent_alloc() takes
  * advantage of this to avoid demanding zeroed extents, but taking advantage of
  * them if they are returned.
+ *
+ * The caller can specify szind == NSIZES to indicate "don't know" (forgoing the
+ * possiblity of using the sized-alloc region), in which case it and slab are
+ * ignored.
  */
 static void *
 extent_alloc_core(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
-    size_t alignment, bool *zero, bool *commit, dss_prec_t dss_prec) {
+    bool slab, szind_t szind, size_t alignment, bool *zero, bool *commit,
+    dss_prec_t dss_prec) {
 	void *ret;
 
 	assert(size != 0);
 	assert(alignment != 0);
+
+	/* The sized-alloc region. */
+	if (config_sized_alloc_region && alignment == PAGE
+	    && szind < SIZED_ALLOC_REGION_NUM_SCS && slab && new_addr == NULL
+	    && ((ret = sized_alloc_region_bump_alloc(&sized_alloc_region_global,
+		size, szind, slab, zero, commit)) != NULL)) {
+		return ret;
+	}
 
 	/* "primary" dss. */
 	if (have_dss && dss_prec == dss_prec_primary && (ret =
@@ -1001,8 +1015,8 @@ extent_alloc_default_impl(tsdn_t *tsdn, arena_t *arena, void *new_addr,
     size_t size, size_t alignment, bool *zero, bool *commit) {
 	void *ret;
 
-	ret = extent_alloc_core(tsdn, arena, new_addr, size, alignment, zero,
-	    commit, (dss_prec_t)atomic_load_u(&arena->dss_prec,
+	ret = extent_alloc_core(tsdn, arena, new_addr, size, NSIZES, false,
+	    alignment, zero, commit, (dss_prec_t)atomic_load_u(&arena->dss_prec,
 	    ATOMIC_RELAXED));
 	return ret;
 }
@@ -1069,8 +1083,8 @@ extent_grow_retained(tsdn_t *tsdn, arena_t *arena,
 
 	void *ptr;
 	if (*r_extent_hooks == &extent_hooks_default) {
-		ptr = extent_alloc_core(tsdn, arena, NULL, alloc_size, PAGE,
-		    &zeroed, &committed, (dss_prec_t)atomic_load_u(
+		ptr = extent_alloc_core(tsdn, arena, NULL, alloc_size, slab,
+		    szind, PAGE, &zeroed, &committed, (dss_prec_t)atomic_load_u(
 		    &arena->dss_prec, ATOMIC_RELAXED));
 	} else {
 		ptr = (*r_extent_hooks)->alloc(*r_extent_hooks, NULL,
@@ -1301,6 +1315,15 @@ extent_can_coalesce(arena_t *arena, extents_t *extents, const extent_t *inner,
 	}
 
 	if (extent_committed_get(inner) != extent_committed_get(outer)) {
+		return false;
+	}
+
+	if (sized_alloc_region_lookup(&sized_alloc_region_global,
+	    extent_base_get(inner), NULL)) {
+		return false;
+	}
+	if (sized_alloc_region_lookup(&sized_alloc_region_global,
+	    extent_base_get(outer), NULL)) {
 		return false;
 	}
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -12,6 +12,7 @@
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/size_classes.h"
+#include "jemalloc/internal/sized_alloc_region.h"
 #include "jemalloc/internal/spin.h"
 #include "jemalloc/internal/sz.h"
 #include "jemalloc/internal/ticker.h"
@@ -1173,6 +1174,10 @@ malloc_conf_init(void) {
 				CONF_HANDLE_BOOL(opt_prof_final, "prof_final")
 				CONF_HANDLE_BOOL(opt_prof_leak, "prof_leak")
 			}
+			if (config_sized_alloc_region) {
+				CONF_HANDLE_BOOL(opt_sized_alloc_region,
+				    "sized_alloc_region");
+			}
 			malloc_conf_error("Invalid conf pair", k, klen, v,
 			    vlen);
 #undef CONF_MATCH
@@ -1508,6 +1513,10 @@ malloc_init_hard(void) {
 		if (err) {
 			return true;
 		}
+	}
+
+	if (config_sized_alloc_region && opt_sized_alloc_region) {
+		sized_alloc_region_init(&sized_alloc_region_global);
 	}
 #undef UNLOCK_RETURN
 	return false;
@@ -2122,9 +2131,17 @@ ifree(tsd_t *tsd, void *ptr, tcache_t *tcache, bool slow_path) {
 	assert(malloc_initialized() || IS_INITIALIZER);
 
 	alloc_ctx_t alloc_ctx;
-	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
-	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	bool alloc_ctx_found = false;
+	if (config_sized_alloc_region) {
+		alloc_ctx_found = sized_alloc_region_lookup(
+		    &sized_alloc_region_global, ptr, &alloc_ctx);
+	}
+	if (unlikely(!alloc_ctx_found)) {
+		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
+		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
+		    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	}
+
 	assert(alloc_ctx.szind != NSIZES);
 
 	size_t usize;

--- a/src/pages.c
+++ b/src/pages.c
@@ -60,7 +60,6 @@ os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 */
 	{
 		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
-
 		ret = mmap(addr, size, prot, mmap_flags, -1, 0);
 	}
 	assert(ret != NULL);

--- a/src/sized_alloc_region.c
+++ b/src/sized_alloc_region.c
@@ -1,0 +1,34 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/sized_alloc_region.h"
+
+extern sized_alloc_region_t sized_alloc_region_global;
+
+/* Disabled by default. */
+bool opt_sized_alloc_region = false;
+sized_alloc_region_t sized_alloc_region_global;
+
+void
+sized_alloc_region_init(sized_alloc_region_t *region) {
+#ifndef JEMALLOC_JET
+	/* Should only be one of these in a real program. */
+	assert(region == &sized_alloc_region_global);
+#endif
+	memset(region, '\0', sizeof(*region));
+	void *mem = pages_map(NULL, SIZED_ALLOC_REGION_SIZE, PAGE,
+	    &region->committed);
+	if (mem != NULL) {
+		region->region_start = (uintptr_t)mem;
+		region->region_size = SIZED_ALLOC_REGION_SIZE;
+	}
+}
+
+#ifdef JEMALLOC_JET
+void
+sized_alloc_region_destroy(sized_alloc_region_t *region) {
+	if (region->region_start != 0) {
+		pages_unmap((void *)region->region_start, region->region_size);
+	}
+}
+#endif

--- a/test/unit/sized_alloc_region.c
+++ b/test/unit/sized_alloc_region.c
@@ -1,0 +1,98 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/sized_alloc_region.h"
+
+#define ALLOCS_PER_SC 10
+
+TEST_BEGIN(test_lookup) {
+	sized_alloc_region_t region;
+	sized_alloc_region_init(&region);
+
+
+	void *allocs[SIZED_ALLOC_REGION_NUM_SCS][ALLOCS_PER_SC];
+	for (unsigned sc = 0; sc < SIZED_ALLOC_REGION_NUM_SCS; sc++) {
+		for (int alloc = 0; alloc < ALLOCS_PER_SC; alloc++) {
+			bool zero = false;
+			bool commit = false;
+
+			size_t size = PAGE * (alloc + 1);
+			void *ptr = sized_alloc_region_bump_alloc(
+			    &region, size, sc, true, &zero, &commit);
+			allocs[sc][alloc] = ptr;
+			assert_true(zero, "Got non-zero alloc.");
+			assert_ptr_not_null(ptr, "Unexpected null alloc.");
+		}
+	}
+
+	for (unsigned sc = 0; sc < SIZED_ALLOC_REGION_NUM_SCS; sc++) {
+		for (int alloc = 0; alloc < ALLOCS_PER_SC; alloc++) {
+			alloc_ctx_t alloc_ctx = {0, false};
+			char *begin = (char *)allocs[sc][alloc];
+			char *end = begin + (alloc + 1) * PAGE;
+			for (char *p = begin; p < end; p++) {
+				bool success = sized_alloc_region_lookup(
+				    &region, (void *)p, &alloc_ctx);
+				assert_true(success, "Lookup failure");
+				assert_d_eq(sc, (int)alloc_ctx.szind,
+				    "Lookup found incorrect size class.");
+				assert_true(alloc_ctx.slab,
+				    "Lookup found non-slab alloc.");
+			}
+		}
+	}
+
+	sized_alloc_region_destroy(&region);
+
+}
+TEST_END
+
+TEST_BEGIN(test_overflow) {
+	sized_alloc_region_t region;
+	sized_alloc_region_init(&region);
+
+	/* Pick an arbitrary size class. */
+	unsigned sc = 7;
+
+	/*
+	 * We include a "+ 1" on the loop boundary to make sure we go *past* the
+	 * end of the size class range.
+	 */
+	for (unsigned i = 0; i < SIZED_ALLOC_REGION_SC_SIZE / (100 * PAGE) + 1;
+	    i++) {
+		bool zero = false;
+		bool commit = false;
+		sized_alloc_region_bump_alloc(&region, 100 * PAGE, sc, true,
+		    &zero, &commit);
+	}
+	bool zero = false;
+	bool commit = false;
+	void *ptr = sized_alloc_region_bump_alloc(&region, PAGE, sc, true,
+	    &zero, &commit);
+	assert_ptr_null(ptr, "Kept allocating even after space exhausted.");
+
+	sized_alloc_region_destroy(&region);
+}
+TEST_END
+
+TEST_BEGIN(test_zero_init) {
+	/*
+	 * An uninitialized sized_alloc_region_t should return NULL for
+	 * allocations occurring before initialization.
+	 */
+	sized_alloc_region_t region;
+	memset(&region, 0, sizeof(region));
+	bool zero = false;
+	bool commit = false;
+	void *ptr = sized_alloc_region_bump_alloc(&region, PAGE, 0, true, &zero,
+	    &commit);
+	assert_ptr_null(ptr, "Zero-initialized region should not allocate.");
+}
+TEST_END
+
+int
+main(void) {
+	return test_no_reentrancy(
+	    test_lookup,
+	    test_overflow,
+	    test_zero_init);
+}


### PR DESCRIPTION
This implements the ideas in https://github.com/jemalloc/jemalloc/issues/887.
We split a large portion of virtual address space into regions reserved for
particular size classes.  We can then compute the size class of a particular
allocation by using only its address and a small amount of global metadata,
avoiding any cache-unfriendly lookups.