### PR TITLE
Fix crash on NULL iealloc return  

### DIFF
--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -47,7 +47,11 @@ arena_prof_tctx_get(tsdn_t *tsdn, const void *ptr, alloc_ctx_t *alloc_ctx) {
 		}
 	} else {
 		if (unlikely(!alloc_ctx->slab)) {
-			return large_prof_tctx_get(tsdn, iealloc(tsdn, ptr));
+			extent_t *extent = iealloc(tsdn, ptr);
+			if (unlikely(extent == NULL)) {
+				return (prof_tctx_t *)(uintptr_t)1U;
+			}
+			return large_prof_tctx_get(tsdn, extent);
 		}
 	}
 	return (prof_tctx_t *)(uintptr_t)1U;
@@ -67,7 +71,11 @@ arena_prof_tctx_set(tsdn_t *tsdn, const void *ptr, size_t usize,
 		}
 	} else {
 		if (unlikely(!alloc_ctx->slab)) {
-			large_prof_tctx_set(tsdn, iealloc(tsdn, ptr), tctx);
+			extent_t *extent = iealloc(tsdn, ptr);
+			if (unlikely(extent == NULL)) {
+				return;
+			}
+			large_prof_tctx_set(tsdn, extent, tctx);
 		}
 	}
 }


### PR DESCRIPTION
Our only extra configure option is `--enable-prof`

This crash occurs once about over thousands of hours of runtime. This is the patch that we're going with to band-aid it in-house

iealloc returns NULL which is then passed down to atomic_store_p as 0x40 (via the &extent->..)