### PR TITLE
Disable JEMALLOC_HAVE_MADVISE_HUGE for arm* CPUs.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1863,9 +1863,15 @@ if test "x${je_cv_madvise}" = "xyes" ; then
 	madvise((void *)0, 0, MADV_HUGEPAGE);
 	madvise((void *)0, 0, MADV_NOHUGEPAGE);
 ], [je_cv_thp])
+case "${host_cpu}" in
+  arm*)
+    ;;
+  *)
   if test "x${je_cv_thp}" = "xyes" ; then
     AC_DEFINE([JEMALLOC_HAVE_MADVISE_HUGE], [ ])
   fi
+  ;;
+esac
 fi
 
 dnl Enable transparent huge page support by default.


### PR DESCRIPTION
As mentioned in #1045, the macro should be disabled for arm*.
Unfortunately the patch as is can't be backported to 5.0.x release.