### PR TITLE
Correct the spelling of __riscv.

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/include/jemalloc/internal/jemalloc_internal_types.h
@@ -94,7 +94,7 @@ typedef int malloc_cpuid_t;
 #  ifdef __powerpc__
 #    define LG_QUANTUM		4
 #  endif
-#  ifdef __riscv__
+#  if defined(__riscv) || defined(__riscv__)
 #    define LG_QUANTUM		4
 #  endif
 #  ifdef __s390__


### PR DESCRIPTION
According to the RISC-V toolchain conventions, `__riscv__` is the old spelling of this definition. `__riscv` should be used going forward.

https://github.com/riscv/riscv-toolchain-conventions#cc-preprocessor-definitions