### PR TITLE
SC: Shrink global data consumption.

### DIFF
--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -85,7 +85,7 @@ size_t arena_extent_sn_next(arena_t *arena);
 arena_t *arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
 bool arena_init_huge(void);
 arena_t *arena_choose_huge(tsd_t *tsd);
-void arena_boot(void);
+void arena_boot(sc_t scs[SC_NSIZES]);
 void arena_prefork0(tsdn_t *tsdn, arena_t *arena);
 void arena_prefork1(tsdn_t *tsdn, arena_t *arena);
 void arena_prefork2(tsdn_t *tsdn, arena_t *arena);

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -79,8 +79,9 @@ struct bin_s {
 	bin_stats_t	stats;
 };
 
-void bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]);
-void bin_boot();
+void bin_infos_init(sc_data_t *sc_data, sc_t scs[SC_NSIZES],
+    bin_info_t bin_infos[SC_NBINS]);
+void bin_boot(sc_data_t *sc_data, sc_t scs[SC_NSIZES]);
 
 /* Initializes a bin to empty.  Returns true on error. */
 bool bin_init(bin_t *bin);

--- a/include/jemalloc/internal/sc.h
+++ b/include/jemalloc/internal/sc.h
@@ -311,17 +311,23 @@ struct sc_data_s {
 	/* True if the sc_data_t has been initialized (for debugging only). */
 	bool initialized;
 
-	sc_t sc[SC_NSIZES];
+	/*
+	 * We omit the actual size class data itself, which is used only at
+	 * initialization.  This can reduce consumption of global data (and, in
+	 * particular, makes it more likely that the bits of global data touched
+	 * on the hot path all live on the same page.
+	 */
+	/* sc_t sc[SC_NSIZES]; */
 };
 
 extern sc_data_t sc_data_global;
-void sc_data_init(sc_data_t *data);
+void sc_data_init(sc_data_t *data, sc_t scs[SC_NSIZES]);
 /*
  * Updates slab sizes in [begin, end] to be pgs pages in length, if possible.
  * Otherwise, does its best to accomodate the request.
  */
-void sc_data_update_slab_size(sc_data_t *data, size_t begin, size_t end,
-    int pgs);
-void sc_boot();
+void sc_data_update_slab_size(sc_data_t *data, sc_t scs[SC_NSIZES],
+    size_t begin, size_t end, int pgs);
+void sc_boot(sc_t scs[SC_NSIZES]);
 
 #endif /* JEMALLOC_INTERNAL_SC_H */

--- a/include/jemalloc/internal/sz.h
+++ b/include/jemalloc/internal/sz.h
@@ -47,7 +47,7 @@ static const size_t sz_large_pad =
 #endif
     ;
 
-extern void sz_boot(const sc_data_t *sc_data);
+extern void sz_boot(const sc_data_t *sc_data, const sc_t scs[SC_NSIZES]);
 
 JEMALLOC_ALWAYS_INLINE pszind_t
 sz_psz2ind(size_t psz) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -2001,11 +2001,11 @@ arena_init_huge(void) {
 }
 
 void
