### PR TITLE
 Allow low values of oversize_threshold to disable the feature.

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1248,8 +1248,8 @@ malloc_conf_init(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS]) {
 			 * contention on the huge arena.
 			 */
 			CONF_HANDLE_SIZE_T(opt_oversize_threshold,
-			    "oversize_threshold", SC_LARGE_MINCLASS,
-			    SC_LARGE_MAXCLASS, yes, yes, false)
+			    "oversize_threshold", 0, SC_LARGE_MAXCLASS, no, yes,
+			    false)
 			CONF_HANDLE_SIZE_T(opt_lg_extent_max_active_fit,
 			    "lg_extent_max_active_fit", 0,
 			    (sizeof(size_t) << 3), yes, yes, false)

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -123,6 +123,9 @@ tbin_extents_lookup_size_check(tsdn_t *tsdn, cache_bin_t *tbin, szind_t binind,
 		sz_sum -= szind;
 	}
 	if (sz_sum != 0) {
+		malloc_printf("<jemalloc>: size mismatch in thread cache "
+		    "detected, likely caused by sized deallocation bugs by "
+		    "application. Abort.\n");
 		abort();
 	}
 }


### PR DESCRIPTION
We should allow a way to easily disable the feature (e.g. not reserving the
arena id at all).