### PR TITLE
Remove malloc_init() off the fastpath

### DIFF
--- a/include/jemalloc/internal/tsd_malloc_thread_cleanup.h
+++ b/include/jemalloc/internal/tsd_malloc_thread_cleanup.h
@@ -47,7 +47,6 @@ tsd_get_allocates(void) {
 /* Get/set. */
 JEMALLOC_ALWAYS_INLINE tsd_t *
 tsd_get(bool init) {
-	assert(tsd_booted);
 	return &tsd_tls;
 }
 JEMALLOC_ALWAYS_INLINE void

--- a/include/jemalloc/internal/tsd_tls.h
+++ b/include/jemalloc/internal/tsd_tls.h
@@ -40,7 +40,6 @@ tsd_get_allocates(void) {
 /* Get/set. */
 JEMALLOC_ALWAYS_INLINE tsd_t *
 tsd_get(bool init) {
-	assert(tsd_booted);
 	return &tsd_tls;
 }
 

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -280,11 +280,13 @@ tsd_fetch_slow(tsd_t *tsd, bool minimal) {
 		tsd_slow_update(tsd);
 	} else if (tsd_state_get(tsd) == tsd_state_uninitialized) {
 		if (!minimal) {
-			tsd_state_set(tsd, tsd_state_nominal);
-			tsd_slow_update(tsd);
-			/* Trigger cleanup handler registration. */
-			tsd_set(tsd);
-			tsd_data_init(tsd);
+			if (tsd_booted) {
+				tsd_state_set(tsd, tsd_state_nominal);
+				tsd_slow_update(tsd);
+				/* Trigger cleanup handler registration. */
+				tsd_set(tsd);
+				tsd_data_init(tsd);
+			}
 		} else {
 			tsd_state_set(tsd, tsd_state_minimal_initialized);
 			tsd_set(tsd);


### PR DESCRIPTION
Move malloc_init() off of the fast path in imalloc(). If tsd can't allocate, then it is safe to check the tsd_state (which will be uninitialized the first time), and then only do the malloc_init() check on the slowpath.   

This appears to pass our internal testing, but I'm not sure this is enough for freebsd libc.