### PR TITLE
Disable muzzy decay by default.

### DIFF
--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -9,7 +9,7 @@
 
 /* Default decay times in milliseconds. */
 #define DIRTY_DECAY_MS_DEFAULT	ZD(10 * 1000)
-#define MUZZY_DECAY_MS_DEFAULT	ZD(10 * 1000)
+#define MUZZY_DECAY_MS_DEFAULT	(0)
 /* Number of event ticks between time checks. */
 #define DECAY_NTICKS_PER_UPDATE	1000
 


### PR DESCRIPTION
I'm going to do more validation here. So far the consensus seem to say that the 10s muzzy decay is on the aggressive side. We do have a few use cases enabling it explicitly got desired tradeoffs, but given that we don't have a good story on getting accurate RSS accounting with MADV_FREE, and being able to track memory regression is also very valuable, we may want it to be turned off by default in the next release.