### PR TITLE
Address-based size-class computations

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -112,6 +112,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/prof.c \
 	$(srcroot)src/rtree.c \
 	$(srcroot)src/stats.c \
+	$(srcroot)src/sized_alloc_region.c \
 	$(srcroot)src/sz.c \
 	$(srcroot)src/tcache.c \
 	$(srcroot)src/ticker.c \
@@ -195,6 +196,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/rtree.c \
 	$(srcroot)test/unit/SFMT.c \
 	$(srcroot)test/unit/size_classes.c \
+	$(srcroot)test/unit/sized_alloc_region.c \
 	$(srcroot)test/unit/slab.c \
 	$(srcroot)test/unit/smoothstep.c \
 	$(srcroot)test/unit/spin.c \

--- a/include/jemalloc/internal/alloc_ctx.h
+++ b/include/jemalloc/internal/alloc_ctx.h
@@ -1,0 +1,11 @@
+#ifndef JEMALLOC_INTERNAL_ALLOC_CTX_H
+#define JEMALLOC_INTERNAL_ALLOC_CTX_H
+
+/* Used to pass rtree lookup context down the path. */
+typedef struct alloc_ctx_s alloc_ctx_t;
+struct alloc_ctx_s {
+	szind_t szind;
+	bool slab;
+};
+
+#endif /* JEMALLOC_INTERNAL_ALLOC_CTX_H */

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_ARENA_INLINES_B_H
 
 #include "jemalloc/internal/jemalloc_internal_types.h"
