### PR TITLE
Remove external linkage for spin_adaptive

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -112,7 +112,6 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/prof.c \
 	$(srcroot)src/rtree.c \
 	$(srcroot)src/stats.c \
-	$(srcroot)src/spin.c \
 	$(srcroot)src/sz.c \
 	$(srcroot)src/tcache.c \
 	$(srcroot)src/ticker.c \

--- a/include/jemalloc/internal/spin.h
+++ b/include/jemalloc/internal/spin.h
@@ -1,19 +1,13 @@
 #ifndef JEMALLOC_INTERNAL_SPIN_H
 #define JEMALLOC_INTERNAL_SPIN_H
 
-#ifdef JEMALLOC_SPIN_C_
-#  define SPIN_INLINE extern inline
-#else
-#  define SPIN_INLINE inline
-#endif
-
 #define SPIN_INITIALIZER {0U}
 
 typedef struct {
 	unsigned iteration;
 } spin_t;
 
-SPIN_INLINE void
+static inline void
 spin_adaptive(spin_t *spin) {
 	volatile uint32_t i;
 

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -56,7 +56,6 @@
     <ClCompile Include="..\..\..\..\src\prng.c" />
     <ClCompile Include="..\..\..\..\src\prof.c" />
     <ClCompile Include="..\..\..\..\src\rtree.c" />
-    <ClCompile Include="..\..\..\..\src\spin.c" />
     <ClCompile Include="..\..\..\..\src\stats.c" />
     <ClCompile Include="..\..\..\..\src\sz.c" />
     <ClCompile Include="..\..\..\..\src\tcache.c" />

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -70,9 +70,6 @@
     <ClCompile Include="..\..\..\..\src\rtree.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\src\spin.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\src\stats.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/spin.c
+++ b/src/spin.c
@@ -1,4 +1,0 @@
-#define JEMALLOC_SPIN_C_
-#include "jemalloc/internal/jemalloc_preamble.h"
-
-#include "jemalloc/internal/spin.h"


### PR DESCRIPTION
The external linkage for spin_adaptive was not used, and the inline
declaration of spin_adaptive that was used caused a probem on FreeBSD
where CPU_SPINWAIT is implemented as a call to a static procedure for
x86 architectures.

A little more explanation:

On FreeBSD, CPU_SPINWAIT is defined as cpu_spinwait(), which for amd64
and i386 is in turn defined as ia32_pause, which is declared as static
inline.

The problem is, the C standard says that inline non-static procedures
(e.g. spin_adaptive) are not allowed to call static procedures (e.g.
ia32_pause) (ISO/IEC 9899:201x 6.7.4,
http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf).

At some point gcc started emitting a warning for this.  FreeBSD is now
using clang by default but I have been trying to get the amd64/gcc build
functional again.  This warning in jemalloc is one of the last
obstacles.

This could perhaps be solved differently (FreeBSD could maybe change
ia32_pause to a macro?) but since the external linkage of spin_adaptive
doesn't actually seem to be used and since this seems to be the only
use of "extern inline" in jemalloc, it seems to make sense to me just to
remove the extern definition.