### PR TITLE
Add missing deregister before extents_leak.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -995,6 +995,7 @@ extent_recycle_split(tsdn_t *tsdn, arena_t *arena,
 			extent_deregister(tsdn, to_salvage);
 		}
 		if (to_leak != NULL) {
+			extent_deregister(tsdn, to_leak);
 			extents_leak(tsdn, arena, r_extent_hooks, extents,
 			    to_leak, growing_retained);
 		}


### PR DESCRIPTION
This fixes an regression introduced by 211b1f3 (refactor extent split).