### PR TITLE
arm64: Correct LG_VADDR to 56 bits.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -412,12 +412,12 @@ AC_DEFINE_UNQUOTED([CPU_SPINWAIT], [$CPU_SPINWAIT])
 case "${host_cpu}" in
   aarch64)
     AC_MSG_CHECKING([number of significant virtual address bits])
-    if test "x${ac_cv_sizeof_void_p}" = "x4" ; then
+    if test "x${LG_SIZEOF_PTR}" = "x2" ; then
       #aarch64 ILP32
       LG_VADDR=32
     else
-      #aarch64 LP64
-      LG_VADDR=48
+      #aarch64 LP64 allows to use the upper 8 bits for tagging
+      LG_VADDR=56
     fi
     AC_MSG_RESULT([$LG_VADDR])
     ;;


### PR DESCRIPTION
The AArch64 architecture reference manual permits to use
the upper eight bits of an virtual address for address tagging
if the translation table is set up accordingly.
The Linux kernel enables address tagging [1], so it is safe to use
it on Linux-based systems.

That gives us an allowed LG_VADDR value of 56 bits.
The previous value of 48 bits is clearly a violation of the specification.

[1] https://www.kernel.org/doc/Documentation/arm64/tagged-pointers.txt

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>