### PR TITLE
aarch64: Add ILP32 support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -412,7 +412,13 @@ AC_DEFINE_UNQUOTED([CPU_SPINWAIT], [$CPU_SPINWAIT])
 case "${host_cpu}" in
   aarch64)
     AC_MSG_CHECKING([number of significant virtual address bits])
-    LG_VADDR=48
+    if test "x${ac_cv_sizeof_void_p}" = "x4" ; then
+      #aarch64 ILP32
+      LG_VADDR=32
+    else
+      #aarch64 LP64
+      LG_VADDR=48
+    fi
     AC_MSG_RESULT([$LG_VADDR])
     ;;
   x86_64)


### PR DESCRIPTION
Instead of setting a fix value of 48 allowed VA bits,
we distiguish between LP64 and ILP32.

Testsuite result with LP64:
Test suite summary: pass: 13/13, skip: 0/13, fail: 0/13

Testsuit result with ILP32:
Test suite summary: pass: 13/13, skip: 0/13, fail: 0/13

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>
Reviewed-by: Philipp Tomsich <philipp.tomsich@theobroma-systems.com>