### PR TITLE
Avoid redefining tsd_t.

### DIFF
--- a/include/jemalloc/internal/tcache_structs.h
+++ b/include/jemalloc/internal/tcache_structs.h
@@ -5,9 +5,9 @@
 #include "jemalloc/internal/ql.h"
 #include "jemalloc/internal/sc.h"
 #include "jemalloc/internal/ticker.h"
+#include "jemalloc/internal/tsd_types.h"
 
 /* Various uses of this struct need it to be a named type. */
-typedef struct tsd_s tsd_t;
 typedef ql_elm(tsd_t) tsd_link_t;
 
 struct tcache_s {


### PR DESCRIPTION
This fixes a build failure when integrating with FreeBSD's libc.  This
regression was introduced by d1e11d48d4c706e17ef3508e2ddb910f109b779f
(Move tsd link and in_hook after tcache.).