### PR TITLE
Fix test/unit/pages

### DIFF
--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -61,6 +61,13 @@ static const bool have_dss =
     false
 #endif
     ;
+static const bool have_madvise_huge =
+#ifdef JEMALLOC_HAVE_MADVISE_HUGE
+    true
+#else
+    false
+#endif
+    ;
 static const bool config_fill =
 #ifdef JEMALLOC_FILL
     true

--- a/src/pages.c
+++ b/src/pages.c
@@ -417,13 +417,14 @@ os_overcommits_proc(void) {
 
 static void
 init_thp_state(void) {
-#ifndef JEMALLOC_HAVE_MADVISE_HUGE
-	if (opt_metadata_thp && opt_abort) {
-		malloc_write("<jemalloc>: no MADV_HUGEPAGE support\n");
-		abort();
+	if (!have_madvise_huge) {
+		if (opt_metadata_thp && opt_abort) {
+			malloc_write("<jemalloc>: no MADV_HUGEPAGE support\n");
+			abort();
+		}
+		goto label_error;
 	}
-	goto label_error;
-#endif
+
 	static const char madvise_state[] = "always [madvise] never\n";
 	char buf[sizeof(madvise_state)];
 

--- a/test/unit/pages.c
+++ b/test/unit/pages.c
@@ -11,7 +11,7 @@ TEST_BEGIN(test_pages_huge) {
 	assert_ptr_not_null(pages, "Unexpected pages_map() error");
 
 	hugepage = (void *)(ALIGNMENT_CEILING((uintptr_t)pages, HUGEPAGE));
-	assert_b_ne(pages_huge(hugepage, HUGEPAGE), config_thp,
+	assert_b_ne(pages_huge(hugepage, HUGEPAGE), have_madvise_huge,
 	    "Unexpected pages_huge() result");
 	assert_false(pages_nohuge(hugepage, HUGEPAGE),
 	    "Unexpected pages_nohuge() result");


### PR DESCRIPTION
As part of the metadata_thp support, We now have a separate swtich
(JEMALLOC_HAVE_MADVISE_HUGE) for MADV_HUGEPAGE availability.  Use that instead
of JEMALLOC_THP (which doesn't guard pages_huge anymore) in tests.