### PR TITLE
Support multiple sizes for the extent_t struct

### DIFF
--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -195,8 +195,8 @@ struct arena_s {
 	 *
 	 * Synchronization: extent_avail_mtx.
 	 */
-	extent_tree_t		extent_avail;
-	atomic_zu_t		extent_avail_cnt;
+	extent_tree_t		extent_avail[EXTENT_NCLASSES];
+	atomic_zu_t		extent_avail_cnt[EXTENT_NCLASSES];
 	malloc_mutex_t		extent_avail_mtx;
 
 	/*

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -3,9 +3,21 @@
 
 #include "jemalloc/internal/sc.h"
 
-/* Maximum number of regions in one slab. */
-#define LG_SLAB_MAXREGS		(LG_PAGE - SC_LG_TINY_MIN)
-#define SLAB_MAXREGS		(1U << LG_SLAB_MAXREGS)
+#define LG_SLAB_SMALL_BYTES (LG_CACHELINE)
+
+/* 
+ * The size of the slabs is capped by how many bits we have for nfree in the
+ * extent_t metadata.
+ */
+#define LG_SLAB_LARGE_BYTES (LG_CACHELINE + 3)
+
+#define LG_SLAB_SMALL_REGS  (3 + LG_SLAB_SMALL_BYTES)
+#define LG_SLAB_LARGE_REGS  (3 + LG_SLAB_LARGE_BYTES)
+
+#define SLAB_SMALL_REGS (1 << LG_SLAB_SMALL_REGS)
+#define SLAB_LARGE_REGS (1 << LG_SLAB_LARGE_REGS)
+#define SLAB_SMALL_BYTES (1 << LG_SLAB_SMALL_BYTES)
+#define SLAB_LARGE_BYTES (1 << LG_SLAB_LARGE_BYTES)
 
 /* Default decay times in milliseconds. */
 #define DIRTY_DECAY_MS_DEFAULT	ZD(10 * 1000)

--- a/include/jemalloc/internal/base_externs.h
+++ b/include/jemalloc/internal/base_externs.h
@@ -11,7 +11,8 @@ extent_hooks_t *base_extent_hooks_get(base_t *base);
 extent_hooks_t *base_extent_hooks_set(base_t *base,
     extent_hooks_t *extent_hooks);
 void *base_alloc(tsdn_t *tsdn, base_t *base, size_t size, size_t alignment);
-extent_t *base_alloc_extent(tsdn_t *tsdn, base_t *base);
+extent_t *base_alloc_extent(tsdn_t *tsdn, base_t *base, extent_class_t
+    extent_class);
 void base_stats_get(tsdn_t *tsdn, base_t *base, size_t *allocated,
     size_t *resident, size_t *mapped, size_t *n_thp);
 void base_prefork(tsdn_t *tsdn, base_t *base);

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -47,10 +47,17 @@ struct bin_info_s {
 	 * bin.
 	 */
 	bitmap_info_t		bitmap_info;
+
+	extent_class_t		extent_class;
 };
 
 extern bin_info_t bin_infos[SC_NBINS];
 
+/*
+ * The maximum number of regions that a bin can use per slab. This determines
+ * how big large extent_t structs are. Initialized by bin_boot.
+ */
+extern size_t bin_max_regs;
 
 typedef struct bin_s bin_t;
 struct bin_s {

--- a/include/jemalloc/internal/bitmap.h
+++ b/include/jemalloc/internal/bitmap.h
@@ -8,29 +8,13 @@
 typedef unsigned long bitmap_t;
 #define LG_SIZEOF_BITMAP	LG_SIZEOF_LONG
 
-/* Maximum bitmap bit count is 2^LG_BITMAP_MAXBITS. */
-#if LG_SLAB_MAXREGS > LG_CEIL(SC_NSIZES)
-/* Maximum bitmap bit count is determined by maximum regions per slab. */
-#  define LG_BITMAP_MAXBITS	LG_SLAB_MAXREGS
-#else
-/* Maximum bitmap bit count is determined by number of extent size classes. */
-#  define LG_BITMAP_MAXBITS	LG_CEIL(SC_NSIZES)
-#endif
+#define LG_BITMAP_MAXBITS	LG_SLAB_LARGE_REGS
 #define BITMAP_MAXBITS		(ZU(1) << LG_BITMAP_MAXBITS)
 
 /* Number of bits per group. */
 #define LG_BITMAP_GROUP_NBITS		(LG_SIZEOF_BITMAP + 3)
 #define BITMAP_GROUP_NBITS		(1U << LG_BITMAP_GROUP_NBITS)
 #define BITMAP_GROUP_NBITS_MASK		(BITMAP_GROUP_NBITS-1)
-
-/*
- * Do some analysis on how big the bitmap is before we use a tree.  For a brute
- * force linear search, if we would have to call ffs_lu() more than 2^3 times,
- * use a tree instead.
- */
-#if LG_BITMAP_MAXBITS - LG_BITMAP_GROUP_NBITS > 3
-#  define BITMAP_USE_TREE
-#endif
 
 /* Number of groups required to store a given number of bits. */
 #define BITMAP_BITS2GROUPS(nbits)					\

--- a/include/jemalloc/internal/extent_externs.h
+++ b/include/jemalloc/internal/extent_externs.h
@@ -12,8 +12,10 @@ extern rtree_t extents_rtree;
 extern const extent_hooks_t extent_hooks_default;
 extern mutex_pool_t extent_mutex_pool;
 
-extent_t *extent_alloc(tsdn_t *tsdn, arena_t *arena);
-void extent_dalloc(tsdn_t *tsdn, arena_t *arena, extent_t *extent);
+extent_t *extent_alloc(tsdn_t *tsdn, arena_t *arena, extent_class_t
+    extent_class);
+void extent_dalloc(tsdn_t *tsdn, arena_t *arena, extent_t *extent,
+    extent_class_t extent_class);
 
 extent_hooks_t *extent_hooks_get(arena_t *arena);
 extent_hooks_t *extent_hooks_set(tsd_t *tsd, arena_t *arena,
@@ -71,6 +73,8 @@ extent_t *extent_split_wrapper(tsdn_t *tsdn, arena_t *arena,
     szind_t szind_a, bool slab_a, size_t size_b, szind_t szind_b, bool slab_b);
 bool extent_merge_wrapper(tsdn_t *tsdn, arena_t *arena,
     extent_hooks_t **r_extent_hooks, extent_t *a, extent_t *b);
+bool extent_register_no_gdump_add(tsdn_t *tsdn, extent_t *extent);
+void extent_deregister_no_gdump_sub(tsdn_t *tsdn, extent_t *extent);
 
 bool extent_boot(void);
 

--- a/src/bin.c
+++ b/src/bin.c
@@ -7,6 +7,7 @@
 #include "jemalloc/internal/witness.h"
 
 bin_info_t bin_infos[SC_NBINS];
+size_t bin_max_regs;
 
 void
 bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]) {
@@ -21,6 +22,16 @@ bin_infos_init(sc_data_t *sc_data, bin_info_t bin_infos[SC_NBINS]) {
 		bitmap_info_t bitmap_info = BITMAP_INFO_INITIALIZER(
 		    bin_info->nregs);
 		bin_info->bitmap_info = bitmap_info;
+
+		if (bin_max_regs < bin_info->nregs) {
+			bin_max_regs = bin_info->nregs;
+		}
+
+		if (bin_info->nregs > SLAB_SMALL_REGS) {
+			bin_info->extent_class = extent_class_large;
+		} else {
+			bin_info->extent_class = extent_class_small;
+		}
 	}
 }
 

--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -123,7 +123,7 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 		return NULL;
 	}
 
-	gap = extent_alloc(tsdn, arena);
+	gap = extent_alloc(tsdn, arena, extent_class_small);
 	if (gap == NULL) {
 		return NULL;
 	}
@@ -187,7 +187,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 				if (gap_size_page != 0) {
 					extent_dalloc_gap(tsdn, arena, gap);
 				} else {
-					extent_dalloc(tsdn, arena, gap);
+					extent_dalloc(tsdn, arena, gap,
+					    extent_class_small);
 				}
 				if (!*commit) {
 					*commit = pages_decommit(ret, size);
@@ -223,7 +224,7 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 	}
 label_oom:
 	extent_dss_extending_finish();
-	extent_dalloc(tsdn, arena, gap);
+	extent_dalloc(tsdn, arena, gap, extent_class_small);
 	return NULL;
 }
 


### PR DESCRIPTION
This enables bitmaps that are larger than 512 regions. Using the `slab_sizes` MALLOC_CONF option allows slabs up to 4096 regions. Normal slabs use a regularly sized `extent_t`, and larger slabs use a larger `extent_t`. Production results maybe indicate a slight (< 1.0% CPU) win on `malloc` and `free` calls, but I don't have enough experience reading those to feel comfortable concluding.