-arena_boot(void) {
+arena_boot(sc_t scs[SC_NSIZES]) {
 	arena_dirty_decay_ms_default_set(opt_dirty_decay_ms);
 	arena_muzzy_decay_ms_default_set(opt_muzzy_decay_ms);
 	for (unsigned i = 0; i < SC_NBINS; i++) {
-		sc_t *sc = &sc_data_global.sc[i];
+		sc_t *sc = &scs[i];
 		div_init(&arena_binind_div_info[i],
 		    (1U << sc->lg_base) + (sc->ndelta << sc->lg_delta));
 	}

--- a/src/bin.c
+++ b/src/bin.c
@@ -9,10 +9,11 @@
 bin_info_t bin_infos[SC_NBINS];
 
 void
-bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]) {
+bin_infos_init(sc_data_t *sc_data, sc_t scs[SC_NSIZES],
+    bin_info_t bin_infos[SC_NBINS]) {
 	for (unsigned i = 0; i < SC_NBINS; i++) {
 		bin_info_t *bin_info = &bin_infos[i];
-		sc_t *sc = &sc_data->sc[i];
+		sc_t *sc = &scs[i];
 		bin_info->reg_size = ((size_t)1U << sc->lg_base)
 		    + ((size_t)sc->ndelta << sc->lg_delta);
 		bin_info->slab_size = (sc->pgs << LG_PAGE);
@@ -25,9 +26,9 @@ bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]) {
 }
 
 void
-bin_boot(sc_data_t *sc_data) {
+bin_boot(sc_data_t *sc_data, sc_t scs[SC_NSIZES]) {
 	assert(sc_data->initialized);
-	bin_infos_init(sc_data, bin_infos);
+	bin_infos_init(sc_data, scs, bin_infos);
 }
 
 bool

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -915,7 +915,7 @@ malloc_slow_flag_init(void) {
 }
 
 static void
-malloc_conf_init(void) {
+malloc_conf_init(sc_t scs[SC_NSIZES]) {
 	unsigned i;
 	char buf[PATH_MAX + 1];
 	const char *opts, *k, *v;
@@ -1249,8 +1249,9 @@ malloc_conf_init(void) {
 					    &pgs);
 					if (!err) {
 						sc_data_update_slab_size(
-						    &sc_data_global, slab_start,
-						    slab_end, (int)pgs);
+						    &sc_data_global, scs,
+						    slab_start, slab_end,
+						    (int)pgs);
 					} else {
 						malloc_conf_error(
 						    "Invalid settings for "
@@ -1370,10 +1371,15 @@ malloc_init_hard_a0_locked() {
 	 * before sz_boot and bin_boot, which assume that the values they read
 	 * out of sc_data_global are final.
 	 */
-	sc_boot();
-	malloc_conf_init();
-	sz_boot(&sc_data_global);
-	bin_boot(&sc_data_global);
+	JEMALLOC_DIAGNOSTIC_PUSH
+	    JEMALLOC_DIAGNOSTIC_IGNORE_MISSING_STRUCT_FIELD_INITIALIZERS
+	sc_t scs[SC_NSIZES] = {{0}};
+	JEMALLOC_DIAGNOSTIC_POP
+
+	sc_boot(scs);
+	malloc_conf_init(scs);
+	sz_boot(&sc_data_global, scs);
+	bin_boot(&sc_data_global, scs);
 
 	if (config_prof) {
 		prof_boot0();
@@ -1402,7 +1408,7 @@ malloc_init_hard_a0_locked() {
 	if (config_prof) {
 		prof_boot1();
 	}
-	arena_boot();
+	arena_boot(scs);
 	if (tcache_boot(TSDN_NULL)) {
 		return true;
 	}

--- a/src/sz.c
+++ b/src/sz.c
@@ -5,10 +5,10 @@ JEMALLOC_ALIGNED(CACHELINE)
 size_t sz_pind2sz_tab[SC_NPSIZES_MAX+1];
 
 static void
-sz_boot_pind2sz_tab(const sc_data_t *sc_data) {
+sz_boot_pind2sz_tab(const sc_data_t *sc_data, const sc_t scs[SC_NSIZES]) {
 	int pind = 0;
 	for (unsigned i = 0; i < SC_NSIZES; i++) {
-		const sc_t *sc = &sc_data->sc[i];
+		const sc_t *sc = &scs[i];
 		if (sc->psz) {
 			sz_pind2sz_tab[pind] = (ZU(1) << sc->lg_base)
 			    + (ZU(sc->ndelta) << sc->lg_delta);
@@ -22,9 +22,9 @@ JEMALLOC_ALIGNED(CACHELINE)
 size_t sz_index2size_tab[SC_NSIZES];
 
 static void
-sz_boot_index2size_tab(const sc_data_t *sc_data) {
+sz_boot_index2size_tab(const sc_t scs[SC_NSIZES]) {
 	for (unsigned i = 0; i < SC_NSIZES; i++) {
-		const sc_t *sc = &sc_data->sc[i];
+		const sc_t *sc = &scs[i];
 		sz_index2size_tab[i] = (ZU(1) << sc->lg_base)
 		    + (ZU(sc->ndelta) << (sc->lg_delta));
 	}
@@ -38,12 +38,12 @@ JEMALLOC_ALIGNED(CACHELINE)
 uint8_t sz_size2index_tab[SC_LOOKUP_MAXCLASS >> SC_LG_TINY_MIN];
 
 static void
-sz_boot_size2index_tab(const sc_data_t *sc_data) {
+sz_boot_size2index_tab(const sc_t scs[SC_NSIZES]) {
 	size_t dst_max = (SC_LOOKUP_MAXCLASS >> SC_LG_TINY_MIN);
 	size_t dst_ind = 0;
 	for (unsigned sc_ind = 0; sc_ind < SC_NSIZES && dst_ind < dst_max;
 	    sc_ind++) {
-		const sc_t *sc = &sc_data->sc[sc_ind];
+		const sc_t *sc = &scs[sc_ind];
 		size_t sz = (ZU(1) << sc->lg_base)
 		    + (ZU(sc->ndelta) << sc->lg_delta);
 		size_t max_ind = ((sz - 1) >> SC_LG_TINY_MIN);
@@ -54,8 +54,8 @@ sz_boot_size2index_tab(const sc_data_t *sc_data) {
 }
 
 void
-sz_boot(const sc_data_t *sc_data) {
-	sz_boot_pind2sz_tab(sc_data);
-	sz_boot_index2size_tab(sc_data);
-	sz_boot_size2index_tab(sc_data);
+sz_boot(const sc_data_t *sc_data, const sc_t scs[SC_NSIZES]) {
+	sz_boot_pind2sz_tab(sc_data, scs);
+	sz_boot_index2size_tab(scs);
+	sz_boot_size2index_tab(scs);
 }

--- a/test/unit/sc.c
+++ b/test/unit/sc.c
@@ -2,18 +2,20 @@
 
 TEST_BEGIN(test_update_slab_size) {
 	sc_data_t data;
+	sc_t scs[SC_NSIZES];
 	memset(&data, 0, sizeof(data));
-	sc_data_init(&data);
-	sc_t *tiny = &data.sc[0];
+	sc_data_init(&data, scs);
+	sc_t *tiny = &scs[0];
 	size_t tiny_size = (ZU(1) << tiny->lg_base)
 	    + (ZU(tiny->ndelta) << tiny->lg_delta);
 	size_t pgs_too_big = (tiny_size * BITMAP_MAXBITS + PAGE - 1) / PAGE + 1;
-	sc_data_update_slab_size(&data, tiny_size, tiny_size, (int)pgs_too_big);
+	sc_data_update_slab_size(&data, scs, tiny_size, tiny_size,
+	    (int)pgs_too_big);
 	assert_zu_lt((size_t)tiny->pgs, pgs_too_big, "Allowed excessive pages");
 
-	sc_data_update_slab_size(&data, 1, 10 * PAGE, 1);
+	sc_data_update_slab_size(&data, scs, 1, 10 * PAGE, 1);
 	for (int i = 0; i < data.nbins; i++) {
-		sc_t *sc = &data.sc[i];
+		sc_t *sc = &scs[i];
 		size_t reg_size = (ZU(1) << sc->lg_base)
 		    + (ZU(sc->ndelta) << sc->lg_delta);
 		if (reg_size <= PAGE) {


### PR DESCRIPTION
The amount of global data we consume can force some hot-path variables onto
separate pages, slightly increasing TLB miss rate.  Since we don't need the sc_t
data after each module has done its own initialization, we move it to the stack,
during configure-time.