### PR TITLE
Restore a FreeBSD-specific getpagesize(3) optimization.

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -415,6 +415,12 @@ os_page_detect(void) {
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 	return si.dwPageSize;
+#elif defined(__FreeBSD__)
+	/*
+	 * This returns the value obtained from
+	 * the auxv vector, avoiding a syscall.
+	 */
+	return getpagesize();
 #else
 	long result = sysconf(_SC_PAGESIZE);
 	if (result == -1) {


### PR DESCRIPTION
It was removed in 0771ff2cea6dc18fcd3f6bf452b4224a4e17ae38.
Add a comment explaining its purpose.