### PR TITLE
Add a fastpath for free and sdallocx

### DIFF
--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -90,7 +90,7 @@ cache_bin_alloc_easy(cache_bin_t *bin, bool *success) {
 
 	bin->ncached--;
 
-	/* 
+	/*
 	 * Check for both bin->ncached == 0 and ncached < low_water
 	 * in a single branch.
 	 */
@@ -102,7 +102,7 @@ cache_bin_alloc_easy(cache_bin_t *bin, bool *success) {
 			return NULL;
 		}
 	}
-        
+
 	/*
 	 * success (instead of ret) should be checked upon the return of this
 	 * function.  We avoid checking (ret == NULL) because there is never a
@@ -114,6 +114,18 @@ cache_bin_alloc_easy(cache_bin_t *bin, bool *success) {
 	ret = *(bin->avail - (bin->ncached + 1));
 
 	return ret;
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+cache_bin_dalloc_easy(cache_bin_t *bin, cache_bin_info_t *bin_info, void *ptr) {
+	if (unlikely(bin->ncached == bin_info->ncached_max)) {
+		return false;
+	}
+	assert(bin->ncached < bin_info->ncached_max);
+	bin->ncached++;
+	*(bin->avail - bin->ncached) = ptr;
+
+	return true;
 }
 
 #endif /* JEMALLOC_INTERNAL_CACHE_BIN_H */

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -175,13 +175,12 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_small_bin_get(tcache, binind);
 	bin_info = &tcache_bin_info[binind];
-	if (unlikely(bin->ncached == bin_info->ncached_max)) {
+	if (unlikely(!cache_bin_dalloc_easy(bin, bin_info, ptr))) {
 		tcache_bin_flush_small(tsd, tcache, bin, binind,
 		    (bin_info->ncached_max >> 1));
+		bool ret = cache_bin_dalloc_easy(bin, bin_info, ptr);
+		assert(ret);
 	}
-	assert(bin->ncached < bin_info->ncached_max);
-	bin->ncached++;
-	*(bin->avail - bin->ncached) = ptr;
 
 	tcache_event(tsd, tcache);
 }


### PR DESCRIPTION
Add unsized and sized deallocation fastpaths.  Similar to the malloc() fastpath, this removes all frame manipulation for the majority of free() calls.  The fastpath must hit the rtree cache, or be a sized dalloc.  Profiled objects go to the slowpath.