### PR TITLE
AIX port

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -73,6 +73,7 @@ AWK := @AWK@
 CC_MM = @CC_MM@
 LM := @LM@
 INSTALL = @INSTALL@
+AIX_WRAPPER = @AIX_WRAPPER@
 
 ifeq (macho, $(ABI))
 TEST_LIBRARY_PATH := DYLD_FALLBACK_LIBRARY_PATH="$(objroot)lib"
@@ -132,6 +133,9 @@ ifdef PIC_CFLAGS
 STATIC_LIBS += $(objroot)lib/$(LIBJEMALLOC)_pic.$(A)
 else
 STATIC_LIBS += $(objroot)lib/$(LIBJEMALLOC)_s.$(A)
+endif
+ifdef AIX_WRAPPER
+WRAPPER_LIBS = $(objroot)lib/$(LIBJEMALLOC)_wrapper.$(A)
 endif
 DSOS := $(objroot)lib/$(LIBJEMALLOC).$(SOREV)
 ifneq ($(SOREV),$(SO))
@@ -395,6 +399,12 @@ $(objroot)lib/$(LIBJEMALLOC).$(SOREV) : $(if $(PIC_CFLAGS),$(C_PIC_OBJS),$(C_OBJ
 	@mkdir -p $(@D)
 	$(CC) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
 
+$(objroot)lib/$(LIBJEMALLOC)_wrapper.$(A) : $(objroot)src/aix_wrapper.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) $(PIC_CFLAGS) -c $(CPPFLAGS) -o $(objroot)src/aix_wrapper.o $<
+	ld -b64 -L$(objroot)lib -m -o $(objroot)lib/mem64.o $(objroot)src/aix_wrapper.o -bnoentry -bE:src/aix_wrapper.exp -bM:SRE -brtl -ljemalloc -lpthreads -lc
+	ar -X32_64 -r $@ $(objroot)lib/mem64.o
+
 $(objroot)lib/$(LIBJEMALLOC)_pic.$(A) : $(C_PIC_OBJS) $(CPP_PIC_OBJS)
 $(objroot)lib/$(LIBJEMALLOC).$(A) : $(C_OBJS) $(CPP_OBJS)
 $(objroot)lib/$(LIBJEMALLOC)_s.$(A) : $(C_OBJS) $(CPP_OBJS)
@@ -421,7 +431,8 @@ $(objroot)test/stress/%$(EXE): $(objroot)test/stress/%.$(O) $(C_JET_OBJS) $(C_TE
 
 build_lib_shared: $(DSOS)
 build_lib_static: $(STATIC_LIBS)
-build_lib: build_lib_shared build_lib_static
+build_wrappers: $(WRAPPER_LIBS)
+build_lib: build_lib_shared build_lib_static build_wrappers
 
 install_bin:
 	$(INSTALL) -d $(BINDIR)
@@ -458,7 +469,14 @@ install_lib_pc: $(PC)
 	$(INSTALL) -m 644 $$l $(LIBDIR)/pkgconfig; \
 done
 
-install_lib: install_lib_shared install_lib_static install_lib_pc
+install_lib_wrappers: $(WRAPPER_LIBS)
+	$(INSTALL) -d $(LIBDIR)
+	@for l in $(WRAPPER_LIBS); do \
+	echo "$(INSTALL) -m 755 $$l $(LIBDIR)"; \
+	$(INSTALL) -m 755 $$l $(LIBDIR); \
+done
+
+install_lib: install_lib_shared install_lib_static install_lib_pc install_lib_wrappers
 
 install_doc_html:
 	$(INSTALL) -d $(DATADIR)/doc/jemalloc$(install_suffix)

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,6 +101,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/extent.c \
 	$(srcroot)src/extent_dss.c \
 	$(srcroot)src/extent_mmap.c \
+	$(srcroot)src/ffs.c \
 	$(srcroot)src/hash.c \
 	$(srcroot)src/hook.c \
 	$(srcroot)src/large.c \

--- a/configure.ac
+++ b/configure.ac
@@ -268,6 +268,7 @@ elif test "x$CC" = "xxlc_r"; then
   JE_CFLAGS_ADD([-q64])
   JE_CFLAGS_ADD([-qmaxmem=-1])
   JE_CFLAGS_ADD([-qsuppress=1506-1300:1506-1385:1506-943])
+  JE_CFLAGS_ADD([-g])
 fi
 if test "x$je_cv_cray" = "xyes" ; then
   dnl cray compiler 8.4 has an inlining bug
@@ -567,11 +568,6 @@ maps_coalesce="1"
 DUMP_SYMS="${NM} -a"
 SYM_PREFIX=""
 case "${host}" in
-  *-ibm-aix*)
-	DUMP_SYMS="${NM} -BC -X64"
-	ARFLAGS="-X64 $ARFLAGS"
-	RPATH=""
-	;;
   *-*-darwin* | *-*-ios*)
 	abi="macho"
 	RPATH=""