+#include "jemalloc/internal/alloc_ctx.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/size_classes.h"

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -122,13 +122,17 @@ struct arena_bin_s {
 	extent_t		*slabcur;
 
 	/*
-	 * Heap of non-full slabs.  This heap is used to assure that new
-	 * allocations come from the non-full slab that is oldest/lowest in
+	 * Heaps of non-empty, non-full slabs.  This heap is used to ensure that
+	 * new allocations come from the non-full slab that is oldest/lowest in
 	 * memory.
+	 * When picking an extent to allocate from, we prefer slabs from the
+	 * sized alloc region, but always prefer active slabs to non-active
+	 * ones.
 	 */
-	extent_heap_t		slabs_nonfull;
+	extent_heap_t		slabs_sized_alloc_region_nonfull;
+	extent_heap_t		slabs_other_nonfull;
 
-	/* List used to track full slabs. */
+	/* List used to track full slabs (regardless of their origin). */
 	extent_list_t		slabs_full;
 
 	/* Bin statistics. */
@@ -273,12 +277,6 @@ struct arena_s {
 /* Used in conjunction with tsd for fast arena-related context lookup. */
 struct arena_tdata_s {
 	ticker_t		decay_ticker;
-};
-
-/* Used to pass rtree lookup context down the path. */
-struct alloc_ctx_s {
-	szind_t szind;
-	bool slab;
 };
 
 #endif /* JEMALLOC_INTERNAL_ARENA_STRUCTS_B_H */

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -17,7 +17,6 @@ typedef struct arena_decay_s arena_decay_t;
 typedef struct arena_bin_s arena_bin_t;
 typedef struct arena_s arena_t;
 typedef struct arena_tdata_s arena_tdata_t;
-typedef struct alloc_ctx_s alloc_ctx_t;
 
 typedef enum {
 	percpu_arena_mode_names_base   = 0, /* Used for options processing. */

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -8,6 +8,7 @@
 #include "jemalloc/internal/rb.h"
 #include "jemalloc/internal/ph.h"
 #include "jemalloc/internal/size_classes.h"
+#include "jemalloc/internal/sized_alloc_region.h"
 
 typedef enum {
 	extent_state_active   = 0,
@@ -156,11 +157,21 @@ struct extents_s {
 	malloc_mutex_t		mtx;
 
 	/*
-	 * Quantized per size class heaps of extents.
+	 * Heaps of extents in the sized alloc region.  For suitably-sized
+	 * requests, we prefer allocating from here over heaps_other.
 	 *
 	 * Synchronization: mtx.
 	 */
-	extent_heap_t		heaps[NPSIZES+1];
+	extent_heap_t		heaps_sized_alloc_region[
+	    SIZED_ALLOC_REGION_NUM_SCS];
+
+	/*
+	 * Quantized per size class heaps of extents from outside the sized
+	 * alloc region.
+	 *
+	 * Synchronization: mtx.
+	 */
+	extent_heap_t		heaps_other[NPSIZES+1];
 
 	/*
 	 * Bitmap for which set bits correspond to non-empty heaps.

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -58,6 +58,7 @@ static const bool pages_can_purge_forced =
 #endif
     ;
 
+/* addr may be NULL, alignment must be at least PAGE, commit may not be NULL. */
 void *pages_map(void *addr, size_t size, size_t alignment, bool *commit);
 void pages_unmap(void *addr, size_t size);
 bool pages_commit(void *addr, size_t size);

--- a/include/jemalloc/internal/sized_alloc_region.h
+++ b/include/jemalloc/internal/sized_alloc_region.h
@@ -1,0 +1,134 @@
+#ifndef JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H
+#define JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H
+
+#include "jemalloc/internal/alloc_ctx.h"
+#include "jemalloc/internal/assert.h"
+#include "jemalloc/internal/atomic.h"
+#include "jemalloc/internal/pages.h"
+
+/*
+ * This file defines sized alloc regions.  These regions have portions of memory
+ * dedicated to a particular size class.  When allocations come out of these
+ * regions, we can quickly determine their size based only on their address and
+ * a little bit of global metadata, thus avoiding any rtree lookups or (if we're
+ * lucky) any other cache-unfriendly lookups at all.
+ *
+ * We orchestrate it so that zero-initialization is a valid state for the
+ * sized_alloc_region_t.  This lets us avoid branching on
+ * opt_sized_alloc_region.
+ */
+
+/* The number of size classes to put in the sized_alloc_region. */
+#define SIZED_ALLOC_REGION_NUM_SCS NBINS
+
+typedef struct sized_alloc_region_s sized_alloc_region_t;
+struct sized_alloc_region_s {
+	JEMALLOC_ALIGNED(CACHELINE)
+	uintptr_t region_start;
+	/*
+	 * This is always either 0 (if uninitialized, or if initialization
+	 * failed), or SIZED_ALLOC_REGION_SIZE.  Doing it this way, instead of
+	 * having "bool initialized;", allows us to fold the initialization and
+	 * range checking branches into one.
+	 */
+	size_t region_size;
+	bool committed;
+
+	/* How much space is used in each size class. */
+	JEMALLOC_ALIGNED(CACHELINE)
+	atomic_zu_t size_class_space_used[SIZED_ALLOC_REGION_NUM_SCS];
+};
+
+/* Whether this feature is enabled. */
+extern bool opt_sized_alloc_region;
+/* The lg of the number of bytes reserved for each size class in the region. */
+extern ssize_t opt_sized_alloc_region_lg_sc_size;
+/*
+ * The region we actually allocate out of.  There should be only one if these in
+ * an actualy program.
+ */
+extern sized_alloc_region_t sized_alloc_region_global;
+
+void sized_alloc_region_init(sized_alloc_region_t *region);
+#ifdef JEMALLOC_JET
+/*
+ * We need this only during testing, when we might spin up multiple of these,
+ * and should be considerate of virtual address space.
+ */
+void sized_alloc_region_destroy(sized_alloc_region_t *region);
+#endif
+
+/*
+ * Returns true if we found the address.  If alloc_ctx is non-null, we fill it
+ * in.  Safe to call on zero-initialized regions.
+ */
+static inline bool
+sized_alloc_region_lookup(sized_alloc_region_t *region, void *addrp,
+    alloc_ctx_t *alloc_ctx) {
+	uintptr_t addr = (uintptr_t)addrp;
+
+	/* Note: wraparound possible if addr < region. */
+	uintptr_t addr_offset = addr - region->region_start;
+
+	if (unlikely(addr_offset >= region->region_size)) {
+		return false;
+	}
+	if (alloc_ctx != NULL) {
+		alloc_ctx->szind = (szind_t)(
+		    addr_offset >> opt_sized_alloc_region_lg_sc_size);
+		alloc_ctx->slab = true;
+	}
+	return true;
+}
+
+/*
+ * This is safe to call on zero-initialized region, or one for whom
+ * initialization failed.
+ */
+static inline void *
+sized_alloc_region_bump_alloc(sized_alloc_region_t *region, size_t size,
+    szind_t szind, bool slab, bool *zero, bool *commit) {
+	assert(PAGE_CEILING(size) == size);
+	/* Only slab allocations allowed in the sized-alloc region. */
+	assert(slab);
+
+	if (region->region_size == 0 || szind >= SIZED_ALLOC_REGION_NUM_SCS) {
+		return NULL;
+	}
+
+	size_t sc_size = (ZU(1) << opt_sized_alloc_region_lg_sc_size);
+
+	/*
+	 * Overflow should be at most a theoretical problem here, since
+	 * presumably if the caller can't get memory from us, they'll get it
+	 * from elsewhere, so we don't hit problems until we exhaust the address
+	 * space.  For extra safety (and simplicity while debugging), we use a
+	 * CAS loop instead of a fetch-add.
+	 */
+	size_t cur = atomic_load_zu(&region->size_class_space_used[szind],
+	    ATOMIC_RELAXED);
+	size_t new_size;
+	do {
+		new_size = cur + size;
+		if (new_size > sc_size) {
+			return NULL;
+		}
+	} while (!atomic_compare_exchange_weak_zu(
+	    &region->size_class_space_used[szind], &cur, new_size,
+	    ATOMIC_RELAXED, ATOMIC_RELAXED));
+
+	void *ret = (void *)(region->region_start + (szind * sc_size) + cur);
+	if (*commit && !region->committed) {
+		if (pages_commit(ret, size)) {
+			/* Just leak the virtual address space here. */
+			return NULL;
+		}
+	} else {
+		*commit = region->committed;
+	}
+	/* We get our memory straight from the OS, and never reuse it. */
+	*zero = true;
+	return ret;
+}
+
+#endif /* JEMALLOC_INTERNAL_SIZED_ALLOC_REGION_H */

--- a/scripts/gen_run_tests.py
+++ b/scripts/gen_run_tests.py
@@ -28,6 +28,7 @@ possible_malloc_conf_opts = [
     'dss:primary',
     'percpu_arena:percpu',
     'background_thread:true',
+    'sized_alloc_region:true',
 ]
 
 print 'set -e'

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -9,6 +9,7 @@
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/size_classes.h"
+#include "jemalloc/internal/sized_alloc_region.h"
 #include "jemalloc/internal/util.h"
 
 /******************************************************************************/
@@ -105,6 +106,8 @@ CTL_PROTO(opt_prof_gdump)
 CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_accum)
+CTL_PROTO(opt_sized_alloc_region)
+CTL_PROTO(opt_sized_alloc_region_lg_sc_size)
 CTL_PROTO(tcache_create)
 CTL_PROTO(tcache_flush)
 CTL_PROTO(tcache_destroy)
@@ -298,7 +301,10 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_gdump"),	CTL(opt_prof_gdump)},
 	{NAME("prof_final"),	CTL(opt_prof_final)},
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
-	{NAME("prof_accum"),	CTL(opt_prof_accum)}
+	{NAME("prof_accum"),	CTL(opt_prof_accum)},
+	{NAME("sized_alloc_region"),	CTL(opt_sized_alloc_region)},
+	{NAME("sized_alloc_region_lg_sc_size"),
+		CTL(opt_sized_alloc_region_lg_sc_size)}
 };
 
 static const ctl_named_node_t	tcache_node[] = {
@@ -1578,6 +1584,9 @@ CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)
 CTL_RO_NL_GEN(opt_stats_print_opts, opt_stats_print_opts, const char *)
+CTL_RO_NL_GEN(opt_sized_alloc_region, opt_sized_alloc_region, bool)
+CTL_RO_NL_GEN(opt_sized_alloc_region_lg_sc_size,
+    opt_sized_alloc_region_lg_sc_size, ssize_t)
 CTL_RO_NL_CGEN(config_fill, opt_junk, opt_junk, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_zero, opt_zero, bool)
 CTL_RO_NL_CGEN(config_utrace, opt_utrace, opt_utrace, bool)

--- a/src/pages.c
+++ b/src/pages.c
@@ -60,7 +60,6 @@ os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 */
 	{
 		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
-
 		ret = mmap(addr, size, prot, mmap_flags, -1, 0);
 	}
 	assert(ret != NULL);

--- a/src/sized_alloc_region.c
+++ b/src/sized_alloc_region.c
@@ -1,0 +1,51 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/sized_alloc_region.h"
+
+#include "jemalloc/internal/log.h"
+
+extern sized_alloc_region_t sized_alloc_region_global;
+
+/* Disabled by default. */
+bool opt_sized_alloc_region = false;
+
+ssize_t opt_sized_alloc_region_lg_sc_size =
+#if LG_SIZEOF_PTR == 2
+  25
+#elif LG_SIZEOF_PTR == 3
+  32
+#else
+#  error Got a weird value of LG_SIZEOF_PTR
+  -1
+#endif
+;
+
+sized_alloc_region_t sized_alloc_region_global;
+
+void
+sized_alloc_region_init(sized_alloc_region_t *region) {
+#ifndef JEMALLOC_JET
+	/* Should only be one of these in a real program. */
+	assert(region == &sized_alloc_region_global);
+#endif
+	memset(region, '\0', sizeof(*region));
+
+	size_t sc_size = (ZU(1) << opt_sized_alloc_region_lg_sc_size);
+	size_t size = SIZED_ALLOC_REGION_NUM_SCS * sc_size;
+	void *mem = pages_map(NULL, size, PAGE, &region->committed);
+	if (mem != NULL) {
+		region->region_start = (uintptr_t)mem;
+		region->region_size = size;
+	}
+	log("sized_alloc_region.init", "start is %p, size is %zu", mem, size);
+}
+
+#ifdef JEMALLOC_JET
+void
+sized_alloc_region_destroy(sized_alloc_region_t *region) {
+	if (region->region_start != 0) {
+		pages_unmap((void *)region->region_start, region->region_size);
+	}
+}
+#endif

--- a/test/unit/sized_alloc_region.c
+++ b/test/unit/sized_alloc_region.c
@@ -1,0 +1,96 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/sized_alloc_region.h"
+
+#define ALLOCS_PER_SC 10
+
+TEST_BEGIN(test_lookup) {
+	sized_alloc_region_t region;
+	sized_alloc_region_init(&region);
+	void *allocs[SIZED_ALLOC_REGION_NUM_SCS][ALLOCS_PER_SC];
+	for (unsigned sc = 0; sc < SIZED_ALLOC_REGION_NUM_SCS; sc++) {
+		for (int alloc = 0; alloc < ALLOCS_PER_SC; alloc++) {
+			bool zero = false;
+			bool commit = false;
+
+			size_t size = PAGE * (alloc + 1);
+			void *ptr = sized_alloc_region_bump_alloc(
+			    &region, size, sc, true, &zero, &commit);
+			allocs[sc][alloc] = ptr;
+			assert_true(zero, "Got non-zero alloc.");
+			assert_ptr_not_null(ptr, "Unexpected null alloc.");
+		}
+	}
+
+	for (unsigned sc = 0; sc < SIZED_ALLOC_REGION_NUM_SCS; sc++) {
+		for (int alloc = 0; alloc < ALLOCS_PER_SC; alloc++) {
+			alloc_ctx_t alloc_ctx = {0, false};
+			char *begin = (char *)allocs[sc][alloc];
+			char *end = begin + (alloc + 1) * PAGE;
+			for (char *p = begin; p < end; p++) {
+				bool success = sized_alloc_region_lookup(
+				    &region, (void *)p, &alloc_ctx);
+				assert_true(success, "Lookup failure");
+				assert_d_eq(sc, (int)alloc_ctx.szind,
+				    "Lookup found incorrect size class.");
+				assert_true(alloc_ctx.slab,
+				    "Lookup found non-slab alloc.");
+			}
+		}
+	}
+
+	sized_alloc_region_destroy(&region);
+
+}
+TEST_END
+
+TEST_BEGIN(test_overflow) {
+	sized_alloc_region_t region;
+	sized_alloc_region_init(&region);
+	/* Pick an arbitrary size class. */
+	unsigned sc = 7;
+
+	/*
+	 * We include a "+ 1" on the loop boundary to make sure we go *past* the
+	 * end of the size class range.
+	 */
+	size_t sc_size = (ZU(1) << opt_sized_alloc_region_lg_sc_size);
+	for (unsigned i = 0; i < sc_size / (100 * PAGE) + 1;
+	    i++) {
+		bool zero = false;
+		bool commit = false;
+		sized_alloc_region_bump_alloc(&region, 100 * PAGE, sc, true,
+		    &zero, &commit);
+	}
+	bool zero = false;
+	bool commit = false;
+	void *ptr = sized_alloc_region_bump_alloc(&region, 100 * PAGE, sc, true,
+	    &zero, &commit);
+	assert_ptr_null(ptr, "Kept allocating even after space exhausted.");
+
+	sized_alloc_region_destroy(&region);
+}
+TEST_END
+
+TEST_BEGIN(test_zero_init) {
+	/*
+	 * An uninitialized sized_alloc_region_t should return NULL for
+	 * allocations occurring before initialization.
+	 */
+	sized_alloc_region_t region;
+	memset(&region, 0, sizeof(region));
+	bool zero = false;
+	bool commit = false;
+	void *ptr = sized_alloc_region_bump_alloc(&region, PAGE, 0, true, &zero,
+	    &commit);
+	assert_ptr_null(ptr, "Zero-initialized region should not allocate.");
+}
+TEST_END
+
+int
+main(void) {
+	return test_no_reentrancy(
+	    test_lookup,
+	    test_overflow,
+	    test_zero_init);
+}


### PR DESCRIPTION
Let's try this again.

The performance wins vary based on machine from "no difference" to "substantial", but I'm hopeful that we'll see wins everywhere once we actually have to share the cache with real application workloads.