### PR TITLE
Enforce minimum autoconf version (currently 2.68).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
+AC_PREREQ(2.68)
 AC_INIT([Makefile.in])
 
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This resolves #912.