### PR TITLE
Fix an incorrect assertion.

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -261,7 +261,7 @@ pages_decommit(void *addr, size_t size) {
 
 bool
 pages_purge_lazy(void *addr, size_t size) {
-	assert(PAGE_ADDR2BASE(addr) == addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
 	assert(PAGE_CEILING(size) == size);
 
 	if (!pages_can_purge_lazy) {


### PR DESCRIPTION
When configured with --with-lg-page, it's possible for the configured page size to be
greater than the system page size, in which case the page address may only be
aligned with the system page size.