### PR TITLE
Cache the serial number of oldest/first extent.

### DIFF
--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -188,6 +188,10 @@ struct extents_s {
 	size_t      lowest_sn_heaps[NPSIZES+1];
 
 	/*
+	 * Flag to indicate if lowest sn is known
+	 */
+	bool	lowest_sn_known[NPSIZES+1];
+	/*
 	 * Bitmap for which set bits correspond to non-empty heaps.
 	 *
 	 * Synchronization: mtx.

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -183,6 +183,11 @@ struct extents_s {
 	extent_heap_t		heaps[NPSIZES+1];
 
 	/*
+	 * lowest/oldest sn of extent_t in heap
+	 */
+	size_t      lowest_sn_heaps[NPSIZES+1];
+
+	/*
 	 * Bitmap for which set bits correspond to non-empty heaps.
 	 *
 	 * Synchronization: mtx.

--- a/include/jemalloc/internal/ph.h
+++ b/include/jemalloc/internal/ph.h
@@ -218,13 +218,9 @@ a_prefix##empty(a_ph_type *ph) {					\
 	return (ph->ph_root == NULL);					\
 }									\
 a_attr bool								\
-a_prefix##first_after_remove(a_ph_type *ph, a_type *phn) {	\
-	return (ph->ph_root == phn && phn_lchild_get(a_type, a_field, phn) != NULL);	\
-}									\
-a_attr a_type *								\
-a_prefix##get_first(a_ph_type *ph) {	\
-	return ph->ph_root; 					\
-}									\
+a_prefix##root_first(a_ph_type *ph) {					\
+	return ph->ph_root != NULL && phn_next_get(a_type, a_field, ph->ph_root) == NULL;	\
+}																	\
 a_attr a_type *								\
 a_prefix##first(a_ph_type *ph) {					\
 	if (ph->ph_root == NULL) {					\

--- a/include/jemalloc/internal/ph.h
+++ b/include/jemalloc/internal/ph.h
@@ -217,6 +217,14 @@ a_attr bool								\
 a_prefix##empty(a_ph_type *ph) {					\
 	return (ph->ph_root == NULL);					\
 }									\
+a_attr bool								\
+a_prefix##first_after_remove(a_ph_type *ph, a_type *phn) {	\
+	return (ph->ph_root == phn && phn_lchild_get(a_type, a_field, phn) != NULL);	\
+}									\
+a_attr a_type *								\
+a_prefix##get_first(a_ph_type *ph) {	\
+	return ph->ph_root; 					\
+}									\
 a_attr a_type *								\
 a_prefix##first(a_ph_type *ph) {					\
 	if (ph->ph_root == NULL) {					\

--- a/src/extent.c
+++ b/src/extent.c
@@ -319,6 +319,8 @@ extents_insert_locked(tsdn_t *tsdn, extents_t *extents, extent_t *extent,
 		    (size_t)pind);
 	}
 	extent_heap_insert(&extents->heaps[pind], extent);
+	extent_t *first_extent = extent_heap_first(&extents->heaps[pind]);
+	extents->lowest_sn_heaps[pind] = extent_sn_get(first_extent);
 	if (!preserve_lru) {
 		extent_list_append(&extents->lru, extent);
 	}
@@ -347,7 +349,11 @@ extents_remove_locked(tsdn_t *tsdn, extents_t *extents, extent_t *extent,
 	if (extent_heap_empty(&extents->heaps[pind])) {
 		bitmap_set(extents->bitmap, &extents_bitmap_info,
 		    (size_t)pind);
+	} else {
+		extent_t *first_extent = extent_heap_first(&extents->heaps[pind]);
+		extents->lowest_sn_heaps[pind] = extent_sn_get(first_extent);
 	}
+
 	if (!preserve_lru) {
 		extent_list_remove(&extents->lru, extent);
 	}
@@ -424,6 +430,26 @@ extents_best_fit_locked(tsdn_t *tsdn, arena_t *arena, extents_t *extents,
 	return NULL;
 }
 
+static int
+extent_sncachedad_comp(extents_t *extents, pszind_t a, pszind_t b) {
+	int ret;
+
+	size_t a_esn = extents->lowest_sn_heaps[a];
+	size_t b_esn = extents->lowest_sn_heaps[b];
+
+	ret = (a_esn > b_esn) - (a_esn < b_esn);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	extent_t *ae = extent_heap_first(&extents->heaps[a]);
+	extent_t *be = extent_heap_first(&extents->heaps[b]);
+
+	ret = extent_ad_comp(ae, be);
+
+	return ret;
+}
 /*
  * Do first-fit extent selection, i.e. select the oldest/lowest extent that is
  * large enough.
@@ -432,6 +458,8 @@ static extent_t *
 extents_first_fit_locked(tsdn_t *tsdn, arena_t *arena, extents_t *extents,
     size_t size) {
 	extent_t *ret = NULL;
+	pszind_t index_lowest;
+	bool found = false;
 
 	pszind_t pind = sz_psz2ind(extent_size_quantize_ceil(size));
 	for (pszind_t i = (pszind_t)bitmap_ffu(extents->bitmap,
@@ -439,16 +467,19 @@ extents_first_fit_locked(tsdn_t *tsdn, arena_t *arena, extents_t *extents,
 	    (pszind_t)bitmap_ffu(extents->bitmap, &extents_bitmap_info,
 	    (size_t)i+1)) {
 		assert(!extent_heap_empty(&extents->heaps[i]));
-		extent_t *extent = extent_heap_first(&extents->heaps[i]);
-		assert(extent_size_get(extent) >= size);
-		if (ret == NULL || extent_snad_comp(extent, ret) < 0) {
-			ret = extent;
-		}
+		if(!found || extent_sncachedad_comp(extents, i, index_lowest) < 0) {
+			index_lowest = i;
+			if(!found) {
+				found = true;
+			}
+  		}
 		if (i == NPSIZES) {
 			break;
 		}
 		assert(i < NPSIZES);
 	}
+
+	ret = found ? extent_heap_first(&extents->heaps[index_lowest]) : NULL;
 
 	return ret;
 }

--- a/test/unit/ph.c
+++ b/test/unit/ph.c
@@ -263,7 +263,6 @@ TEST_BEGIN(test_ph_random) {
 				node_t *prev = NULL;
 				for (k = 0; k < j; k++) {
 					node_t *node = heap_first(&heap);
-					bool first = heap_first_after_remove(&heap, node);
 					assert_u_eq(heap_validate(&heap), j - k,
 					    "Incorrect node count");
 					if (prev != NULL) {
@@ -272,10 +271,10 @@ TEST_BEGIN(test_ph_random) {
 						    "Bad removal order");
 					}
 					node_remove(&heap, node);
-					if(first)
+					if(heap_root_first(&heap))
 					{
-						assert_ptr_eq(heap_get_first(&heap), heap_first(&heap) ,
-								"Node not first node");
+						assert_ptr_eq( (&heap)->ph_root, heap_first(&heap) ,
+								"Root not first node");
 					}
 					assert_u_eq(heap_validate(&heap), j - k
 					    - 1, "Incorrect node count");

--- a/test/unit/ph.c
+++ b/test/unit/ph.c
@@ -263,6 +263,7 @@ TEST_BEGIN(test_ph_random) {
 				node_t *prev = NULL;
 				for (k = 0; k < j; k++) {
 					node_t *node = heap_first(&heap);
+					bool first = heap_first_after_remove(&heap, node);
 					assert_u_eq(heap_validate(&heap), j - k,
 					    "Incorrect node count");
 					if (prev != NULL) {
@@ -271,6 +272,11 @@ TEST_BEGIN(test_ph_random) {
 						    "Bad removal order");
 					}
 					node_remove(&heap, node);
+					if(first)
+					{
+						assert_ptr_eq(heap_get_first(&heap), heap_first(&heap) ,
+								"Node not first node");
+					}
 					assert_u_eq(heap_validate(&heap), j - k
 					    - 1, "Incorrect node count");
 					prev = node;


### PR DESCRIPTION
Fixing issue #1004. Cache the serial number of oldest/first extent in extent_t.  serial number is used during search of first fit extent. Caching sn should avoid filling cache lines with unnecessary extent data which is discarded soon as only sn info is needed during search. This cached sn is updated during insert and remove operations in paired heap. If sn is same during comparison, we load extent_t to compare e_addr.