### PR TITLE
bit_util.h pow2_ceil_u32() #1307 fallback to older XOR based logic to…

### DIFF
--- a/include/jemalloc/internal/bit_util.h
+++ b/include/jemalloc/internal/bit_util.h
@@ -93,7 +93,7 @@ pow2_ceil_u64(uint64_t x) {
 
 BIT_UTIL_INLINE uint32_t
 pow2_ceil_u32(uint32_t x) {
-#if (defined(__i386__) || defined(JEMALLOC_HAVE_BUILTIN_CLZ))
+#if ((defined(__i386__) || defined(JEMALLOC_HAVE_BUILTIN_CLZ)) && (!defined(__s390__)))
 	if(unlikely(x <= 1)) {
 		return x;
 	}


### PR DESCRIPTION
This is workaround for #1307 s390x optimizer bug https://bugzilla.redhat.com/show_bug.cgi?id=1619354 where we are falling back to older XOR version of code for s390 platform.