### PR TITLE
Avoid using atomic "acquire" with reader doing spin and waiting for writer to finish

### DIFF
--- a/include/jemalloc/internal/seq.h
+++ b/include/jemalloc/internal/seq.h
@@ -29,17 +29,19 @@ seq_store_##short_type(seq_##short_type##_t *dst, type *src) {		\
 	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
 		atomic_store_zu(&dst->data[i], buf[i], ATOMIC_RELAXED);	\
 	}								\
-	atomic_store_zu(&dst->seq, old_seq + 2, ATOMIC_RELEASE);	\
+	atomic_fence(ATOMIC_RELEASE);					\
+	atomic_store_zu(&dst->seq, old_seq + 2, ATOMIC_RELAXED);	\
 }									\
 									\
 /* Returns whether or not the read was consistent. */			\
 static inline bool							\
 seq_try_load_##short_type(type *dst, seq_##short_type##_t *src) {	\
 	size_t buf[sizeof(src->data) / sizeof(size_t)];			\
-	size_t seq1 = atomic_load_zu(&src->seq, ATOMIC_ACQUIRE);	\
+	size_t seq1 = atomic_load_zu(&src->seq, ATOMIC_RELAXED);	\
 	if (seq1 % 2 != 0) {						\
 		return false;						\
 	}								\
+	atomic_fence(ATOMIC_ACQUIRE);					\
 	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
 		buf[i] = atomic_load_zu(&src->data[i], ATOMIC_RELAXED);	\
 	}								\


### PR DESCRIPTION
seqlock "try" from reader side could fail if writer interrupts reader by changing seq number.  In that case, reader could retry by "spinning" and waiting for writer to finish.  During this spinning, reader thread is continuously doing "acquire" on seq number load which may not be a good idea.  We could avoid that acquire during spinning if we put "acquire" fence after seq "Odd" number check and load seq number first time using relaxed memory order. 

Since atomic_thread_fence() with same memory order is stronger fence than corresponding load/store with same memory order,  It is a trade off i.e. saving large number of "acquire" fence when writer interrupts readers and reader spins waiting to acquire lock vs using stronger fence when reader is not interrupted by writer.