### PR TITLE
Fix compiler for undefined macro HAVE_CPU_SPINWAIT.

### DIFF
--- a/include/jemalloc/internal/spin.h
+++ b/include/jemalloc/internal/spin.h
@@ -9,7 +9,7 @@ typedef struct {
 
 static inline void
 spin_cpu_spinwait() {
-#  if HAVE_CPU_SPINWAIT
+#  if defined(HAVE_CPU_SPINWAIT) && HAVE_CPU_SPINWAIT == 1
 	CPU_SPINWAIT;
 #  else
 	volatile int x = 0;


### PR DESCRIPTION
GCC 7 complains about the following, when HAVE_CPU_SPINWAIT
is not defined:

src/jemalloc/include/jemalloc/internal/spin.h:12:7:
warning: "HAVE_CPU_SPINWAIT" is not defined, evaluates to 0 [-Wundef]
 #  if HAVE_CPU_SPINWAIT
       ^~~~~~~~~~~~~~~~~

This patch addresses the warning, by checking if the symbol
exists and comparing it with 1.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>