### PR TITLE
meshing: bootstrapping and some stats/ctl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -110,6 +110,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/large.c \
 	$(srcroot)src/log.c \
 	$(srcroot)src/malloc_io.c \
+	$(srcroot)src/mesh.c \
 	$(srcroot)src/mutex.c \
 	$(srcroot)src/mutex_pool.c \
 	$(srcroot)src/nstime.c \

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -25,8 +25,8 @@ void arena_basic_stats_merge(tsdn_t *tsdn, arena_t *arena,
 void arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
     const char **dss, ssize_t *dirty_decay_ms, ssize_t *muzzy_decay_ms,
     size_t *nactive, size_t *ndirty, size_t *nmuzzy, arena_stats_t *astats,
-    bin_stats_t *bstats, arena_stats_large_t *lstats,
-    arena_stats_extents_t *estats);
+    bin_stats_t *bstats, mesh_bin_stats_t *mesh_bstats,
+    arena_stats_large_t *lstats, arena_stats_extents_t *estats);
 void arena_extents_dirty_dalloc(tsdn_t *tsdn, arena_t *arena,
     extent_hooks_t **r_extent_hooks, extent_t *extent);
 #ifdef JEMALLOC_JET

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -7,6 +7,7 @@
 #include "jemalloc/internal/bitmap.h"
 #include "jemalloc/internal/extent_dss.h"
 #include "jemalloc/internal/jemalloc_internal_types.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/ql.h"
