### PR TITLE
Build the docs on make install.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,15 +9,8 @@ If building from unpackaged developer sources, the simplest command sequence
 that might work is:
 
     ./autogen.sh
-    make dist
     make
     make install
-
-Note that documentation is not built by the default target because doing so
-would create a dependency on xsltproc in packaged releases, hence the
-requirement to either run 'make dist' or avoid installing docs via the various
-install_* targets documented below.
-
 
 ## Advanced configuration
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -465,7 +465,7 @@ install_doc_man:
 	$(INSTALL) -m 644 $$d $(MANDIR)/man3; \
 done
 
-install_doc: install_doc_html install_doc_man
+install_doc: build_doc install_doc_html install_doc_man
 
 install: install_bin install_include install_lib install_doc
 


### PR DESCRIPTION
Typically users compile with:

  ./configure
  make
  make install

This will fail for the git tree, since `make dist` is needed
to build the docs, which are required for `make install`.
The reason is, that building the library with `make` should not
require xsltproc to be installed. However, calling `make install`
requires the docs to be built. Therefore this patch introduces
a dependency for `build_doc` to `install_doc`.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>