### PR TITLE
Set commit properly for FreeBSD w/ overcommit.

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -186,6 +186,10 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 * touching existing mappings, and to mmap with specific alignment.
 	 */
 	{
+		if (os_overcommits) {
+			*commit = true;
+		}
+
 		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
 		int flags = mmap_flags;
 


### PR DESCRIPTION
When overcommit is enabled, commit needs to be set when doing mmap().  The
regression was introduced in f80c97e.

This solves #1350