### PR TITLE
Add memory utilization analytics to mallctl

### DIFF
--- a/include/jemalloc/internal/extent_externs.h
+++ b/include/jemalloc/internal/extent_externs.h
@@ -74,4 +74,10 @@ bool extent_merge_wrapper(tsdn_t *tsdn, arena_t *arena,
 
 bool extent_boot(void);
 
+void extent_util_stats_get(tsdn_t *tsdn, const void *ptr,
+    size_t *nfree, size_t *nregs, size_t *size);
+void extent_util_stats_verbose_get(tsdn_t *tsdn, const void *ptr,
+    size_t *nfree, size_t *nregs, size_t *size,
+    size_t *bin_nfree, size_t *bin_nregs, void **slabcur_addr);
+
 #endif /* JEMALLOC_INTERNAL_EXTENT_EXTERNS_H */

--- a/include/jemalloc/internal/extent_structs.h
+++ b/include/jemalloc/internal/extent_structs.h
@@ -228,4 +228,25 @@ struct extents_s {
 	bool			delay_coalesce;
 };
 
+/*
+ * The following two structs are for experimental purposes. See
+ * experimental_utilization_query_ctl and
+ * experimental_utilization_batch_query_ctl in src/ctl.c.
+ */
+
+struct extent_util_stats_s {
+	size_t nfree;
+	size_t nregs;
+	size_t size;
+};
+
+struct extent_util_stats_verbose_s {
+	void *slabcur_addr;
+	size_t nfree;
+	size_t nregs;
+	size_t size;
+	size_t bin_nfree;
+	size_t bin_nregs;
+};
+
 #endif /* JEMALLOC_INTERNAL_EXTENT_STRUCTS_H */

--- a/include/jemalloc/internal/extent_types.h
+++ b/include/jemalloc/internal/extent_types.h
@@ -4,6 +4,9 @@
 typedef struct extent_s extent_t;
 typedef struct extents_s extents_t;
 
+typedef struct extent_util_stats_s extent_util_stats_t;
+typedef struct extent_util_stats_verbose_s extent_util_stats_verbose_t;
+
 #define EXTENT_HOOKS_INITIALIZER	NULL
 
 /*

--- a/src/extent.c
+++ b/src/extent.c
@@ -2279,3 +2279,72 @@ extent_boot(void) {
 
 	return false;
 }
+
+void
+extent_util_stats_get(tsdn_t *tsdn, const void *ptr,
+    size_t *nfree, size_t *nregs, size_t *size) {
+	assert(ptr != NULL && nfree != NULL && nregs != NULL && size != NULL);
+
+	const extent_t *extent = iealloc(tsdn, ptr);
+	if (unlikely(extent == NULL)) {
+		*nfree = *nregs = *size = 0;
+		return;
+	}
+
+	*size = extent_size_get(extent);
+	if (!extent_slab_get(extent)) {
+		*nfree = 0;
+		*nregs = 1;
+	} else {
+		*nfree = extent_nfree_get(extent);
+		*nregs = bin_infos[extent_szind_get(extent)].nregs;
+		assert(*nfree <= *nregs);
+		assert(*nfree * extent_usize_get(extent) <= *size);
+	}
+}
+
+void
+extent_util_stats_verbose_get(tsdn_t *tsdn, const void *ptr,
+    size_t *nfree, size_t *nregs, size_t *size,
+    size_t *bin_nfree, size_t *bin_nregs, void **slabcur_addr) {
+	assert(ptr != NULL && nfree != NULL && nregs != NULL && size != NULL
+	    && bin_nfree != NULL && bin_nregs != NULL && slabcur_addr != NULL);
+
+	const extent_t *extent = iealloc(tsdn, ptr);
+	if (unlikely(extent == NULL)) {
+		*nfree = *nregs = *size = *bin_nfree = *bin_nregs = 0;
+		*slabcur_addr = NULL;
+		return;
+	}
+
+	*size = extent_size_get(extent);
+	if (!extent_slab_get(extent)) {
+		*nfree = *bin_nfree = *bin_nregs = 0;
+		*nregs = 1;
+		*slabcur_addr = NULL;
+		return;
+	}
+
+	*nfree = extent_nfree_get(extent);
+	const szind_t szind = extent_szind_get(extent);
+	*nregs = bin_infos[szind].nregs;
+	assert(*nfree <= *nregs);
+	assert(*nfree * extent_usize_get(extent) <= *size);
+
+	const arena_t *arena = extent_arena_get(extent);
+	assert(arena != NULL);
+	const unsigned binshard = extent_binshard_get(extent);
+	bin_t *bin = &arena->bins[szind].bin_shards[binshard];
+
+	malloc_mutex_lock(tsdn, &bin->lock);
+	if (config_stats) {
+		*bin_nregs = *nregs * bin->stats.curslabs;
+		assert(*bin_nregs >= bin->stats.curregs);
+		*bin_nfree = *bin_nregs - bin->stats.curregs;
+	} else {
+		*bin_nfree = *bin_nregs = 0;
+	}
+	*slabcur_addr = extent_addr_get(bin->slabcur);
+	assert(*slabcur_addr != NULL);
+	malloc_mutex_unlock(tsdn, &bin->lock);
+}

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -853,6 +853,198 @@ TEST_BEGIN(test_hooks_exhaustion) {
 }
 TEST_END
 
+#define TEST_UTIL_EINVAL(node, a, b, c, d, why_inval) do {		\
+	assert_d_eq(mallctl("experimental.utilization." node,		\
+	    a, b, c, d), EINVAL, "Should fail when " why_inval);	\
+	assert_zu_eq(out_sz, out_sz_ref,				\
+	    "Output size touched when given invalid arguments");	\
+	assert_d_eq(memcmp(out, out_ref, out_sz_ref), 0,		\
+	    "Output content touched when given invalid arguments");	\
+} while (0)
+
+#define TEST_UTIL_VALID(node) do {					\
+        assert_d_eq(mallctl("experimental.utilization." node,		\
+	    out, &out_sz, in, in_sz), 0,				\
+	    "Should return 0 on correct arguments");			\
+        assert_zu_eq(out_sz, out_sz_ref, "incorrect output size");	\
+	assert_d_ne(memcmp(out, out_ref, out_sz_ref), 0,		\
+	    "Output content should be changed");			\
+} while (0)
+
+TEST_BEGIN(test_utilization_query) {
+	void *p = mallocx(1, 0);
+	void **in = &p;
+	size_t in_sz = sizeof(const void *);
+	size_t out_sz = sizeof(void *) + sizeof(size_t) * 5;
+	void *out = mallocx(out_sz, 0);
+	void *out_ref = mallocx(out_sz, 0);
+	size_t out_sz_ref = out_sz;
+
+	assert_ptr_not_null(p, "test pointer allocation failed");
+	assert_ptr_not_null(out, "test output allocation failed");
+	assert_ptr_not_null(out_ref, "test reference output allocation failed");
+
+#define SLABCUR_READ(out) (*(void **)out)
+#define COUNTS(out) ((size_t *)((void **)out + 1))
+#define NFREE_READ(out) COUNTS(out)[0]
+#define NREGS_READ(out) COUNTS(out)[1]
+#define SIZE_READ(out) COUNTS(out)[2]
+#define BIN_NFREE_READ(out) COUNTS(out)[3]
+#define BIN_NREGS_READ(out) COUNTS(out)[4]
+
+	SLABCUR_READ(out) = NULL;
+	NFREE_READ(out) = NREGS_READ(out) = SIZE_READ(out) = -1;
+	BIN_NFREE_READ(out) = BIN_NREGS_READ(out) = -1;
+	memcpy(out_ref, out, out_sz);
+
+	/* Test invalid argument(s) errors */
+#define TEST_UTIL_QUERY_EINVAL(a, b, c, d, why_inval) \
+	TEST_UTIL_EINVAL("query", a, b, c, d, why_inval)
+
+	TEST_UTIL_QUERY_EINVAL(NULL, &out_sz, in, in_sz, "old is NULL");
+	TEST_UTIL_QUERY_EINVAL(out, NULL, in, in_sz, "oldlenp is NULL");
+	TEST_UTIL_QUERY_EINVAL(out, &out_sz, NULL, in_sz, "newp is NULL");
+	TEST_UTIL_QUERY_EINVAL(out, &out_sz, in, 0, "newlen is zero");
+	in_sz -= 1;
+	TEST_UTIL_QUERY_EINVAL(out, &out_sz, in, in_sz, "invalid newlen");
+	in_sz += 1;
+	out_sz_ref = out_sz -= 2 * sizeof(size_t);
+	TEST_UTIL_QUERY_EINVAL(out, &out_sz, in, in_sz, "invalid *oldlenp");
+	out_sz_ref = out_sz += 2 * sizeof(size_t);
+
+#undef TEST_UTIL_QUERY_EINVAL
+
+	/* Examine output for valid call */
+	TEST_UTIL_VALID("query");
+	assert_zu_le(NFREE_READ(out), NREGS_READ(out),
+	    "Extent free count exceeded region count");
+	assert_zu_le(NREGS_READ(out), SIZE_READ(out),
+	    "Extent region count exceeded size");
+	assert_zu_ne(NREGS_READ(out), 0,
+	    "Extent region count must be positive");
+	assert_zu_ne(SIZE_READ(out), 0, "Extent size must be positive");
+	if (config_stats) {
+		assert_zu_le(BIN_NFREE_READ(out), BIN_NREGS_READ(out),
+		    "Bin free count exceeded region count");
+		assert_zu_ne(BIN_NREGS_READ(out), 0,
+		    "Bin region count must be positive");
+		assert_zu_le(NFREE_READ(out), BIN_NFREE_READ(out),
+		    "Extent free count exceeded bin free count");
+		assert_zu_le(NREGS_READ(out), BIN_NREGS_READ(out),
+		    "Extent region count exceeded bin region count");
+		assert_zu_eq(BIN_NREGS_READ(out) % NREGS_READ(out), 0,
+		    "Bin region count isn't a multiple of extent region count");
+		assert_zu_le(NREGS_READ(out) - NFREE_READ(out),
+		    BIN_NREGS_READ(out) - BIN_NFREE_READ(out),
+		    "Extent utilized count exceeded bin utilized count");
+	} else {
+		assert_zu_eq(BIN_NFREE_READ(out), 0,
+		    "Bin free count should be zero when stats are disabled");
+		assert_zu_eq(BIN_NREGS_READ(out), 0,
+		    "Bin region count should be zero when stats are disabled");
+	}
+	assert_ptr_not_null(SLABCUR_READ(out), "Current slab is null");
+	assert_true(NFREE_READ(out) == 0 || SLABCUR_READ(out) <= p,
+	    "Allocation should follow first fit principle");
+
+#undef BIN_NREGS_READ
+#undef BIN_NFREE_READ
+#undef SIZE_READ
+#undef NREGS_READ
+#undef NFREE_READ
+#undef COUNTS
+#undef SLABCUR_READ
+
+	free(out_ref);
+	free(out);
+	free(p);
+}
+TEST_END
+
+TEST_BEGIN(test_utilization_batch_query) {
+	void *p = mallocx(1, 0);
+	void *q = mallocx(1, 0);
+	void *in[] = {p, q};
+	size_t in_sz = sizeof(const void *) * 2;
+	size_t out[] = {-1, -1, -1, -1, -1, -1};
+	size_t out_sz = sizeof(size_t) * 6;
+	size_t out_ref[] = {-1, -1, -1, -1, -1, -1};
+	size_t out_sz_ref = out_sz;
+
+	assert_ptr_not_null(p, "test pointer allocation failed");
+	assert_ptr_not_null(q, "test pointer allocation failed");
+
+	/* Test invalid argument(s) errors */
+#define TEST_UTIL_BATCH_EINVAL(a, b, c, d, why_inval)			\
+	TEST_UTIL_EINVAL("batch_query", a, b, c, d, why_inval)
+
+	TEST_UTIL_BATCH_EINVAL(NULL, &out_sz, in, in_sz, "old is NULL");
+	TEST_UTIL_BATCH_EINVAL(out, NULL, in, in_sz, "oldlenp is NULL");
+	TEST_UTIL_BATCH_EINVAL(out, &out_sz, NULL, in_sz, "newp is NULL");
+	TEST_UTIL_BATCH_EINVAL(out, &out_sz, in, 0, "newlen is zero");
+	in_sz -= 1;
+	TEST_UTIL_BATCH_EINVAL(out, &out_sz, in, in_sz,
+	    "newlen is not an exact multiple");
+	in_sz += 1;
+	out_sz_ref = out_sz -= 2 * sizeof(size_t);
+	TEST_UTIL_BATCH_EINVAL(out, &out_sz, in, in_sz,
+	    "*oldlenp is not an exact multiple");
+	out_sz_ref = out_sz += 2 * sizeof(size_t);
+	in_sz -= sizeof(const void *);
+	TEST_UTIL_BATCH_EINVAL(out, &out_sz, in, in_sz,
+	    "*oldlenp and newlen do not match");
+	in_sz += sizeof(const void *);
+
+#undef TEST_UTIL_BATCH_EINVAL
+
+	/* Examine output for valid calls */
+#define TEST_UTIL_BATCH_VALID TEST_UTIL_VALID("batch_query")
+#define TEST_EQUAL_REF(i, message) \
+	assert_d_eq(memcmp(out + (i) * 3, out_ref + (i) * 3, 3), 0, message)
+
+#define NFREE_READ(out, i) out[(i) * 3]
+#define NREGS_READ(out, i) out[(i) * 3 + 1]
+#define SIZE_READ(out, i) out[(i) * 3 + 2]
+
+	out_sz_ref = out_sz /= 2;
+	in_sz /= 2;
+	TEST_UTIL_BATCH_VALID;
+	assert_zu_le(NFREE_READ(out, 0), NREGS_READ(out, 0),
+	    "Extent free count exceeded region count");
+	assert_zu_le(NREGS_READ(out, 0), SIZE_READ(out, 0),
+	    "Extent region count exceeded size");
+	assert_zu_ne(NREGS_READ(out, 0), 0,
+	    "Extent region count must be positive");
+	assert_zu_ne(SIZE_READ(out, 0), 0, "Extent size must be positive");
+	TEST_EQUAL_REF(1, "Should not overwrite content beyond what's needed");
+	in_sz *= 2;
+	out_sz_ref = out_sz *= 2;
+
+	memcpy(out_ref, out, 3 * sizeof(size_t));
+	TEST_UTIL_BATCH_VALID;
+	TEST_EQUAL_REF(0, "Statistics should be stable across calls");
+	assert_zu_le(NFREE_READ(out, 1), NREGS_READ(out, 1),
+	    "Extent free count exceeded region count");
+	assert_zu_eq(NREGS_READ(out, 0), NREGS_READ(out, 1),
+	    "Extent region count should be same for same region size");
+	assert_zu_eq(SIZE_READ(out, 0), SIZE_READ(out, 1),
+	    "Extent size should be same for same region size");
+
+#undef SIZE_READ
+#undef NREGS_READ
+#undef NFREE_READ
+
+#undef TEST_EQUAL_REF
+#undef TEST_UTIL_BATCH_VALID
+
+	free(q);
+	free(p);
+}
+TEST_END
+
+#undef TEST_UTIL_VALID
+#undef TEST_UTIL_EINVAL
+
 int
 main(void) {
 	return test(
@@ -883,5 +1075,7 @@ main(void) {
 	    test_arenas_lookup,
 	    test_stats_arenas,
 	    test_hooks,
-	    test_hooks_exhaustion);
+	    test_hooks_exhaustion,
+	    test_utilization_query,
+	    test_utilization_batch_query);
 }


### PR DESCRIPTION
The analytics tool is put under experimental.utilization namespace in
mallctl.  Input is one pointer or an array of pointers and the output
is a list of memory utilization statistics.