### PR TITLE
Do not use #pragma GCC diagnostic with gcc < 4.6.

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_macros.h
+++ b/include/jemalloc/internal/jemalloc_internal_macros.h
@@ -30,7 +30,7 @@
 #  define restrict
 #endif
 
-/* Various function pointers are statick and immutable except during testing. */
+/* Various function pointers are static and immutable except during testing. */
 #ifdef JEMALLOC_JET
 #  define JET_MUTABLE
 #else
@@ -47,7 +47,6 @@
 #define JEMALLOC_FALLTHROUGH /* falls through */
 #endif
 
-
 /* Diagnostic suppression macros */
 #if defined(_MSC_VER) && !defined(__clang__)
 #  define JEMALLOC_DIAGNOSTIC_PUSH __pragma(warning(push))
@@ -57,7 +56,9 @@
 #  define JEMALLOC_DIAGNOSTIC_IGNORE_TYPE_LIMITS
 #  define JEMALLOC_DIAGNOSTIC_IGNORE_ALLOC_SIZE_LARGER_THAN
 #  define JEMALLOC_DIAGNOSTIC_DISABLE_SPURIOUS
-#elif defined(__GNUC__) || defined(__clang__)
+/* #pragma GCC diagnostic first appeared in gcc 4.6. */
+#elif (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && \
+  (__GNUC_MINOR__ > 5)))) || defined(__clang__)
 /*
  * The JEMALLOC_PRAGMA__ macro is an implementation detail of the GCC and Clang
  * diagnostic suppression macros and should not be used anywhere else.
@@ -65,14 +66,16 @@
 #  define JEMALLOC_PRAGMA__(X) _Pragma(#X)
 #  define JEMALLOC_DIAGNOSTIC_PUSH JEMALLOC_PRAGMA__(GCC diagnostic push)
 #  define JEMALLOC_DIAGNOSTIC_POP JEMALLOC_PRAGMA__(GCC diagnostic pop)
-#  define JEMALLOC_DIAGNOSTIC_IGNORE(W) JEMALLOC_PRAGMA__(GCC diagnostic ignored W)
+#  define JEMALLOC_DIAGNOSTIC_IGNORE(W) \
+     JEMALLOC_PRAGMA__(GCC diagnostic ignored W)
 
 /*
  * The -Wmissing-field-initializers warning is buggy in GCC versions < 5.1 and
- * all clang versions up to version 7 (currently trunk, unreleased).
- * This macro suppresses the warning for the affected compiler versions only.
+ * all clang versions up to version 7 (currently trunk, unreleased).  This macro
+ * suppresses the warning for the affected compiler versions only.
  */
-#  if ((defined(__GNUC__) && !defined(__clang__)) && (__GNUC__ < 5)) || defined(__clang__)
+#  if ((defined(__GNUC__) && !defined(__clang__)) && (__GNUC__ < 5)) || \
+     defined(__clang__)
 #    define JEMALLOC_DIAGNOSTIC_IGNORE_MISSING_STRUCT_FIELD_INITIALIZERS  \
           JEMALLOC_DIAGNOSTIC_IGNORE("-Wmissing-field-initializers")
 #  else
@@ -103,9 +106,8 @@
 #endif
 
 /*
- * Disables spurious diagnostics for all headers
- * Since these headers are not included by users directly,
- * it does not affect their diagnostic settings.
+ * Disables spurious diagnostics for all headers.  Since these headers are not
+ * included by users directly, it does not affect their diagnostic settings.
  */
 JEMALLOC_DIAGNOSTIC_DISABLE_SPURIOUS
 


### PR DESCRIPTION
This regression was introduced by
3d29d11ac2c1583b9959f73c0548545018d31c8a (Clean compilation -Wextra).

The functional change is at line 60 (cleaning up while I'm here).