### PR TITLE
Add deterministic testing support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -97,6 +97,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/bitmap.c \
 	$(srcroot)src/ckh.c \
 	$(srcroot)src/ctl.c \
+	$(srcroot)src/deterministic.c \
 	$(srcroot)src/div.c \
 	$(srcroot)src/extent.c \
 	$(srcroot)src/extent_dss.c \
@@ -214,6 +215,7 @@ TESTS_UNIT += \
 endif
 TESTS_INTEGRATION := $(srcroot)test/integration/aligned_alloc.c \
 	$(srcroot)test/integration/allocated.c \
+	$(srcroot)test/integration/deterministic.c \
 	$(srcroot)test/integration/extent.c \
 	$(srcroot)test/integration/mallocx.c \
 	$(srcroot)test/integration/MALLOCX_ARENA.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1521,6 +1521,13 @@ if test "x$abi" != "xpecoff" ; then
   if test "x${je_cv_pthread_setname_np}" = "xyes" ; then
     AC_DEFINE([JEMALLOC_HAVE_PTHREAD_SETNAME_NP], [ ])
   fi
+  dnl Check if pthread_tryjoin_np is available
+  JE_COMPILABLE([pthread_tryjoin_np(3)], [
+#include <pthread.h>
+], [
+  void* ret;
+  pthread_tryjoin_np(pthread_self(), &ret);
+], [je_cv_pthread_tryjoin_np])
 fi
 
 JE_APPEND_VS(CPPFLAGS, -D_REENTRANT)
@@ -1857,7 +1864,7 @@ if test "x${je_cv_madvise}" = "xyes" ; then
   if test "x${je_cv_madv_dontdump}" = "xyes" ; then
     AC_DEFINE([JEMALLOC_MADVISE_DONTDUMP], [ ])
   fi
- 
+
   dnl Check for madvise(..., MADV_[NO]HUGEPAGE).
   JE_COMPILABLE([madvise(..., MADV_[[NO]]HUGEPAGE)], [
 #include <sys/mman.h>
@@ -2021,6 +2028,16 @@ if test "x${have_pthread}" = "x1" -a "x${have_dlsym}" = "x1" \
     -a "x${je_cv_os_unfair_lock}" != "xyes" \
     -a "x${je_cv_osspin}" != "xyes" ; then
   AC_DEFINE([JEMALLOC_BACKGROUND_THREAD])
+fi
+
+dnl ============================================================================
+dnl Enable deterministic scheduling if possible.
+
+if test "x${have_pthread}" = "x1" -a "x${enable_debug}" == "x1" \
+    -a "x${je_cv_os_unfair_lock}" != "xyes" \
+    -a "x${je_cv_osspin}" != "xyes" \
+    -a "x${je_cv_pthread_tryjoin_np}" = "xyes"; then
+  AC_DEFINE([JEMALLOC_DETERMINISTIC_SCHED])
 fi
 
 dnl ============================================================================

--- a/include/jemalloc/internal/atomic_gcc_atomic.h
+++ b/include/jemalloc/internal/atomic_gcc_atomic.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_ATOMIC_GCC_ATOMIC_H
 
 #include "jemalloc/internal/assert.h"
+#include "jemalloc/internal/deterministic.h"
 
 #define ATOMIC_INIT(...) {__VA_ARGS__}
 
@@ -46,22 +47,28 @@ ATOMIC_INLINE type							\
 atomic_load_##short_type(const atomic_##short_type##_t *a,		\
     atomic_memory_order_t mo) {						\
 	type result;							\
+	det_before_shared();						\
 	__atomic_load(&a->repr, &result, atomic_enum_to_builtin(mo));	\
+	det_after_shared();						\
 	return result;							\
 }									\
 									\
 ATOMIC_INLINE void							\
 atomic_store_##short_type(atomic_##short_type##_t *a, type val,		\
     atomic_memory_order_t mo) {						\
+	det_before_shared();						\
 	__atomic_store(&a->repr, &val, atomic_enum_to_builtin(mo));	\
+	det_after_shared();						\
 }									\
 									\
 ATOMIC_INLINE type							\
 atomic_exchange_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
 	type result;							\
