### PR TITLE
Fix huge page test in test/unit/pages.

### DIFF
--- a/test/unit/pages.c
+++ b/test/unit/pages.c
@@ -10,11 +10,13 @@ TEST_BEGIN(test_pages_huge) {
 	pages = pages_map(NULL, alloc_size, PAGE, &commit);
 	assert_ptr_not_null(pages, "Unexpected pages_map() error");
 
-	hugepage = (void *)(ALIGNMENT_CEILING((uintptr_t)pages, HUGEPAGE));
-	assert_b_ne(pages_huge(hugepage, HUGEPAGE), have_madvise_huge,
-	    "Unexpected pages_huge() result");
-	assert_false(pages_nohuge(hugepage, HUGEPAGE),
-	    "Unexpected pages_nohuge() result");
+	if (thp_state_madvise) {
+	    hugepage = (void *)(ALIGNMENT_CEILING((uintptr_t)pages, HUGEPAGE));
+	    assert_b_ne(pages_huge(hugepage, HUGEPAGE), have_madvise_huge,
+	        "Unexpected pages_huge() result");
+	    assert_false(pages_nohuge(hugepage, HUGEPAGE),
+	        "Unexpected pages_nohuge() result");
+	}
 
 	pages_unmap(pages, alloc_size);
 }


### PR DESCRIPTION
Huge pages could be disabled even if the kernel header has MAD_HUGEPAGE
defined.  Guard the huge pagetest with runtime detection.