@@ -208,6 +209,8 @@ struct arena_s {
 	 * Synchronization: internal.
 	 */
 	bins_t			bins[SC_NBINS];
+
+	mesh_arena_data_t	*mesh_arena_data;
 
 	/*
 	 * Base allocator, from which arena metadata are allocated.

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -105,8 +105,7 @@ void bin_postfork_child(tsdn_t *tsdn, bin_t *bin);
 /* Stats. */
 static inline void
 bin_stats_merge(tsdn_t *tsdn, bin_stats_t *dst_bin_stats, bin_t *bin) {
-	malloc_mutex_lock(tsdn, &bin->lock);
-	malloc_mutex_prof_accum(tsdn, &dst_bin_stats->mutex_data, &bin->lock);
+	/* Must hold bin->lock */
 	dst_bin_stats->nmalloc += bin->stats.nmalloc;
 	dst_bin_stats->ndalloc += bin->stats.ndalloc;
 	dst_bin_stats->nrequests += bin->stats.nrequests;
@@ -116,7 +115,6 @@ bin_stats_merge(tsdn_t *tsdn, bin_stats_t *dst_bin_stats, bin_t *bin) {
 	dst_bin_stats->nslabs += bin->stats.nslabs;
 	dst_bin_stats->reslabs += bin->stats.reslabs;
 	dst_bin_stats->curslabs += bin->stats.curslabs;
-	malloc_mutex_unlock(tsdn, &bin->lock);
 }
 
 #endif /* JEMALLOC_INTERNAL_BIN_H */

--- a/include/jemalloc/internal/bitmap.h
+++ b/include/jemalloc/internal/bitmap.h
@@ -202,6 +202,12 @@ bitmap_get(bitmap_t *bitmap, const bitmap_info_t *binfo, size_t bit) {
 	return !(g & (ZU(1) << (bit & BITMAP_GROUP_NBITS_MASK)));
 }
 
+static inline uint8_t
+bitmap_get_first_logical_byte(bitmap_t *bitmap, const bitmap_info_t *binfo) {
+	assert(binfo->nbits <= 8);
+	return ~((uint8_t)bitmap[0] & 0xff);
+}
+
 static inline void
 bitmap_set(bitmap_t *bitmap, const bitmap_info_t *binfo, size_t bit) {
 	size_t goff;

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -3,13 +3,14 @@
 
 #include "jemalloc/internal/jemalloc_internal_types.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex_prof.h"
 #include "jemalloc/internal/ql.h"
 #include "jemalloc/internal/sc.h"
 #include "jemalloc/internal/stats.h"
 
 /* Maximum ctl tree depth. */
-#define CTL_MAX_DEPTH	7
+#define CTL_MAX_DEPTH	9
 
 typedef struct ctl_node_s {
 	bool named;
@@ -41,6 +42,7 @@ typedef struct ctl_arena_stats_s {
 	uint64_t nrequests_small;
 
 	bin_stats_t bstats[SC_NBINS];
+	mesh_bin_stats_t mesh_bstats[SC_NBINS];
 	arena_stats_large_t lstats[SC_NSIZES - SC_NBINS];
 	arena_stats_extents_t estats[SC_NPSIZES];
 } ctl_arena_stats_t;

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -1,0 +1,5 @@
+#ifndef JEMALLOC_INTERNAL_MESH_H
+#define JEMALLOC_INTERNAL_MESH_H
+
+extern bool opt_mesh;
+#endif /* JEMALLOC_INTERNAL_H */

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -20,6 +20,7 @@ struct mesh_arena_data_s {
 	mesh_bin_datas_t *bin_datas;
 };
 
+bool mesh_binind_meshable(szind_t bindind);
 bool mesh_slab_is_candidate(extent_t *slab);
 void mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
     const bin_info_t *bin_info, extent_t *slab);
@@ -27,5 +28,10 @@ void mesh_slab_shape_remove(mesh_arena_data_t *data,
     arena_slab_data_t *slab_data, const bin_info_t *bin_info, extent_t *slab);
 mesh_arena_data_t * mesh_arena_data_new(tsdn_t *tsdn, base_t *base);
 bool mesh_boot(void);
+
+/* Stats. */
+void mesh_bin_stats_merge(tsdn_t *tsdn, mesh_bin_stats_t *dst_mesh_bin_stats,
+    mesh_arena_data_t *mesh_arena_data, bin_t *bin, szind_t binind,
+    unsigned binshard);
 
 #endif /* JEMALLOC_INTERNAL_MESH_H */

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -1,5 +1,31 @@
 #ifndef JEMALLOC_INTERNAL_MESH_H
 #define JEMALLOC_INTERNAL_MESH_H
 
+#include "jemalloc/internal/mesh_stats.h"
+
 extern bool opt_mesh;
-#endif /* JEMALLOC_INTERNAL_H */
+
+typedef struct mesh_bin_data_s mesh_bin_data_t;
+struct mesh_bin_data_s {
+	mesh_bin_stats_t	stats;
+};
+
+typedef struct mesh_bin_datas_s mesh_bin_datas_t;
+struct mesh_bin_datas_s {
+	mesh_bin_data_t *bin_data_shards;
+};
+
+typedef struct mesh_arena_data_s mesh_arena_data_t;
+struct mesh_arena_data_s {
+	mesh_bin_datas_t *bin_datas;
+};
+
+bool mesh_slab_is_candidate(extent_t *slab);
+void mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab);
+void mesh_slab_shape_remove(mesh_arena_data_t *data,
+    arena_slab_data_t *slab_data, const bin_info_t *bin_info, extent_t *slab);
+mesh_arena_data_t * mesh_arena_data_new(tsdn_t *tsdn, base_t *base);
+bool mesh_boot(void);
+
+#endif /* JEMALLOC_INTERNAL_MESH_H */

--- a/include/jemalloc/internal/mesh_stats.h
+++ b/include/jemalloc/internal/mesh_stats.h
@@ -1,0 +1,9 @@
+#ifndef JEMALLOC_INTERNAL_MESH_STATS_H
+#define JEMALLOC_INTERNAL_MESH_STATS_H
+
+typedef struct mesh_bin_stats_s mesh_bin_stats_t;
+struct mesh_bin_stats_s {
+        unsigned        shape_counts[1 << 8];
+};
+
+#endif /* JEMALLOC_INTERNAL_MESH_STATS_H */

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -171,7 +171,9 @@ CTL_PROTO(stats_arenas_i_bins_j_nflushes)
 CTL_PROTO(stats_arenas_i_bins_j_nslabs)
 CTL_PROTO(stats_arenas_i_bins_j_nreslabs)
 CTL_PROTO(stats_arenas_i_bins_j_curslabs)
+CTL_PROTO(stats_arenas_i_bins_j_mesh_shape_counts_k_count)
 INDEX_PROTO(stats_arenas_i_bins_j)
+INDEX_PROTO(stats_arenas_i_bins_j_mesh_shape_counts_k)
 CTL_PROTO(stats_arenas_i_lextents_j_nmalloc)
 CTL_PROTO(stats_arenas_i_lextents_j_ndalloc)
 CTL_PROTO(stats_arenas_i_lextents_j_nrequests)
@@ -447,6 +449,28 @@ static const ctl_named_node_t stats_##prefix##_node[] = {		\
 
 MUTEX_PROF_DATA_NODE(arenas_i_bins_j_mutex)
 
+static const ctl_named_node_t
+stats_arenas_i_bins_j_mesh_shape_counts_k_node[] = {
+	{NAME("count"),
+	    CTL(stats_arenas_i_bins_j_mesh_shape_counts_k_count)}
+};
+
+static const ctl_named_node_t
+super_stats_arenas_i_bins_j_mesh_shape_counts_k_node[] = {
+	{NAME(""),
+		CHILD(named, stats_arenas_i_bins_j_mesh_shape_counts_k)}
+};
+
+static const ctl_indexed_node_t
+stats_arenas_i_bins_j_mesh_shape_counts_node[] = {
+	{INDEX(stats_arenas_i_bins_j_mesh_shape_counts_k)}
+};
+
+static const ctl_named_node_t stats_arenas_i_bins_j_mesh_node[] = {
+	{NAME("shape_counts"),
+	    CHILD(indexed, stats_arenas_i_bins_j_mesh_shape_counts)},
+};
+
 static const ctl_named_node_t stats_arenas_i_bins_j_node[] = {
 	{NAME("nmalloc"),	CTL(stats_arenas_i_bins_j_nmalloc)},
 	{NAME("ndalloc"),	CTL(stats_arenas_i_bins_j_ndalloc)},
@@ -457,7 +481,8 @@ static const ctl_named_node_t stats_arenas_i_bins_j_node[] = {
 	{NAME("nslabs"),	CTL(stats_arenas_i_bins_j_nslabs)},
 	{NAME("nreslabs"),	CTL(stats_arenas_i_bins_j_nreslabs)},
 	{NAME("curslabs"),	CTL(stats_arenas_i_bins_j_curslabs)},
-	{NAME("mutex"),		CHILD(named, stats_arenas_i_bins_j_mutex)}
+	{NAME("mutex"),		CHILD(named, stats_arenas_i_bins_j_mutex)},
+	{NAME("mesh"),		CHILD(named, stats_arenas_i_bins_j_mesh)}
 };
 
 static const ctl_named_node_t super_stats_arenas_i_bins_j_node[] = {
@@ -757,6 +782,8 @@ ctl_arena_clear(ctl_arena_t *ctl_arena) {
 		ctl_arena->astats->nrequests_small = 0;
 		memset(ctl_arena->astats->bstats, 0, SC_NBINS *
 		    sizeof(bin_stats_t));
+		memset(ctl_arena->astats->mesh_bstats, 0, SC_NBINS *
+		    sizeof(mesh_bin_stats_t));
 		memset(ctl_arena->astats->lstats, 0, (SC_NSIZES - SC_NBINS) *
 		    sizeof(arena_stats_large_t));
 		memset(ctl_arena->astats->estats, 0, SC_NPSIZES *
@@ -774,6 +801,7 @@ ctl_arena_stats_amerge(tsdn_t *tsdn, ctl_arena_t *ctl_arena, arena_t *arena) {
 		    &ctl_arena->muzzy_decay_ms, &ctl_arena->pactive,
 		    &ctl_arena->pdirty, &ctl_arena->pmuzzy,
 		    &ctl_arena->astats->astats, ctl_arena->astats->bstats,
+		    ctl_arena->astats->mesh_bstats,
 		    ctl_arena->astats->lstats, ctl_arena->astats->estats);
 
 		for (i = 0; i < SC_NBINS; i++) {
@@ -792,6 +820,19 @@ ctl_arena_stats_amerge(tsdn_t *tsdn, ctl_arena_t *ctl_arena, arena_t *arena) {
 		    &ctl_arena->dss, &ctl_arena->dirty_decay_ms,
 		    &ctl_arena->muzzy_decay_ms, &ctl_arena->pactive,
 		    &ctl_arena->pdirty, &ctl_arena->pmuzzy);
+	}
+}
+
+static void
+ctl_sum_mesh_shape_counts(mesh_bin_stats_t *dst, mesh_bin_stats_t *src,
+    bool destroyed) {
+	unsigned i;
+	for (i = 0; i < (1 << 8); i++) {
+		if (!destroyed) {
+			dst->shape_counts[i] += src->shape_counts[i];
+		} else {
+			assert(src->shape_counts[i] == 0);
+		}
 	}
 }
 
@@ -912,6 +953,12 @@ MUTEX_PROF_ARENA_MUTEXES
 				    astats->bstats[i].curslabs;
 			} else {
 				assert(astats->bstats[i].curslabs == 0);
+			}
+			if (opt_mesh && mesh_binind_meshable(i)) {
+				ctl_sum_mesh_shape_counts(
+				    &sdstats->mesh_bstats[i],
+				    &astats->mesh_bstats[i],
+				    destroyed);
 			}
 			malloc_mutex_prof_merge(&sdstats->bstats[i].mutex_data,
 			    &astats->bstats[i].mutex_data);
@@ -2970,6 +3017,8 @@ CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_nreslabs,
     arenas_i(mib[2])->astats->bstats[mib[4]].reslabs, uint64_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_curslabs,
     arenas_i(mib[2])->astats->bstats[mib[4]].curslabs, size_t)
+CTL_RO_CGEN(config_stats, stats_arenas_i_bins_j_mesh_shape_counts_k_count,
+    arenas_i(mib[2])->astats->mesh_bstats[mib[4]].shape_counts[mib[7]], size_t)
 
 static const ctl_named_node_t *
 stats_arenas_i_bins_j_index(tsdn_t *tsdn, const size_t *mib,
@@ -2978,6 +3027,15 @@ stats_arenas_i_bins_j_index(tsdn_t *tsdn, const size_t *mib,
 		return NULL;
 	}
 	return super_stats_arenas_i_bins_j_node;
+}
+
+static const ctl_named_node_t *
+stats_arenas_i_bins_j_mesh_shape_counts_k_index(tsdn_t *tsdn, const size_t *mib,
+    size_t miblen, size_t k) {
+	if (k >= (1 << 8)) {
+		return NULL;
+	}
+	return super_stats_arenas_i_bins_j_mesh_shape_counts_k_node;
 }
 
 CTL_RO_CGEN(config_stats, stats_arenas_i_lextents_j_nmalloc,
@@ -2990,7 +3048,7 @@ CTL_RO_CGEN(config_stats, stats_arenas_i_lextents_j_nrequests,
     ctl_arena_stats_read_u64(
     &arenas_i(mib[2])->astats->lstats[mib[4]].nrequests), uint64_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_lextents_j_curlextents,
-    arenas_i(mib[2])->astats->lstats[mib[4]].curlextents, size_t)
+    arenas_i(mib[2])->astats->lstats[mib[4]].curlextents, uint64_t)
 
 static const ctl_named_node_t *
 stats_arenas_i_lextents_j_index(tsdn_t *tsdn, const size_t *mib,

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -6,6 +6,7 @@
 #include "jemalloc/internal/ctl.h"
 #include "jemalloc/internal/extent_dss.h"
 #include "jemalloc/internal/extent_mmap.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/sc.h"
@@ -89,6 +90,7 @@ CTL_PROTO(opt_percpu_arena)
 CTL_PROTO(opt_oversize_threshold)
 CTL_PROTO(opt_background_thread)
 CTL_PROTO(opt_max_background_threads)
+CTL_PROTO(opt_mesh)
 CTL_PROTO(opt_dirty_decay_ms)
 CTL_PROTO(opt_muzzy_decay_ms)
 CTL_PROTO(opt_stats_print)
@@ -307,6 +309,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("oversize_threshold"),	CTL(opt_oversize_threshold)},
 	{NAME("background_thread"),	CTL(opt_background_thread)},
 	{NAME("max_background_threads"),	CTL(opt_max_background_threads)},
+	{NAME("mesh"),		CTL(opt_mesh)},
 	{NAME("dirty_decay_ms"), CTL(opt_dirty_decay_ms)},
 	{NAME("muzzy_decay_ms"), CTL(opt_muzzy_decay_ms)},
 	{NAME("stats_print"),	CTL(opt_stats_print)},
@@ -1730,6 +1733,7 @@ CTL_RO_NL_GEN(opt_percpu_arena, percpu_arena_mode_names[opt_percpu_arena],
 CTL_RO_NL_GEN(opt_oversize_threshold, opt_oversize_threshold, size_t)
 CTL_RO_NL_GEN(opt_background_thread, opt_background_thread, bool)
 CTL_RO_NL_GEN(opt_max_background_threads, opt_max_background_threads, size_t)
+CTL_RO_NL_GEN(opt_mesh, opt_mesh, bool)
 CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1474,6 +1474,11 @@ malloc_init_hard_a0_locked() {
 		return true;
 	}
 	hook_boot();
+	if (opt_mesh) {
+		if (mesh_boot()) {
+			return true;
+		}
+	}
 	/*
 	 * Create enough scaffolding to allow recursive allocation in
 	 * malloc_ncpus().

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -11,6 +11,7 @@
 #include "jemalloc/internal/jemalloc_internal_types.h"
 #include "jemalloc/internal/log.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/safety_check.h"
@@ -1237,6 +1238,7 @@ malloc_conf_init(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS]) {
 				CONF_HANDLE_BOOL(opt_xmalloc, "xmalloc")
 			}
 			CONF_HANDLE_BOOL(opt_tcache, "tcache")
+			CONF_HANDLE_BOOL(opt_mesh, "mesh")
 			CONF_HANDLE_SSIZE_T(opt_lg_tcache_max, "lg_tcache_max",
 			    -1, (sizeof(size_t) << 3) - 1)
 

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -1,0 +1,5 @@
+#define JEMALLOC_MESH_C_
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+bool opt_mesh = false;

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -13,11 +13,17 @@ unsigned binind_to_meshind_table[SC_NBINS];
 unsigned meshind_to_binind_table[SC_NBINS];
 
 bool
-mesh_slab_is_candidate(extent_t *slab) {
-	szind_t binind = extent_szind_get(slab);
+mesh_binind_meshable(szind_t binind) {
+	assert(binind < SC_NBINS);
 	unsigned meshind = binind_to_meshind_table[binind];
 	assert(meshind < nmeshable_scs || meshind == SC_NBINS);
 	return meshind != SC_NBINS;
+}
+
+bool
+mesh_slab_is_candidate(extent_t *slab) {
+	szind_t binind = extent_szind_get(slab);
+	return mesh_binind_meshable(binind);
 }
 
 static void
@@ -128,4 +134,23 @@ mesh_boot(void) {
 	}
 
 	return nmeshable_scs == 0;
+}
+
+/* Stats. */
+inline void
+mesh_bin_stats_merge(tsdn_t *tsdn, mesh_bin_stats_t *dst_mesh_bin_stats,
+    mesh_arena_data_t *mesh_arena_data, bin_t *bin, szind_t binind,
+    unsigned binshard) {
+	unsigned meshind = binind_to_meshind_table[binind];
+	if (meshind == SC_NBINS) {
+		return;
+	}
+	mesh_bin_datas_t *mesh_bin_datas =
+	    &mesh_arena_data->bin_datas[meshind];
+	mesh_bin_stats_t *mesh_bin_stats =
+	    &mesh_bin_datas->bin_data_shards[binshard].stats;
+	for (unsigned i = 0; i < (1 << 8); i++) {
+		dst_mesh_bin_stats->shape_counts[i] +=
+		    mesh_bin_stats->shape_counts[i];
+	}
 }

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -2,4 +2,130 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
+#include "jemalloc/internal/mesh.h"
+
 bool opt_mesh = false;
+
+unsigned nmeshable_scs;
+unsigned nmeshable_bins_per_arena;
+unsigned binind_to_meshind_table[SC_NBINS];
+// (SC_NBINS - nmeshable_scs) unused at end
+unsigned meshind_to_binind_table[SC_NBINS];
+
+bool
+mesh_slab_is_candidate(extent_t *slab) {
+	szind_t binind = extent_szind_get(slab);
+	unsigned meshind = binind_to_meshind_table[binind];
+	assert(meshind < nmeshable_scs || meshind == SC_NBINS);
+	return meshind != SC_NBINS;
+}
+
+static void
+insert_into_bin_data(mesh_bin_data_t *bin_data, uint8_t key, extent_t *slab) {
+	if (config_stats) {
+		bin_data->stats.shape_counts[key]++;
+	}
+}
+
+static void
+remove_from_bin_data(mesh_bin_data_t *bin_data, uint8_t key, extent_t *slab) {
+	if (config_stats) {
+		assert(bin_data->stats.shape_counts[key] != 0);
+		bin_data->stats.shape_counts[key]--;
+	}
+}
+
+static mesh_bin_data_t *
+get_bin_data_for_slab(mesh_arena_data_t *data, const bin_info_t *bin_info,
+    extent_t *slab) {
+	szind_t binind = extent_szind_get(slab);
+	unsigned meshind = binind_to_meshind_table[binind];
+	assert(meshind != SC_NBINS);
+	unsigned shard = extent_binshard_get(slab);
+	return &data->bin_datas[meshind].bin_data_shards[shard];
+}
+
+void
+mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab) {
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+	assert(extent_nfree_get(slab) != bin_info->nregs);
+
+	mesh_bin_data_t *bin_data = get_bin_data_for_slab(data, bin_info, slab);
+	uint8_t key = bitmap_get_first_logical_byte(slab_data->bitmap,
+	    &bin_info->bitmap_info);
+	insert_into_bin_data(bin_data, key, slab);
+}
+
+void
+mesh_slab_shape_remove(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab) {
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+	assert(extent_nfree_get(slab) != bin_info->nregs);
+
+	mesh_bin_data_t *bin_data = get_bin_data_for_slab(data, bin_info, slab);
+	uint8_t key = bitmap_get_first_logical_byte(slab_data->bitmap,
+	    &bin_info->bitmap_info);
+	remove_from_bin_data(bin_data, key, slab);
+}
+
+static void
+bin_data_init(mesh_bin_data_t *bin_data) {
+	if (config_stats) {
+		memset(&bin_data->stats, sizeof(mesh_bin_stats_t), 0x0);
+	}
+}
+
+mesh_arena_data_t *
+mesh_arena_data_new(tsdn_t *tsdn, base_t *base) {
+	size_t size = sizeof(mesh_arena_data_t) +
+	    nmeshable_scs * sizeof(mesh_bin_datas_t);
+	mesh_arena_data_t *arena_data = (mesh_arena_data_t *)base_alloc(
+	    tsdn, base, size, CACHELINE);
+
+	arena_data->bin_datas = (mesh_bin_datas_t *)(arena_data + 1);
+
+	size = sizeof(mesh_bin_data_t) * nmeshable_bins_per_arena;
+
+	mesh_bin_data_t *bin_data_base = (mesh_bin_data_t *)base_alloc(
+	    tsdn, base, size, CACHELINE);
+	uintptr_t bin_data_addr = (uintptr_t)bin_data_base;
+
+	for (size_t i = 0; i < nmeshable_scs; i++) {
+		mesh_bin_datas_t *mesh_bin_datas = &arena_data->bin_datas[i];
+		mesh_bin_data_t *addr = (mesh_bin_data_t *)bin_data_addr;
+		mesh_bin_datas->bin_data_shards = addr;
+
+		unsigned binind = meshind_to_binind_table[i];
+		bin_data_addr += sizeof(mesh_bin_data_t) *
+		    bin_infos[binind].n_shards;
+	}
+	assert(bin_data_addr == (uintptr_t)bin_data_base + size);
+
+	for (size_t i = 0; i < nmeshable_bins_per_arena; i++) {
+		bin_data_init(&bin_data_base[i]);
+	}
+	return arena_data;
+}
+
+
+bool
+mesh_boot(void) {
+	nmeshable_scs = 0;
+	nmeshable_bins_per_arena = 0;
+	for (size_t i = 0; i < SC_NBINS; i++) {
+		if (bin_infos[i].nregs <= 8 && bin_infos[i].nregs > 1) {
+			meshind_to_binind_table[nmeshable_scs] = i;
+			binind_to_meshind_table[i] = nmeshable_scs++;
+			nmeshable_bins_per_arena += bin_infos[i].n_shards;
+		} else {
+			binind_to_meshind_table[i] = SC_NBINS;
+		}
+	}
+
+	for (size_t i = nmeshable_scs; i < SC_NBINS; i++) {
+		meshind_to_binind_table[nmeshable_scs] = SC_NBINS;
+	}
+
+	return nmeshable_scs == 0;
+}


### PR DESCRIPTION
These 3 commits add features that are primarily all behind the new `opt_mesh` option which defaults to false. Overhead for programs with `opt_mesh:false` should hopefully be little to none: 1 NULL ptr in arena_t, as well as some branches based off of the value of `opt_mesh` on removal/insertion into slabs->nonfull and arena_dalloc_bin_locked_impl in src/arena.c

The end result of this stack of commits is that programs with `opt_mesh` will have stats available on the number of nonfull slabs with each possible 8 bit mesh shape. This should be useful in assessing the possible benefits of a mesh approach based on an exhaustive search of slabs with nregs <= 8.

I'm not a fan of the pervasive `(1 << 8)` everywhere that needs to logically represent the number of possible 8 bit mesh shapes, so I would definitely welcome feedback on how to improve that. 