### PR TITLE
jemalloc_mangle.sh: set sh in strict mode

### DIFF
--- a/include/jemalloc/jemalloc_mangle.sh
+++ b/include/jemalloc/jemalloc_mangle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
 public_symbols_txt=$1
 symbol_prefix=$2


### PR DESCRIPTION
Set sh in "strict mode" in `jemalloc_mangle.sh`.

I've had a [TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/third_party/jemalloc.BUILD) build fail in weird ways because the sysroot did not have `awk` installed. It would have been nice if the script failed right away instead of producing a malformed header.