### PR TITLE
Fix strerror_r() wrapper for cross-compilation.

### DIFF
--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -98,7 +98,8 @@ buferror(int err, char *buf, size_t buflen) {
 	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0,
 	    (LPSTR)buf, (DWORD)buflen, NULL);
 	return 0;
-#elif defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE) && defined(_GNU_SOURCE)
+#elif defined(_GNU_SOURCE) && ( defined(__GLIBC__) || \
+	defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE) )
 	char *b = strerror_r(err, buf, buflen);
 	if (b != buf) {
 		strncpy(buf, b, buflen);


### PR DESCRIPTION
Commit f78d4ca3f moved the compile-time check for the strerror_r() return type
into a configure-time check. Since configure-time checks don't work for
cross-compilers, we put the old static check additionally back in as well.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>