### PR TITLE
Only use dlsym if JEMALLOC_LAZY_LOCK is set.

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -812,7 +812,21 @@ pthread_create_fptr_init(void) {
 	if (pthread_create_fptr != NULL) {
 		return false;
 	}
+
+	/* If JEMALLOC_LAZY_LOCK is defined, we have overwritten
+         * pthread_create with our own function. In this case we have
+         * to use dlsym with RTLD_NEXT to find the real symbol
+         * "pthread_create" in the library.
+	 * If JEMALLOC_LAZY_LOCK is not defined, pthread_create
+         * is not overwritten and we better use the symbol directly
+         * to allow for static linking.
+	 */
+#ifdef JEMALLOC_LAZY_LOCK
 	pthread_create_fptr = dlsym(RTLD_NEXT, "pthread_create");
+#else
+	pthread_create_fptr = pthread_create;
+#endif
+
 	if (pthread_create_fptr == NULL) {
 		can_enable_background_thread = false;
 		if (config_lazy_lock || opt_background_thread) {


### PR DESCRIPTION
This avoids problems when using jemalloc in a completely static binary (for example with libmusl on Alpine), at least when JEMALLOC_LAZY_LOCK is not set.
The approach here works, since there is only a local `pthread_create` function if `JEMALLOC_LAZY_LOCK` is defined. If not, one can easily avoid `dlsym` by using the global symbol `pthread_create` directly.