### PR TITLE
Avoid touching all pages in extent_recycle for debug build.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -1162,14 +1162,15 @@ extent_recycle(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 
 	if (*zero) {
 		void *addr = extent_base_get(extent);
-		size_t size = extent_size_get(extent);
 		if (!extent_zeroed_get(extent)) {
+			size_t size = extent_size_get(extent);
 			if (pages_purge_forced(addr, size)) {
 				memset(addr, 0, size);
 			}
 		} else if (config_debug) {
 			size_t *p = (size_t *)(uintptr_t)addr;
-			for (size_t i = 0; i < size / sizeof(size_t); i++) {
+			/* Check the first page only. */
+			for (size_t i = 0; i < PAGE / sizeof(size_t); i++) {
 				assert(p[i] == 0);
 			}
 		}


### PR DESCRIPTION
We may have a large number of pages with *zero set (since they are populated on
demand).  Only check the first page to avoid paging in all of them.