@@ -664,6 +660,13 @@ case "${host}" in
 	  LD_PRELOAD_VAR="LDR_PRELOAD"
 	fi
 	abi="xcoff"
+	RPATH=""
+	DUMP_SYMS="${NM} -BC -X64"
+	ARFLAGS="-X64 $ARFLAGS"
+	AIX_WRAPPER="yes"
+	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H])
+	AC_DEFINE([JEMALLOC_INIT_BEFORE_THREADS], [1])
+	AC_DEFINE([JEMALLOC_AIX_WRAPPERS])
 	;;
   *-*-mingw* | *-*-cygwin*)
 	abi="pecoff"
@@ -742,6 +745,7 @@ AC_SUBST([ARFLAGS])
 AC_SUBST([AROUT])
 AC_SUBST([DUMP_SYMS])
 AC_SUBST([CC_MM])
+AC_SUBST([AIX_WRAPPER])
 
 dnl Determine whether libm must be linked to use e.g. log(3).
 AC_SEARCH_LIBS([log], [m], , [AC_MSG_ERROR([Missing math functions])])
@@ -855,6 +859,11 @@ else
   JEMALLOC_PREFIX="je_"
 fi]
 )
+
+dln Always prefix public symbols on AIX
+if test "x$PLATFORM" = "xAIX" -a "x$JEMALLOC_PREFIX" = "x"; then
+  JEMALLOC_PREFIX="je_"
+fi
 if test "x$JEMALLOC_PREFIX" = "x" ; then
   AC_DEFINE([JEMALLOC_IS_MALLOC])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -1366,7 +1366,7 @@ else
     AC_DEFINE([JEMALLOC_INTERNAL_FFSLL], [__ffsll])
     AC_DEFINE([JEMALLOC_INTERNAL_FFSL], [__ffsl])
     AC_DEFINE([JEMALLOC_INTERNAL_FFS], [__ffs])
-    AC_DEFINE([JEMALLOC_BUNDLED_FFS], [1])
+    AC_DEFINE([JEMALLOC_BUNDLED_FFS], [ ])
   fi
 fi
 
@@ -1395,7 +1395,7 @@ if test "x$LG_PAGE" = "xdetect"; then
 #endif
 #include <stdio.h>
 
-#if JEMALLOC_BUNDLED_FFS
+#ifdef JEMALLOC_BUNDLED_FFS
 static int __ffsl(long mask)
 {
 	int bit;

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,14 @@ fi
 )
 AC_SUBST([XSLROOT])
 
+dnl Platform-specific compliler search tweaking
+PLATFORM=`uname -s`
+if test "x$PLATFORM" = "xAIX"; then
+        AC_CHECK_PROG([CC], [xlc_r], [xlc_r])
+        AC_CHECK_PROG([CCC], [xlC_r], [xlC_r])
+	LDFLAGS="$LDFLAGS -q64 -Wl,-brtl"
+fi
+
 dnl If CFLAGS isn't defined, set CFLAGS to something reasonable.  Otherwise,
 dnl just prevent autoconf from molesting CFLAGS.
 CFLAGS=$CFLAGS
