### PR TITLE
handle 32 bit mutex counters

### DIFF
--- a/include/jemalloc/internal/mutex_prof.h
+++ b/include/jemalloc/internal/mutex_prof.h
@@ -35,21 +35,34 @@ typedef enum {
 	mutex_prof_num_arena_mutexes
 } mutex_prof_arena_ind_t;
 
-#define MUTEX_PROF_COUNTERS						\
+#define MUTEX_PROF_UINT64_COUNTERS				\
     OP(num_ops, uint64_t)						\
     OP(num_wait, uint64_t)						\
-    OP(num_spin_acq, uint64_t)						\
-    OP(num_owner_switch, uint64_t)					\
-    OP(total_wait_time, uint64_t)					\
-    OP(max_wait_time, uint64_t)						\
+    OP(num_spin_acq, uint64_t)					\
+    OP(num_owner_switch, uint64_t)				\
+    OP(total_wait_time, uint64_t)				\
+    OP(max_wait_time, uint64_t)
+
+#define MUTEX_PROF_UINT32_COUNTERS				\
     OP(max_num_thds, uint32_t)
 
-typedef enum {
+#define MUTEX_PROF_COUNTERS		\
+		MUTEX_PROF_UINT64_COUNTERS \
+		MUTEX_PROF_UINT32_COUNTERS
+
 #define OP(counter, type) mutex_counter_##counter,
-	MUTEX_PROF_COUNTERS
+
+#define COUNTER_ENUM(counter_list, t)           \
+		typedef enum {                          \
+			counter_list                        \
+			mutex_prof_num_##t##_counters       \
+		} mutex_prof_##t##_counter_ind_t;
+
+COUNTER_ENUM(MUTEX_PROF_UINT64_COUNTERS, uint64_t)
+COUNTER_ENUM(MUTEX_PROF_UINT32_COUNTERS, uint32_t)
+
+#undef COUNTER_ENUM
 #undef OP
-	mutex_prof_num_counters
-} mutex_prof_counter_ind_t;
 
 typedef struct {
 	/*


### PR DESCRIPTION
This fixes #1063 , where we are separating 64 bit and 32 bit mutex stats counters.  During read, we read them in their respective types.
  