### PR TITLE
Proposal: track the peak memory used by each thread

### DIFF
--- a/include/jemalloc/internal/tsd.h
+++ b/include/jemalloc/internal/tsd.h
@@ -67,6 +67,7 @@ typedef void (*test_callback_t)(int *);
     O(narenas_tdata,		uint32_t,		uint32_t)	\
     O(thread_allocated,		uint64_t,		uint64_t)	\
     O(thread_deallocated,	uint64_t,		uint64_t)	\
+    O(thread_peakused,		int64_t,		int64_t)	\
     O(prof_tdata,		prof_tdata_t *,		prof_tdata_t *)	\
     O(rtree_ctx,		rtree_ctx_t,		rtree_ctx_t)	\
     O(iarena,			arena_t *,		arena_t *)	\

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -66,6 +66,8 @@ CTL_PROTO(thread_allocated)
 CTL_PROTO(thread_allocatedp)
 CTL_PROTO(thread_deallocated)
 CTL_PROTO(thread_deallocatedp)
+CTL_PROTO(thread_peakused)
+CTL_PROTO(thread_peakusedp)
 CTL_PROTO(config_cache_oblivious)
 CTL_PROTO(config_debug)
 CTL_PROTO(config_fill)
@@ -252,6 +254,8 @@ static const ctl_named_node_t	thread_node[] = {
 	{NAME("allocatedp"),	CTL(thread_allocatedp)},
 	{NAME("deallocated"),	CTL(thread_deallocated)},
 	{NAME("deallocatedp"),	CTL(thread_deallocatedp)},
+	{NAME("peakused"),	CTL(thread_peakused)},
+	{NAME("peakusedp"),	CTL(thread_peakusedp)},
 	{NAME("tcache"),	CHILD(named, thread_tcache)},
 	{NAME("prof"),		CHILD(named, thread_prof)}
 };
@@ -1662,6 +1666,10 @@ CTL_TSD_RO_NL_CGEN(config_stats, thread_deallocated, tsd_thread_deallocated_get,
     uint64_t)
 CTL_TSD_RO_NL_CGEN(config_stats, thread_deallocatedp,
     tsd_thread_deallocatedp_get, uint64_t *)
+CTL_TSD_RO_NL_CGEN(config_stats, thread_peakused, tsd_thread_peakused_get,
+    int64_t)
+CTL_TSD_RO_NL_CGEN(config_stats, thread_peakusedp, tsd_thread_peakusedp_get,
+    int64_t *)
 
 static int
 thread_tcache_enabled_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1860,6 +1860,10 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 	if (config_stats) {
 		assert(usize == isalloc(tsd_tsdn(tsd), allocation));
 		*tsd_thread_allocatedp_get(tsd) += usize;
+		int64_t used = *tsd_thread_allocatedp_get(tsd) - *tsd_thread_deallocatedp_get(tsd);
+		if (used > *tsd_thread_peakusedp_get(tsd)) {
+			*tsd_thread_peakusedp_get(tsd) = used;
+		}
 	}
 
 	if (sopts->slow) {
@@ -2254,6 +2258,10 @@ je_realloc(void *ptr, size_t size) {
 		tsd = tsdn_tsd(tsdn);
 		*tsd_thread_allocatedp_get(tsd) += usize;
 		*tsd_thread_deallocatedp_get(tsd) += old_usize;
+		int64_t used = *tsd_thread_allocatedp_get(tsd) - *tsd_thread_deallocatedp_get(tsd);
+		if (used > *tsd_thread_peakusedp_get(tsd)) {
+			*tsd_thread_peakusedp_get(tsd) = used;
+		}
 	}
 	UTRACE(ptr, size, ret);
 	check_entry_exit_locking(tsdn);
@@ -2604,6 +2612,10 @@ je_rallocx(void *ptr, size_t size, int flags) {
 	if (config_stats) {
 		*tsd_thread_allocatedp_get(tsd) += usize;
 		*tsd_thread_deallocatedp_get(tsd) += old_usize;
+		int64_t used = *tsd_thread_allocatedp_get(tsd) - *tsd_thread_deallocatedp_get(tsd);
+		if (used > *tsd_thread_peakusedp_get(tsd)) {
+			*tsd_thread_peakusedp_get(tsd) = used;
+		}
 	}
 	UTRACE(ptr, size, p);
 	check_entry_exit_locking(tsd_tsdn(tsd));
@@ -2746,6 +2758,10 @@ je_xallocx(void *ptr, size_t size, size_t extra, int flags) {
 	if (config_stats) {
 		*tsd_thread_allocatedp_get(tsd) += usize;
 		*tsd_thread_deallocatedp_get(tsd) += old_usize;
+		int64_t used = *tsd_thread_allocatedp_get(tsd) - *tsd_thread_deallocatedp_get(tsd);
+		if (used > *tsd_thread_peakusedp_get(tsd)) {
+			*tsd_thread_peakusedp_get(tsd) = used;
+		}
 	}
 label_not_resized:
 	UTRACE(ptr, size, ptr);


### PR DESCRIPTION
In the context of profiling a modular application, I am interested in the peak memory used by each thread, within each module. Here "module" could be a function call, a TBB task, _etc._ that is going to run within a given thread.

Something like
  - at the begin of each module, check the memory usage and reset the peak value;
  - while the module is running, track each memory allocation and deallocation and update the peak memory usage accordingly;
  - at the end of the module, read the peak memory usage.

`jemalloc` can already track each allocation and deallocation; if we define the "memory usage" as "allocated memory - deallocated memory" (and let the client code take care of the offset) a possible solution is to add one more field to the `tsd` and track the peak "allocated - deallocated memory".

Note that an alternative approach would be store both the current and peak usage in the `tsd`, relieving the user form the need to compute the offset. However the current usage would need to be updated for all allocations and deallocations, while the peak usage can be checked only for the allocations, so it might be cheaper.

This PR is a working implementation of this idea.
The usage could be, for example:
```c++
{
  thread_local bool initialized = false;
  thread_local uint64_t * thread_allocated_p   = nullptr;
  thread_local uint64_t * thread_deallocated_p = nullptr;
  thread_local int64_t *  thread_peak_used_p   = nullptr;
  if (not initialized) {
    size_t ptr_s = sizeof(uint64_t *);
    mallctl("thread.allocatedp",   & thread_allocated_p,   & ptr_s, nullptr, 0);
    mallctl("thread.deallocatedp", & thread_deallocated_p, & ptr_s, nullptr, 0);
    mallctl("thread.peakusedp",    & thread_peak_used_p,   & ptr_s, nullptr, 0);
    initialized = true;
  }
  // reset the peak memory use before running the task and read the offset
  * thread_peak_used_p = 0;
  int64_t offset = * thread_allocated_p - * thread_deallocated_p;

  // here goes the task to be profiled
  // ...
  
  // read the peak memory use after running the task
  std::cout << "peak memory usage: " << thread_peak_used_p - offset << std::endl;
```

Before working on the documentation (both in `tsd.c` and in the man pages), test case, etc. I would like to ask for comments and feedback, whether this would be acceptable, if the implementation is reasonable, etc.
