### PR TITLE
FreeBSD binary startup improvements

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -357,6 +357,8 @@ os_page_detect(void) {
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 	return si.dwPageSize;
+#elif defined(__FreeBSD__)
+	return getpagesize();
 #else
 	long result = sysconf(_SC_PAGESIZE);
 	if (result == -1) {


### PR DESCRIPTION
The purpose of those commits is to do one sysctl(2) syscall during binary startup instead of current three.