### PR TITLE
Couple of portability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -567,7 +567,7 @@ case "${host}" in
 	  default_retain="1"
 	fi
 	;;
-  *-*-linux* | *-*-kfreebsd*)
+  *-*-linux*)
 	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
 	JE_APPEND_VS(CPPFLAGS, -D_GNU_SOURCE)
 	abi="elf"
@@ -579,6 +579,15 @@ case "${host}" in
 	if test "${LG_SIZEOF_PTR}" = "3"; then
 	  default_retain="1"
 	fi
+	;;
+  *-*-kfreebsd*)
+	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
+	JE_APPEND_VS(CPPFLAGS, -D_GNU_SOURCE)
+	abi="elf"
+	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H])
+	AC_DEFINE([JEMALLOC_SYSCTL_VM_OVERCOMMIT], [ ])
+	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ])
+	AC_DEFINE([JEMALLOC_USE_CXX_THROW], [ ])
 	;;
   *-*-netbsd*)
 	AC_MSG_CHECKING([ABI])

--- a/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/include/jemalloc/internal/jemalloc_internal_types.h
@@ -79,7 +79,13 @@ typedef int malloc_cpuid_t;
 #  ifdef __hppa__
 #    define LG_QUANTUM		4
 #  endif
+#  ifdef __m68k__
+#    define LG_QUANTUM		3
+#  endif
 #  ifdef __mips__
+#    define LG_QUANTUM		3
+#  endif
+#  ifdef __nios2__
 #    define LG_QUANTUM		3
 #  endif
 #  ifdef __or1k__
@@ -94,7 +100,8 @@ typedef int malloc_cpuid_t;
 #  ifdef __s390__
 #    define LG_QUANTUM		4
 #  endif
-#  ifdef __SH4__
+#  if (defined (__SH3E__) || defined(__SH4_SINGLE__) || defined(__SH4__) || \
+	defined(__SH4_SINGLE_ONLY__))
 #    define LG_QUANTUM		4
 #  endif
 #  ifdef __tile__


### PR DESCRIPTION
- GNU/kFreeBSD support is broken as far as I can tell, by assuming that because the system runs glibc, it also has some features that are Linux-only. Workaround that by creating a new kFreeBSD entry, that enables the combination of features that glibc + kFreeBSD have. The right fix would probably be to split the `$host` case to two, one of which matching the kernel, and another one the libc, but that's way over my head :)
- A few Debian porters have submitted bug reports for (still unofficial) ports they're building, with the lg quantum size that is required for their architecture, and this just incorporates them upstream.