### PR TITLE
metadata_thp: auto mode adjustment for a0.

### DIFF
--- a/include/jemalloc/internal/base_types.h
+++ b/include/jemalloc/internal/base_types.h
@@ -6,6 +6,15 @@ typedef struct base_s base_t;
 
 #define METADATA_THP_DEFAULT metadata_thp_disabled
 
+/*
+ * In auto mode, arenas switch to huge pages for the base allocator on the
+ * second base block.  a0 switches to thp on the 5th block (after 20 megabytes
+ * of metadata), since more metadata (e.g. rtree nodes) come from a0's base.
+ */
+
+#define BASE_AUTO_THP_THRESHOLD    2
+#define BASE_AUTO_THP_THRESHOLD_A0 5
+
 typedef enum {
 	metadata_thp_disabled   = 0,
 	/*


### PR DESCRIPTION
We observed that arena 0 can have much more metadata allocated comparing to
other arenas.  Tune the auto mode to only switch to huge page on the 5th block
(instead of 3 previously) for a0.