### PR TITLE
Avoid a printf format specifier warning.

### DIFF
--- a/include/jemalloc/internal/emitter.h
+++ b/include/jemalloc/internal/emitter.h
@@ -247,7 +247,7 @@ emitter_begin(emitter_t *emitter) {
 		emitter_nest_inc(emitter);
 	} else {
 		// tabular init
-		emitter_printf(emitter, "");
+		emitter_printf(emitter, "%s", "");
 	}
 }
 


### PR DESCRIPTION
This dodges a warning emitted by the FreeBSD system gcc when compiling
libc for architectures which don't use clang as the system compiler.