### PR TITLE
c does not have array as argument

### DIFF
--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -79,7 +79,7 @@ struct bin_s {
 	bin_stats_t	stats;
 };
 
-void bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]);
+void bin_infos_init(sc_data_t *sc_data, bin_info_t *bin_infos);
 void bin_boot();
 
 /* Initializes a bin to empty.  Returns true on error. */

--- a/src/bin.c
+++ b/src/bin.c
@@ -9,7 +9,7 @@
 bin_info_t bin_infos[SC_NBINS];
 
 void
-bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]) {
+bin_infos_init(sc_data_t *sc_data, bin_info_t *bin_infos) {
 	for (unsigned i = 0; i < SC_NBINS; i++) {
 		bin_info_t *bin_info = &bin_infos[i];
 		sc_t *sc = &sc_data->sc[i];

--- a/src/stats.c
+++ b/src/stats.c
@@ -87,8 +87,8 @@ gen_mutex_ctl_str(char *str, size_t buf_len, const char *prefix,
 static void
 mutex_stats_init_cols(emitter_row_t *row, const char *table_name,
     emitter_col_t *name,
-    emitter_col_t col_uint64_t[mutex_prof_num_uint64_t_counters],
-    emitter_col_t col_uint32_t[mutex_prof_num_uint32_t_counters]) {
+    emitter_col_t *col_uint64_t,
+    emitter_col_t *col_uint32_t) {
 	mutex_prof_uint64_t_counter_ind_t k_uint64_t = 0;
 	mutex_prof_uint32_t_counter_ind_t k_uint32_t = 0;
 
@@ -120,8 +120,8 @@ mutex_stats_init_cols(emitter_row_t *row, const char *table_name,
 
 static void
 mutex_stats_read_global(const char *name, emitter_col_t *col_name,
-    emitter_col_t col_uint64_t[mutex_prof_num_uint64_t_counters],
-    emitter_col_t col_uint32_t[mutex_prof_num_uint32_t_counters]) {
+    emitter_col_t *col_uint64_t,
+    emitter_col_t *col_uint32_t) {
 	char cmd[MUTEX_CTL_STR_MAX_LENGTH];
 
 	col_name->str_val = name;
@@ -144,8 +144,8 @@ mutex_stats_read_global(const char *name, emitter_col_t *col_name,
 static void
 mutex_stats_read_arena(unsigned arena_ind, mutex_prof_arena_ind_t mutex_ind,
     const char *name, emitter_col_t *col_name,
-    emitter_col_t col_uint64_t[mutex_prof_num_uint64_t_counters],
-    emitter_col_t col_uint32_t[mutex_prof_num_uint32_t_counters]) {
+    emitter_col_t *col_uint64_t,
+    emitter_col_t *col_uint32_t) {
 	char cmd[MUTEX_CTL_STR_MAX_LENGTH];
 
 	col_name->str_val = name;
@@ -168,8 +168,8 @@ mutex_stats_read_arena(unsigned arena_ind, mutex_prof_arena_ind_t mutex_ind,
 
 static void
 mutex_stats_read_arena_bin(unsigned arena_ind, unsigned bin_ind,
-    emitter_col_t col_uint64_t[mutex_prof_num_uint64_t_counters],
-    emitter_col_t col_uint32_t[mutex_prof_num_uint32_t_counters]) {
+    emitter_col_t *col_uint64_t,
+    emitter_col_t *col_uint32_t) {
 	char cmd[MUTEX_CTL_STR_MAX_LENGTH];
 	emitter_col_t *dst;
 
@@ -191,8 +191,8 @@ mutex_stats_read_arena_bin(unsigned arena_ind, unsigned bin_ind,
 /* "row" can be NULL to avoid emitting in table mode. */
 static void
 mutex_stats_emit(emitter_t *emitter, emitter_row_t *row,
-    emitter_col_t col_uint64_t[mutex_prof_num_uint64_t_counters],
-    emitter_col_t col_uint32_t[mutex_prof_num_uint32_t_counters]) {
+    emitter_col_t *col_uint64_t,
+    emitter_col_t *col_uint32_t) {
 	if (row != NULL) {
 		emitter_table_row(emitter, row);
 	}


### PR DESCRIPTION
c does not have concept of array[] being passing as argument and compiler silently converts array[] argument into pointer.  Hiding the real thing (pointer) behind array[] might not be the right thing to do.  Someone might inadvertently do something  (such as sizeof() to get size of array) assuming that it is an actual array that was being passed in argument, while under the hood, it is just a pointer.