@@ -256,6 +264,10 @@ elif test "x$je_cv_msvc" = "xyes" ; then
   JE_CFLAGS_ADD([-W3])
   JE_CFLAGS_ADD([-FS])
   JE_APPEND_VS(CPPFLAGS, -I${srcdir}/include/msvc_compat)
+elif test "x$CC" = "xxlc_r"; then
+  JE_CFLAGS_ADD([-q64])
+  JE_CFLAGS_ADD([-qmaxmem=-1])
+  JE_CFLAGS_ADD([-qsuppress=1506-1300:1506-1385:1506-943])
 fi
 if test "x$je_cv_cray" = "xyes" ; then
   dnl cray compiler 8.4 has an inlining bug
@@ -526,6 +538,11 @@ if test "x${je_cv_cray}" = "xyes" ; then
   CC_MM=
 fi
 
+if test "x$CC" = "xxlc_r"; then
+  CC_MM=
+  DSO_LDFLAGS='-G -q64'
+fi
+
 AN_MAKEVAR([AR], [AC_PROG_AR])
 AN_PROGRAM([ar], [AC_PROG_AR])
 AC_DEFUN([AC_PROG_AR], [AC_CHECK_TOOL(AR, ar, :)])
@@ -550,6 +567,11 @@ maps_coalesce="1"
 DUMP_SYMS="${NM} -a"
 SYM_PREFIX=""
 case "${host}" in
+  *-ibm-aix*)
+	DUMP_SYMS="${NM} -BC -X64"
+	ARFLAGS="-X64 $ARFLAGS"
+	RPATH=""
+	;;
   *-*-darwin* | *-*-ios*)
 	abi="macho"
 	RPATH=""
@@ -1020,6 +1042,9 @@ if test "x$enable_debug" = "x0" ; then
   elif test "x$je_cv_msvc" = "xyes" ; then
     JE_CFLAGS_ADD([-O2])
     JE_CXXFLAGS_ADD([-O2])
+  elif test "x$PLATFORM" = "xAIX" ; then
+    JE_CFLAGS_ADD([-O2])
+    JE_CXXFLAGS_ADD([-O2])
   else
     JE_CFLAGS_ADD([-O])
     JE_CXXFLAGS_ADD([-O])
@@ -1294,7 +1319,7 @@ else
 fi
 
 dnl ============================================================================
-dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.
+dnl Check for  __builtin_ffsl(), then ffsl(3), and use built-in implementation if none are found
 dnl One of those two functions should (theoretically) exist on all platforms
 dnl that jemalloc currently has a chance of functioning on without modification.
 dnl We additionally assume ffs[ll]() or __builtin_ffs[ll]() are defined if
@@ -1329,7 +1354,10 @@ else
     AC_DEFINE([JEMALLOC_INTERNAL_FFSL], [ffsl])
     AC_DEFINE([JEMALLOC_INTERNAL_FFS], [ffs])
   else
-    AC_MSG_ERROR([Cannot build without ffsl(3) or __builtin_ffsl()])
+    AC_DEFINE([JEMALLOC_INTERNAL_FFSLL], [__ffsll])
+    AC_DEFINE([JEMALLOC_INTERNAL_FFSL], [__ffsl])
+    AC_DEFINE([JEMALLOC_INTERNAL_FFS], [__ffs])
+    AC_DEFINE([JEMALLOC_BUNDLED_FFS], [1])
   fi
 fi
 
@@ -1357,6 +1385,19 @@ if test "x$LG_PAGE" = "xdetect"; then
 #include <unistd.h>
 #endif
 #include <stdio.h>