+	det_before_shared();						\
 	__atomic_exchange(&a->repr, &val, &result,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
 	return result;							\
 }									\
 									\
@@ -69,19 +76,25 @@ ATOMIC_INLINE bool							\
 atomic_compare_exchange_weak_##short_type(atomic_##short_type##_t *a,	\
     type *expected, type desired, atomic_memory_order_t success_mo,	\
     atomic_memory_order_t failure_mo) {					\
-	return __atomic_compare_exchange(&a->repr, expected, &desired,	\
-	    true, atomic_enum_to_builtin(success_mo),			\
+	det_before_shared();						\
+	bool res = __atomic_compare_exchange(&a->repr, expected,	\
+	    &desired, true, atomic_enum_to_builtin(success_mo),		\
 	    atomic_enum_to_builtin(failure_mo));			\
+	det_after_shared();						\
+	return res;							\
 }									\
 									\
 ATOMIC_INLINE bool							\
 atomic_compare_exchange_strong_##short_type(atomic_##short_type##_t *a,	\
     type *expected, type desired, atomic_memory_order_t success_mo,	\
     atomic_memory_order_t failure_mo) {					\
-	return __atomic_compare_exchange(&a->repr, expected, &desired,	\
-	    false,							\
+	det_before_shared();						\
+	bool res = __atomic_compare_exchange(&a->repr, expected,	\
+	    &desired, false,						\
 	    atomic_enum_to_builtin(success_mo),				\
 	    atomic_enum_to_builtin(failure_mo));			\
+	det_after_shared();						\
+	return res;							\
 }
 
 
@@ -92,36 +105,51 @@ JEMALLOC_GENERATE_ATOMICS(type, short_type, /* unused */ lg_size)	\
 ATOMIC_INLINE type							\
 atomic_fetch_add_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
-	return __atomic_fetch_add(&a->repr, val,			\
+	det_before_shared();						\
+	type res =  __atomic_fetch_add(&a->repr, val,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
+	return res;							\
 }									\
 									\
 ATOMIC_INLINE type							\
 atomic_fetch_sub_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
-	return __atomic_fetch_sub(&a->repr, val,			\
+	det_before_shared();						\
+	type res =  __atomic_fetch_sub(&a->repr, val,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
+	return res;							\
 }									\
 									\
 ATOMIC_INLINE type							\
 atomic_fetch_and_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
-	return __atomic_fetch_and(&a->repr, val,			\
+	det_before_shared();						\
+	type res = __atomic_fetch_and(&a->repr, val,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
+	return res;							\
 }									\
 									\
 ATOMIC_INLINE type							\
 atomic_fetch_or_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
-	return __atomic_fetch_or(&a->repr, val,				\
+	det_before_shared();						\
+	type res =  __atomic_fetch_or(&a->repr, val,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
+	return res;							\
 }									\
 									\
 ATOMIC_INLINE type							\
 atomic_fetch_xor_##short_type(atomic_##short_type##_t *a, type val,	\
     atomic_memory_order_t mo) {						\
-	return __atomic_fetch_xor(&a->repr, val,			\
+	det_before_shared();						\
+	type res =  __atomic_fetch_xor(&a->repr, val,			\
 	    atomic_enum_to_builtin(mo));				\
+	det_after_shared();						\
+	return res;							\
 }
 
 #endif /* JEMALLOC_INTERNAL_ATOMIC_GCC_ATOMIC_H */

--- a/include/jemalloc/internal/deterministic.h
+++ b/include/jemalloc/internal/deterministic.h
@@ -1,0 +1,30 @@
+#ifndef JEMALLOC_DETERMINISTIC_H
+#define JEMALLOC_DETERMINISTIC_H
+
+#if defined(JEMALLOC_DETERMINISTIC_SCHED)
+
+struct waitlist_s;
+typedef struct waitlist_s waitlist_t;
+
+/* Public API for tests */
+JEMALLOC_EXPORT JEMALLOC_NOTHROW void
+det_schedule(unsigned seed, unsigned count,
+             void *(*proc)(void *), void *arg);
+
+/* Instrumentation needed internally in jemalloc lib */
+void det_before_shared();
+void det_after_shared();
+bool det_active();
+void det_wait(waitlist_t** waiters);
+void det_wake(waitlist_t** waiters);
+
+#else /* JEMALLOC_DETERMINISTIC_SCHED */
+
+JEMALLOC_ALWAYS_INLINE void det_before_shared() {}
+JEMALLOC_ALWAYS_INLINE void det_after_shared() {}
+JEMALLOC_ALWAYS_INLINE void det_active() {}
+JEMALLOC_ALWAYS_INLINE void det_wake() {}
+
+#endif /* JEMALLOC_DETERMINISTIC_SCHED */
+
+#endif /* JEMALLOC_DETERMINISTIC_H */

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -347,6 +347,11 @@
 #undef JEMALLOC_BACKGROUND_THREAD
 
 /*
+ * If defined, all the features necessary for deterministic sched are present.
+ */
+#undef JEMALLOC_DETERMINISTIC_SCHED
+
+/*
  * If defined, jemalloc symbols are not exported (doesn't work when
  * JEMALLOC_PREFIX is not defined).
  */

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -197,5 +197,12 @@ static const bool have_background_thread =
     false
 #endif
     ;
+static const bool have_deterministic_sched =
+#ifdef JEMALLOC_DETERMINISTIC_SCHED
+    true
+#else
+    false
+#endif
+    ;
 
 #endif /* JEMALLOC_PREAMBLE_H */

--- a/src/deterministic.c
+++ b/src/deterministic.c
@@ -1,0 +1,323 @@
+#define JEMALLOC_DETERMINISTIC_C_
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#if defined(JEMALLOC_DETERMINISTIC_SCHED)
+
+#include <semaphore.h>
+#include <pthread.h>
+
+/*
+ * This file implements a deterministic scheduler used for testing.
+ * It instruments atomics and mutexes in jemalloc, and tests using it
+ * attempt to fully explore the state-space of various atomic access
+ * and mutex acquisitions.  Race conditions that might otherwise
+ * only show up in hours show up within minutes of testing.
+ *
+ * Usage: (must be built with --enable-debug)
+ * 	det_start(atoi(getenv("SEED")), numthreads, &testthread, NULL);
+ *
+ * Where testthread implements any current testing necessary.  No
+ * det_* specific calls are necessary in testthread (only usage of
+ * jemalloc's mutex and atomics classes).  If you do have any
+ * additional synchronized state, wrap it in det_before_shared() and
+ * det_after_shared(), like a lock.
+ */
+
+#define MAX_THREADS 100
+
+struct waitlist_s {
+	unsigned id;
+	struct waitlist_s* next;
+	sem_t sem;
+};
+
+/* Our sem and id. Must be TLS, because it indexes
+ * in to the other arrays.
+ */
+static __thread sem_t* tls_sem = NULL;
+static __thread unsigned id;
+
+/* Number of assigned threads. */
+static unsigned nextid = 0;
+/* Sems.  Used before pthread_create for new threads, so can't be
+ * TLS.
+ */
+static sem_t sems[MAX_THREADS];
+/* State used for selecting next thread to wake.  Seed is set at init
+ * time.  The state is deterministic based on seed.
+ */
+static uint64_t rand_state;
+
+/* Threads actually waiting for scheduling. Threads are removed from
+ * here if they are waiting on a mutex, or they are waiting to
+ * pthread_join.
+ *
+ * Threads are *not* removed if they are already running - it just
+ * means the same thread is activated twice in a row.
+ */
+static sem_t *sems_active[MAX_THREADS];
+static unsigned active_count;
+
+/* Assertions that no extraneous calls to det_* functions happen after
+ * we have started the schedule
+ */
+static bool started = false;
+
+struct barrier_s {
+	pthread_mutex_t m;
+	pthread_cond_t c;
+	unsigned num;
+	unsigned gen;
+	unsigned count;
+};
+
+typedef struct barrier_s barrier_t;
+
+/* Used for starting joining threads */
+static barrier_t thread_barrier;
+
+static void barrier_init(barrier_t* barrier, unsigned count) {
+	pthread_mutex_init(&barrier->m, NULL);
+	pthread_cond_init(&barrier->c, NULL);
+	barrier->count = count;
+	barrier->gen = 0;
+	barrier->num = 0;
+}
+
+static void barrier_wait(barrier_t* barrier) {
+	pthread_mutex_lock(&barrier->m);
+	unsigned gen = barrier->gen;
+	if (++barrier->num == barrier->count) {
+		barrier->num = 0;
+		barrier->gen++;
+		pthread_cond_broadcast(&barrier->c);
+	} else {
+		while (barrier->num < barrier->count && barrier->gen == gen) {
+			pthread_cond_wait(&barrier->c, &barrier->m);
+		}
+	}
+	pthread_mutex_unlock(&barrier->m);
+}
+
+static void barrier_destroy(barrier_t* barrier) {
+	pthread_mutex_destroy(&barrier->m);
+	pthread_cond_destroy(&barrier->c);
+}
+
+/* Add to main scheduler. */
+static void det_activate(unsigned id) {
+	assert(active_count <= MAX_THREADS);
+	sems_active[active_count++] = &sems[id];
+}
+
+/* Remove from main scheduler. */
+static void det_deactivate(unsigned id) {
+	assert(tls_sem);
+	assert(active_count > 0);
+	unsigned pos;
+	for (pos = 0; pos < active_count; pos++) {
+		if (sems_active[pos] == &sems[id])
+		break;
+	}
+	assert(pos < active_count);
+	memmove(&sems_active[pos], &sems_active[pos + 1],
+                (active_count - pos - 1) * sizeof(sem_t*));
+	active_count--;
+}
+
+bool det_active() {
+	return tls_sem != NULL;
+}
+
+/* Remove from main scheduler, and add to mutex's waitlist.  Wait list
+ * is *not* deterministic, but after waking, threads go through main
+ * scheduler again.  Since jemalloc heavily uses mutexes, this
+ * optimization is important to complete deterministic schedules in a
+ * reasonable time, vs. the more straightforward
+ *
+ * while(true) {
+ * 	det_before_shared()
+ * 	ret = trylock();
+ * 	det_after_shared();
+ *      if (ret) break;
+ * }
+ *
+ * *MUST HOLD* det_before_shared()
+ * calls det_after_shared()
+ */
+void det_wait(waitlist_t** waiters) {
+	if (!tls_sem) {
+		assert(!started);
+		return;
+	}
+	waitlist_t waitnode;
+
+	sem_init(&waitnode.sem, 0, 0);
+	det_deactivate(id);
+	waitnode.id = id;
+	waitnode.next = NULL;
+
+	if (!*waiters) {
+		*waiters = &waitnode;
+	} else {
+		waitlist_t* n = *waiters;
+		while (n->next) {
+			n = n->next;
+		}
+		n->next = &waitnode;
+	}
+
+	det_after_shared();
+	sem_wait(&waitnode.sem);
+	sem_destroy(&waitnode.sem);
+}
+
+/* Wake a thread from mutex's waitlist, and add it back
+ * to the main scheduler.
+ * *MUST HOLD* det_before_shared()
+ */
+void det_wake(waitlist_t** waiters) {
+	assert(!started  || tls_sem);
+	if (!tls_sem) {
+		return;
+	}
+
+	if (!*waiters) {
+		return;
+	}
+
+	waitlist_t *first = *waiters;
+	*waiters = first->next;
+
+	det_activate(first->id);
+	sem_post(&first->sem);
+}
+
+/* Used before shared data access, it's a global *deterministic* lock,
+ * based on initial seed.
+ */
+void det_before_shared() {
+	if (tls_sem) {
+		sem_wait(tls_sem);
+	}
+}
+
+/* Schedule a single thread to run */
+static void det_schedule_one() {
+	assert(active_count != 0);
+	unsigned long r = prng_lg_range_u64(&rand_state, 64);
+	unsigned int pos = r % active_count;
+	sem_post(sems_active[pos]);
+}
+
+/* Used after shared data access.  Wakes another thread
+ * deterministically based on initial seed.  */
+void det_after_shared() {
+	if (!tls_sem) {
+		return;
+	}
+
+	det_schedule_one();
+}
+
+/* Deactivate and cleanup this thread. */
+static void det_thread_cleanup() {
+	det_before_shared();
+	det_deactivate(id);
+	if (active_count > 0) {
+		det_after_shared();
+	}
+
+	sem_destroy(tls_sem);
+	tls_sem = NULL;
+}
+
+struct args {
+	void* arg;
+	unsigned id;
+	void *(*proc)(void*);
+};
+
+/* New thread start routine, set up TLS vars. */
+static void* det_thd_start(void* a) {
+	struct args* args = a;
+
+	id = args->id;
+
+	void* arg = args->arg;
+	void *(*proc)(void*) = args->proc;
+	free(args);
+
+	tls_sem = &sems[id];
+
+	barrier_wait(&thread_barrier);
+	/* starting is set, threads being added to scheduler */
+	barrier_wait(&thread_barrier);
+
+	void* res = proc(arg);
+
+	/* Remove us from scheduler */
+	det_thread_cleanup();
+
+	barrier_wait(&thread_barrier);
+	/* starting is unset, thread shutdown/join not tracked */
+	barrier_wait(&thread_barrier);
+
+	return res;
+}
+
+/* Add a new thread to this schedule. */
+static int det_thd_create(pthread_t *thd, void *(*proc)(void *), void *arg) {
+	struct args* args = malloc(sizeof(struct args));
+	args->arg = arg;
+	args->proc = proc;
+
+	args->id = nextid++;
+	int nid = args->id;
+	if (args->id >= MAX_THREADS) {
+		exit(-1);
+	}
+	sem_init(&sems[nid], 0, 0);
+
+	pthread_create(thd, NULL, det_thd_start, args);
+
+	return nid;
+}
+
+/* Start a schedule. Starts count threads via proc(arg) */
+void det_schedule(unsigned seed, unsigned count,
+                  void *(*proc)(void *), void *arg) {
+	active_count = 0;
+        barrier_init(&thread_barrier, count + 1);
+	memset(sems_active, 0, sizeof(sems_active));
+	nextid = 0;
+	rand_state = seed;
+
+	pthread_t thrs[count];
+
+	for (unsigned i = 0; i < count; i++) {
+		det_thd_create(&thrs[i], proc, arg);
+	}
+
+	barrier_wait(&thread_barrier);
+	for (unsigned i = 0; i < count; i++) {
+		det_activate(i);
+	}
+	started = true;
+	det_schedule_one();
+	barrier_wait(&thread_barrier);
+
+	barrier_wait(&thread_barrier);
+	started = false;
+	barrier_wait(&thread_barrier);
+
+	for(unsigned i = 0; i < count; i++) {
+		void* ret;
+		pthread_join(thrs[i], &ret);
+	}
+
+	barrier_destroy(&thread_barrier);
+}
+
+#endif /* JEMALLOC_DETERMINISTIC_SCHED */

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -179,6 +179,9 @@ malloc_mutex_init(malloc_mutex_t *mutex, const char *name,
 			witness_init(&mutex->witness, name, rank, NULL, NULL);
 		}
 	}
+#if defined(JEMALLOC_DETERMINISTIC_SCHED)
+	mutex->waiters = NULL;
+#endif
 	return false;
 }
 

--- a/test/integration/deterministic.c
+++ b/test/integration/deterministic.c
@@ -1,0 +1,99 @@
+#include "test/jemalloc_test.h"
+#include "jemalloc/internal/deterministic.h"
+
+#if defined(JEMALLOC_DETERMINISTIC_SCHED)
+static unsigned	long	arena_ind;
+
+static bool
+disable_background_thread(void) {
+	bool enabled = false;
+	int ret = mallctl("background_thread", NULL, NULL,
+			  (void *)&enabled, sizeof(bool));
+	if (ret == ENOENT) {
+		return false;
+	}
+	assert_d_eq(ret, 0, "Unexpected mallctl error");
+	return enabled;
+}
+
+static unsigned
+do_arena_create(extent_hooks_t *h) {
+	unsigned arena_ind;
+	size_t sz = sizeof(unsigned);
+	assert_d_eq(mallctl("arenas.create", (void *)&arena_ind, &sz,
+	    (void *)(h != NULL ? &h : NULL), (h != NULL ? sizeof(h) : 0)), 0,
+	    "Unexpected mallctl() failure");
+	return arena_ind;
+}
+
+static void
+do_arena_destroy(unsigned arena_ind) {
+	size_t mib[3];
+	size_t miblen;
+
+	miblen = sizeof(mib)/sizeof(size_t);
+	assert_d_eq(mallctlnametomib("arena.0.destroy", mib, &miblen), 0,
+	    "Unexpected mallctlnametomib() failure");
+	mib[1] = (size_t)arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
+	    "Unexpected mallctlbymib() failure");
+}
+
+static void*
+mythread(void* arg) {
+	for (int i = 0; i < 30; i++) {
+		size_t sz = random() % 32000;
+		size_t sz2 = random() % 32000;
+		if (sz == 0) sz++;
+		size_t align = 0;
+		while (sz > (1UL << (align +1))) {
+			align++;
+		}
+		if (sz2 == 0) sz2++;
+
+		void *p = mallocx(sz, MALLOCX_ARENA(arena_ind) |
+				      MALLOCX_TCACHE_NONE |
+				      MALLOCX_LG_ALIGN(align)
+				 );
+		p = rallocx(p, sz2, MALLOCX_ARENA(arena_ind) |
+				    MALLOCX_TCACHE_NONE
+			   );
+		dallocx(p, MALLOCX_ARENA(arena_ind) |
+			   MALLOCX_TCACHE_NONE);
+	}
+	return NULL;
+}
+#endif /* JEMALLOC_DETERMINISTIC_SCHED */
+
+/* A single run is probably not enough, suggested usage is:
+ * for i in `seq 1 100`; do echo $i; SEED=$i MALLOC_CONF="tcache:false,narenas:1"  ./test/integration/deterministic ; done
+ */
+TEST_BEGIN(test_deterministic) {
+#if defined(JEMALLOC_DETERMINISTIC_SCHED)
+	/* Not yet integrated with background thread */
+	disable_background_thread();
+
+	int numthreads = 40;
+
+	arena_ind = do_arena_create(NULL);
+	char* seed = getenv("SEED");
+	int s = 0;
+	if (seed) {
+		s = atoi(seed);
+	}
+	srandom(s);
+	det_schedule(s, numthreads, &mythread, (void*)arena_ind);
+
+	do_arena_destroy((unsigned int)arena_ind);
+
+#else /* JEMALLOC_DETERMINISTIC_SCHED */
+	test_skip("no deterministic schedule support");
+#endif /* JEMALLOC_DETERMINISTIC_SCHED */
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+		test_deterministic);
+}


### PR DESCRIPTION
This diff adds a deterministic scheduler to jemalloc.  In debug mode,
the deterministic scheduler *may* be activated for testing purposes.
It is extremely useful in testing concurrency changes, to ensure
correctness.  See notes at top of deterministic.c for usage.

Jemalloc's mutex and atomic classes are instrumented to support
determinsitic scheduling.  Currently only gcc_atomic is instrumented,
but others are similar.

In non-debug mode, it should compile out completely, they are inlined empty functions.  In debug mode with the scheduler off, it is an extra branch or two for each mutex or atomic call.