### PR TITLE
Fix test/unit/prof_log

### DIFF
--- a/test/unit/prof_log.c
+++ b/test/unit/prof_log.c
@@ -125,12 +125,14 @@ TEST_BEGIN(test_prof_log_many_traces) {
 		assert_rep();
 	}
 	/*
-	 * There should be 8 total backtraces: two for malloc/free in f1(),
-	 * two for malloc/free in f2(), two for malloc/free in f3(), and then
-	 * two for malloc/free in f1()'s call to f3().
+	 * There should be 8 total backtraces: two for malloc/free in f1(), two
+	 * for malloc/free in f2(), two for malloc/free in f3(), and then two
+	 * for malloc/free in f1()'s call to f3().  However compiler
+	 * optimizations such as loop unrolling might generate more call sites.
+	 * So >= 8 traces are expected.
 	 */
-	assert_zu_eq(prof_log_bt_count(), 8,
-	    "Wrong number of backtraces given sample workload");
+	assert_zu_ge(prof_log_bt_count(), 8,
+	    "Expect at least 8 backtraces given sample workload");
 	assert_d_eq(mallctl("prof.log_stop", NULL, NULL, NULL, 0), 0,
 	    "Unexpected mallctl failure when stopping logging");
 }


### PR DESCRIPTION
The unwinder may produce traces more than expected.  Instead verify the lower
bound only.

Corresponding to #1477 