### PR TITLE
Eagerly purge oversized extents.

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -56,9 +56,6 @@
 /* and the 8-bit variant support. */
 #undef JEMALLOC_GCC_U8_SYNC_ATOMICS
 
-/* Defined if 8-bit atomics are supported. */
-
-
 /*
  * Defined if __builtin_clz() and __builtin_clzl() are available.
  */


### PR DESCRIPTION
This change improves memory usage slightly, at virtually no CPU cost.

Also resolves the issue in #1454