+
+#if JEMALLOC_BUNDLED_FFS
+static int __ffsl(long mask)
+{
+	int bit;
+
+	if (mask == 0)
+		return (0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned long)mask >> 1;
+	return (bit);
+}
+#endif
 ]],
 [[
     int result;

--- a/include/jemalloc/internal/bit_util.h
+++ b/include/jemalloc/internal/bit_util.h
@@ -11,7 +11,6 @@
 #  error JEMALLOC_INTERNAL_FFS{,L,LL} should have been defined by configure
 #endif
 
-
 BIT_UTIL_INLINE unsigned
 ffs_llu(unsigned long long bitmap) {
 	return JEMALLOC_INTERNAL_FFSLL(bitmap);

--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -18,7 +18,7 @@
 #else
 #  include <sys/param.h>
 #  include <sys/mman.h>
-#  if !defined(__pnacl__) && !defined(__native_client__)
+#  if !defined(__pnacl__) && !defined(__native_client__) && defined(JEMALLOC_USE_SYSCALL)
 #    include <sys/syscall.h>
 #    if !defined(SYS_write) && defined(__NR_write)
 #      define SYS_write __NR_write

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -363,4 +363,7 @@
  */
 #undef JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE
 
+/* If defined, jemalloc uses bundled ffs* functions. */
+#undef JEMALLOC_BUNDLED_FFS
+
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -135,6 +135,11 @@
 #undef JEMALLOC_THREADED_INIT
 
 /*
+ * Defined if first allocation is known to be before thread library initialization
+ */
+#undef JEMALLOC_INIT_BEFORE_THREADS
+
+/*
  * Defined if the pthreads implementation defines
  * _pthread_mutex_init_calloc_cb(), in which case the function is used in order
  * to avoid recursive allocation during mutex initialization.
@@ -365,5 +370,8 @@
 
 /* If defined, jemalloc uses bundled ffs* functions. */
 #undef JEMALLOC_BUNDLED_FFS
+
+/* If defined, jemalloc defines AIX memory allocation wrappers. */
+#undef JEMALLOC_AIX_WRAPPERS
 
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/include/jemalloc/internal/mutex.h
+++ b/include/jemalloc/internal/mutex.h
@@ -88,6 +88,10 @@ struct malloc_mutex_s {
 #    define MALLOC_MUTEX_LOCK(m)    OSSpinLockLock(&(m)->lock)
 #    define MALLOC_MUTEX_UNLOCK(m)  OSSpinLockUnlock(&(m)->lock)
 #    define MALLOC_MUTEX_TRYLOCK(m) (!OSSpinLockTry(&(m)->lock))
+#elif (defined(JEMALLOC_INIT_BEFORE_THREADS))
+#    define MALLOC_MUTEX_LOCK(m)    do { if (__n_pthreads > 0) pthread_mutex_lock(&(m)->lock); } while(0)
+#    define MALLOC_MUTEX_UNLOCK(m)  do { if (__n_pthreads > 0) pthread_mutex_unlock(&(m)->lock); } while(0)
+#    define MALLOC_MUTEX_TRYLOCK(m) ((__n_pthreads > 0) ? (pthread_mutex_trylock(&(m)->lock) != 0) : false)
 #else
 #    define MALLOC_MUTEX_LOCK(m)    pthread_mutex_lock(&(m)->lock)
 #    define MALLOC_MUTEX_UNLOCK(m)  pthread_mutex_unlock(&(m)->lock)

--- a/include/jemalloc/internal/private_symbols.sh
+++ b/include/jemalloc/internal/private_symbols.sh
@@ -14,13 +14,12 @@ cat <<EOF
 
 BEGIN {
   sym_prefix = "${sym_prefix}"
-  split("\\
 EOF
 
+printf 'split("'
+
 for public_sym in "$@" ; do
-  cat <<EOF
-        ${sym_prefix}${public_sym} \\
-EOF
+  printf "${sym_prefix}${public_sym} "
 done
 
 cat <<"EOF"

--- a/include/jemalloc/jemalloc.sh
+++ b/include/jemalloc/jemalloc.sh
@@ -5,6 +5,30 @@ objroot=$1
 cat <<EOF
 #ifndef JEMALLOC_H_
 #define JEMALLOC_H_
+
+#ifdef _AIX
+
+/* Force symbol mangling on AIX */
+#define JEMALLOC_MANGLE	1
+
+/*
+ * Define global variable _malloc_user_defined_name so AIX runtime
+ * linker load lubjemalloc_wrapper archive as custom memory subsystem
+ */
+#ifdef __cplusplus
+#define JEMALLOC_LOAD_WRAPPER \
+	extern "C" const char *_malloc_user_defined_name; \
+	const char *_malloc_user_defined_name="libjemalloc_wrapper.a";
+#else
+#define JEMALLOC_LOAD_WRAPPER const char *_malloc_user_defined_name = "libjemalloc_wrapper.a";
+#endif
+
+#else
+
+#define JEMALLOC_LOAD_WRAPPER
+
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,6 +44,7 @@ for hdr in jemalloc_defs.h jemalloc_rename.h jemalloc_macros.h \
 done
 
 cat <<EOF
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/aix_wrapper.c
+++ b/src/aix_wrapper.c
@@ -1,0 +1,64 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#ifdef JEMALLOC_AIX_WRAPPERS
+
+#include <malloc.h>
+
+static bool initialized = false;
+
+void *__malloc__(size_t size)
+{
+	return initialized ? je_malloc(size) : bootstrap_malloc(size);
+}
+
+void __free__(void *ptr)
+{
+	if (initialized)
+		je_free(ptr);
+	else
+		bootstrap_free(ptr);
+}
+
+void *__realloc__(void *ptr, size_t size)
+{
+	return je_realloc(ptr, size);
+}
+
+void *__calloc__(size_t numb, size_t size)
+{
+	return initialized ? je_calloc(numb, size) : bootstrap_calloc(numb, size);
+}
+
+int __posix_memalign__(void **memptr, size_t alignment, size_t size)
+{
+	return je_posix_memalign(memptr, alignment, size);
+}
+
+int __mallopt__(int command, int value)
+{
+	/* FIXME: implement at least M_MALIGN */
+	return 0;
+}
+
+struct mallinfo __mallinfo__()
+{
+	/* FIXME: check if some fields can be filled */
+	struct mallinfo mi;
+	memset(&mi, 0, sizeof(mi));
+	return mi;
+}
+
+void __malloc_init__(void)
+{
+}
+
+void __malloc_prefork_lock__(void)
+{
+}
+
+void __malloc_postfork_unlock__(void)
+{
+}
+
+#endif

--- a/src/aix_wrapper.exp
+++ b/src/aix_wrapper.exp
@@ -1,0 +1,10 @@
+__malloc__
+__free__
+__realloc__
+__calloc__
+__mallopt__
+__mallinfo__
+__malloc_init__
+__malloc_prefork_lock__
+__malloc_postfork_unlock__
+__posix_memalign__

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1139,7 +1139,7 @@ ctl_lookup(tsdn_t *tsdn, const char *name, ctl_node_t const **nodesp,
 			}
 
 			inode = ctl_indexed_node(node->children);
-			node = inode->index(tsdn, mibp, *depthp, (size_t)index);
+			node = (inode->index)(tsdn, mibp, *depthp, (size_t)index);
 			if (node == NULL) {
 				ret = ENOENT;
 				goto label_return;
@@ -1258,7 +1258,7 @@ ctl_bymib(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 
 			/* Indexed element. */
 			inode = ctl_indexed_node(node->children);
-			node = inode->index(tsd_tsdn(tsd), mib, miblen, mib[i]);
+			node = (inode->index)(tsd_tsdn(tsd), mib, miblen, mib[i]);
 			if (node == NULL) {
 				ret = ENOENT;
 				goto label_return;

--- a/src/ffs.c
+++ b/src/ffs.c
@@ -32,7 +32,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
-#if JEMALLOC_BUNDLED_FFS
+#ifdef JEMALLOC_BUNDLED_FFS
 
 /*
  * Find First Set bit

--- a/src/ffs.c
+++ b/src/ffs.c
@@ -1,0 +1,79 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#if JEMALLOC_BUNDLED_FFS
+
+/*
+ * Find First Set bit
+ */
+int __ffs(int mask)
+{
+	int bit;
+
+	if (mask == 0)
+		return (0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned int)mask >> 1;
+	return (bit);
+}
+
+/*
+ * Find First Set bit
+ */
+int __ffsl(long mask)
+{
+	int bit;
+
+	if (mask == 0)
+		return (0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned long)mask >> 1;
+	return (bit);
+}
+
+/*
+ * Find First Set bit
+ */
+int __ffsll(long long mask)
+{
+	int bit;
+
+	if (mask == 0)
+		return (0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned long long)mask >> 1;
+	return (bit);
+}
+
+#endif

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1596,6 +1596,8 @@ malloc_init_hard_finish(void) {
 
 static void
 malloc_init_hard_cleanup(tsdn_t *tsdn, bool reentrancy_set) {
+	malloc_mutex_assert_owner(tsdn, &init_lock);
+	malloc_mutex_unlock(tsdn, &init_lock);
 	if (reentrancy_set) {
 		assert(!tsdn_null(tsdn));
 		tsd_t *tsd = tsdn_tsd(tsdn);

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -157,6 +157,9 @@ malloc_mutex_init(malloc_mutex_t *mutex, const char *name,
 			return true;
 		}
 	}
+#elif (defined(JEMALLOC_INIT_BEFORE_THREADS))
+	static pthread_mutex_t __initializer = PTHREAD_MUTEX_INITIALIZER;
+	mutex->lock = __initializer;
 #else
 	pthread_mutexattr_t attr;
 

--- a/test/unit/math.c
+++ b/test/unit/math.c
@@ -5,7 +5,7 @@
 
 #include <float.h>
 
-#ifdef __PGI
+#if defined(__PGI) || defined(__IBMC__)
 #undef INFINITY
 #endif
 


### PR DESCRIPTION
This is my initial attempt on making jemalloc work on AIX. Main issues to be addressed for AIX port:

1. Compiler selection and command line options - configure was modified to select xlc_r on AIX and sett appropriate flags.
2. Missing ffs* functions - FreeBSD implementation bundled and used when target platform doen't have them.
3. awk on AIX do not understand \ in string constants - so private_symbols.sh was changed to generate one line string constant.
4. index is a macro defined somewhere in system headers - this is the reason for changes in src/ctl.c.
5. Library initialization - on AIX pthreads initialization code calls malloc and free - at this time nothing from pthreads library should be called. I've added appropriate define and forward malloc/free calls to bootstrap_malloc/bootstrap_free until pthreads fully initialized.
6. Simple ifdef to avoid including missing sys/syscall.h
7. Correct way for drop-in malloc/free replacement on AIX is to provide user defined memory subsystem via wrapper object - such wrapper object added. I've made some additional changes to build jemalloc functions with je_ prefix because they are supposed to be called from wrapper functions provided by wrapper archive.

Currently it passes all tests except integration/extent, which fails as following:

=== test/integration/extent ===
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_manual_hook (non-reentrant): fail
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_manual_hook (libc-reentrant): fail
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_manual_hook (arena_new-reentrant): fail
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_auto_hook (non-reentrant): fail
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_auto_hook (libc-reentrant): fail
test_extent_body:test/integration/extent.c:61: Failed assertion: (did_purge_lazy || did_purge_forced) == (true) --> false != true: Expected purge
test_extent_auto_hook (arena_new-reentrant): fail
--- pass: 0/6, skip: 0/6, fail: 6/6 ---

Any hints at what should be checked are very welcome.

Best regards,
Victor Kirhenshtein