### PR TITLE
Misc. fixes for logging feature

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1442,6 +1442,19 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         by default.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="opt.prof_log">
+        <term>
+          <mallctl>opt.prof_log</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+          [<option>--enable-prof</option>]
+        </term>
+        <listitem><para>Call
+        <link linkend="prof.log_start"><mallctl>prof.log_start</mallctl></link>
+	when jemalloc is initialized. This option is disabled by default.
+	</para></listitem>
+      </varlistentry>
+
       <varlistentry id="thread.arena">
         <term>
           <mallctl>thread.arena</mallctl>
@@ -2243,6 +2256,38 @@ struct extent_hooks_s {
         <link
         linkend="opt.lg_prof_interval"><mallctl>opt.lg_prof_interval</mallctl></link>
         option for additional information.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="prof.log_start">
+        <term>
+          <mallctl>prof.log_start</mallctl>
+          (<type>const char *</type>)
+          <literal>-w</literal>
+          [<option>--enable-prof</option>]
+        </term>
+	<listitem><para>Begins logging of sampled allocations that will be
+	dumped to the specified file, or if NULL is specified, to the file
+	according to the pattern
+        <filename>&lt;prefix&gt;.&lt;pid&gt;.&lt;seq&gt;.json</filename>,
+        where <literal>&lt;prefix&gt;</literal> is controlled by the
+	<link linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link>
+        option. The file is created and written to once
+	<link linkend="prof.log_stop"><mallctl>prof.log_stop</mallctl></link>
+	is called, or when the process terminates.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="prof.log_stop">
+        <term>
+          <mallctl>prof.log_stop</mallctl>
+          (<type>void</type>)
+          <literal>--</literal>
+          [<option>--enable-prof</option>]
+        </term>
+        <listitem><para>Stops logging that was started by
+	<link linkend="prof.log_start"><mallctl>prof.log_start</mallctl></link>
+	or
+	<link linkend="opt.prof_log"><mallctl>opt.prof_log</mallctl></link>.
+        Nothing happens if logging isn't currently started.</para></listitem>
       </varlistentry>
 
       <varlistentry id="stats.allocated">

--- a/include/jemalloc/internal/prof_structs.h
+++ b/include/jemalloc/internal/prof_structs.h
@@ -6,6 +6,8 @@
 #include "jemalloc/internal/prng.h"
 #include "jemalloc/internal/rb.h"
 
+#define PTHREAD_NAME_MAX_SIZE 16
+
 struct prof_bt_s {
 	/* Backtrace, stored as len program counters. */
 	void		**vec;
@@ -146,6 +148,8 @@ struct prof_tdata_s {
 
 	/* Included in heap profile dumps if non-NULL. */
 	char			*thread_name;
+
+	char			pthread_name[PTHREAD_NAME_MAX_SIZE];
 
 	bool			attached;
 	bool			expired;

--- a/src/prof.c
+++ b/src/prof.c
@@ -2509,7 +2509,7 @@ prof_log_dummy_set(bool new_value) {
 
 bool
 prof_log_start(tsdn_t *tsdn, const char *filename) {
-	if (!opt_prof || !prof_booted) {
+	if (!opt_prof) {
 		return true;
 	}
 


### PR DESCRIPTION
- Fixed the `prof_log` option (which I unknowingly broke earlier); this starts logging at program start.
- Add man page documentation for `mallctl` and `MALLOC_CONF` options.
- Default to pthread names for logging feature if a jemalloc thread name isn't set.