### PR TITLE
Mesh5

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -110,6 +110,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/large.c \
 	$(srcroot)src/log.c \
 	$(srcroot)src/malloc_io.c \
+	$(srcroot)src/mesh.c \
 	$(srcroot)src/mutex.c \
 	$(srcroot)src/mutex_pool.c \
 	$(srcroot)src/nstime.c \

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -25,8 +25,8 @@ void arena_basic_stats_merge(tsdn_t *tsdn, arena_t *arena,
 void arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
     const char **dss, ssize_t *dirty_decay_ms, ssize_t *muzzy_decay_ms,
     size_t *nactive, size_t *ndirty, size_t *nmuzzy, arena_stats_t *astats,
-    bin_stats_t *bstats, arena_stats_large_t *lstats,
-    arena_stats_extents_t *estats);
+    bin_stats_t *bstats, mesh_bin_stats_t *mesh_bstats,
+    arena_stats_large_t *lstats, arena_stats_extents_t *estats);
 void arena_extents_dirty_dalloc(tsdn_t *tsdn, arena_t *arena,
     extent_hooks_t **r_extent_hooks, extent_t *extent);
 #ifdef JEMALLOC_JET

--- a/include/jemalloc/internal/arena_inlines_a.h
+++ b/include/jemalloc/internal/arena_inlines_a.h
@@ -1,6 +1,28 @@
 #ifndef JEMALLOC_INTERNAL_ARENA_INLINES_A_H
 #define JEMALLOC_INTERNAL_ARENA_INLINES_A_H
 
+static inline void
+arena_slab_data_init(extent_t *slab, arena_slab_data_t *slab_data,
+    const bitmap_info_t *binfo, bool fill) {
+	if (binfo->nbits <= 8) {
+		bitmap_init(&slab_data->internal.mesh_data.bitmap,
+		    binfo, fill);
+		ql_elm_new(slab, e_slab_data.internal.mesh_data.ql_link);
+	} else {
+		bitmap_init(slab_data->internal.full_bitmap,
+		    binfo, fill);
+	}
+}
+
+static inline bitmap_t *
+arena_slab_data_bitmap_get(arena_slab_data_t *slab_data, const bitmap_info_t *binfo) {
+	if (binfo->nbits <= 8) {
+		return &slab_data->internal.mesh_data.bitmap;
+	} else {
+		return slab_data->internal.full_bitmap;
+	}
+}
+
 static inline unsigned
 arena_ind_get(const arena_t *arena) {
 	return base_ind_get(arena->base);

--- a/include/jemalloc/internal/arena_structs_a.h
+++ b/include/jemalloc/internal/arena_structs_a.h
@@ -2,10 +2,19 @@
 #define JEMALLOC_INTERNAL_ARENA_STRUCTS_A_H
 
 #include "jemalloc/internal/bitmap.h"
+#include "jemalloc/internal/ql.h"
 
 struct arena_slab_data_s {
-	/* Per region allocated/deallocated bitmap. */
-	bitmap_t	bitmap[BITMAP_GROUPS_MAX];
+	struct {
+		/* Per region allocated/deallocated bitmap. */
+		union {
+			bitmap_t	full_bitmap[BITMAP_GROUPS_MAX];
+			struct {
+				bitmap_t		bitmap;
+				ql_elm(extent_t)        ql_link;
+			} mesh_data;
+		};
+	} internal;
 };
 
 #endif /* JEMALLOC_INTERNAL_ARENA_STRUCTS_A_H */

--- a/include/jemalloc/internal/arena_structs_b.h
+++ b/include/jemalloc/internal/arena_structs_b.h
@@ -7,6 +7,7 @@
 #include "jemalloc/internal/bitmap.h"
 #include "jemalloc/internal/extent_dss.h"
 #include "jemalloc/internal/jemalloc_internal_types.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/ql.h"
@@ -208,6 +209,8 @@ struct arena_s {
 	 * Synchronization: internal.
 	 */
 	bins_t			bins[SC_NBINS];
+
+	mesh_arena_data_t	*mesh_arena_data;
 
 	/*
 	 * Base allocator, from which arena metadata are allocated.

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -105,8 +105,7 @@ void bin_postfork_child(tsdn_t *tsdn, bin_t *bin);
 /* Stats. */
 static inline void
 bin_stats_merge(tsdn_t *tsdn, bin_stats_t *dst_bin_stats, bin_t *bin) {
-	malloc_mutex_lock(tsdn, &bin->lock);
-	malloc_mutex_prof_accum(tsdn, &dst_bin_stats->mutex_data, &bin->lock);
+	/* Must hold bin->lock */
 	dst_bin_stats->nmalloc += bin->stats.nmalloc;
 	dst_bin_stats->ndalloc += bin->stats.ndalloc;
 	dst_bin_stats->nrequests += bin->stats.nrequests;
@@ -116,7 +115,6 @@ bin_stats_merge(tsdn_t *tsdn, bin_stats_t *dst_bin_stats, bin_t *bin) {
 	dst_bin_stats->nslabs += bin->stats.nslabs;
 	dst_bin_stats->reslabs += bin->stats.reslabs;
 	dst_bin_stats->curslabs += bin->stats.curslabs;
-	malloc_mutex_unlock(tsdn, &bin->lock);
 }
 
 #endif /* JEMALLOC_INTERNAL_BIN_H */

--- a/include/jemalloc/internal/bitmap.h
+++ b/include/jemalloc/internal/bitmap.h
@@ -202,6 +202,12 @@ bitmap_get(bitmap_t *bitmap, const bitmap_info_t *binfo, size_t bit) {
 	return !(g & (ZU(1) << (bit & BITMAP_GROUP_NBITS_MASK)));
 }
 
+static inline uint8_t
+bitmap_get_first_logical_byte(bitmap_t *bitmap, const bitmap_info_t *binfo) {
+	assert(binfo->nbits <= 8);
+	return ~((uint8_t)bitmap[0] & 0xff);
+}
+
 static inline void
 bitmap_set(bitmap_t *bitmap, const bitmap_info_t *binfo, size_t bit) {
 	size_t goff;

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -3,13 +3,14 @@
 
 #include "jemalloc/internal/jemalloc_internal_types.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex_prof.h"
 #include "jemalloc/internal/ql.h"
 #include "jemalloc/internal/sc.h"
 #include "jemalloc/internal/stats.h"
 
 /* Maximum ctl tree depth. */
-#define CTL_MAX_DEPTH	7
+#define CTL_MAX_DEPTH	9
 
 typedef struct ctl_node_s {
 	bool named;
@@ -41,6 +42,7 @@ typedef struct ctl_arena_stats_s {
 	uint64_t nrequests_small;
 
 	bin_stats_t bstats[SC_NBINS];
+	mesh_bin_stats_t mesh_bstats[SC_NBINS];
 	arena_stats_large_t lstats[SC_NSIZES - SC_NBINS];
 	arena_stats_extents_t estats[SC_NPSIZES];
 } ctl_arena_stats_t;

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -1,0 +1,5 @@
+#ifndef JEMALLOC_INTERNAL_MESH_H
+#define JEMALLOC_INTERNAL_MESH_H
+
+extern bool opt_mesh;
+#endif /* JEMALLOC_INTERNAL_H */

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -7,6 +7,7 @@ extern bool opt_mesh;
 
 typedef struct mesh_bin_data_s mesh_bin_data_t;
 struct mesh_bin_data_s {
+	extent_list_t		shape_table[1 << 8];
 	mesh_bin_stats_t	stats;
 };
 

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -20,6 +20,7 @@ struct mesh_arena_data_s {
 	mesh_bin_datas_t *bin_datas;
 };
 
+bool mesh_binind_meshable(szind_t bindind);
 bool mesh_slab_is_candidate(extent_t *slab);
 void mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
     const bin_info_t *bin_info, extent_t *slab);
@@ -27,5 +28,10 @@ void mesh_slab_shape_remove(mesh_arena_data_t *data,
     arena_slab_data_t *slab_data, const bin_info_t *bin_info, extent_t *slab);
 mesh_arena_data_t * mesh_arena_data_new(tsdn_t *tsdn, base_t *base);
 bool mesh_boot(void);
+
+/* Stats. */
+void mesh_bin_stats_merge(tsdn_t *tsdn, mesh_bin_stats_t *dst_mesh_bin_stats,
+    mesh_arena_data_t *mesh_arena_data, bin_t *bin, szind_t binind,
+    unsigned binshard);
 
 #endif /* JEMALLOC_INTERNAL_MESH_H */

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -4,6 +4,7 @@
 #include "jemalloc/internal/mesh_stats.h"
 
 extern bool opt_mesh;
+extern bool opt_mesh_bin_data_jit;
 
 typedef struct mesh_bin_data_s mesh_bin_data_t;
 struct mesh_bin_data_s {
@@ -21,6 +22,13 @@ struct mesh_arena_data_s {
 	mesh_bin_datas_t *bin_datas;
 };
 
+static inline bool
+mesh_should_update_shape() {
+	return opt_mesh && !opt_mesh_bin_data_jit;
+}
+
+void mesh_populate_bin_data(bin_t *bin, const bitmap_info_t *binfo,
+    mesh_bin_data_t *bin_data);
 bool mesh_binind_meshable(szind_t bindind);
 bool mesh_slab_is_candidate(extent_t *slab);
 void mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,

--- a/include/jemalloc/internal/mesh.h
+++ b/include/jemalloc/internal/mesh.h
@@ -1,5 +1,31 @@
 #ifndef JEMALLOC_INTERNAL_MESH_H
 #define JEMALLOC_INTERNAL_MESH_H
 
+#include "jemalloc/internal/mesh_stats.h"
+
 extern bool opt_mesh;
-#endif /* JEMALLOC_INTERNAL_H */
+
+typedef struct mesh_bin_data_s mesh_bin_data_t;
+struct mesh_bin_data_s {
+	mesh_bin_stats_t	stats;
+};
+
+typedef struct mesh_bin_datas_s mesh_bin_datas_t;
+struct mesh_bin_datas_s {
+	mesh_bin_data_t *bin_data_shards;
+};
+
+typedef struct mesh_arena_data_s mesh_arena_data_t;
+struct mesh_arena_data_s {
+	mesh_bin_datas_t *bin_datas;
+};
+
+bool mesh_slab_is_candidate(extent_t *slab);
+void mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab);
+void mesh_slab_shape_remove(mesh_arena_data_t *data,
+    arena_slab_data_t *slab_data, const bin_info_t *bin_info, extent_t *slab);
+mesh_arena_data_t * mesh_arena_data_new(tsdn_t *tsdn, base_t *base);
+bool mesh_boot(void);
+
+#endif /* JEMALLOC_INTERNAL_MESH_H */

--- a/include/jemalloc/internal/mesh_stats.h
+++ b/include/jemalloc/internal/mesh_stats.h
@@ -1,0 +1,9 @@
+#ifndef JEMALLOC_INTERNAL_MESH_STATS_H
+#define JEMALLOC_INTERNAL_MESH_STATS_H
+
+typedef struct mesh_bin_stats_s mesh_bin_stats_t;
+struct mesh_bin_stats_s {
+        unsigned        shape_counts[1 << 8];
+};
+
+#endif /* JEMALLOC_INTERNAL_MESH_STATS_H */

--- a/src/arena.c
+++ b/src/arena.c
@@ -1019,7 +1019,7 @@ arena_bin_slabs_nonfull_insert(arena_t *arena, bin_t *bin,
     const bin_info_t *bin_info, extent_t *slab) {
 	assert(extent_nfree_get(slab) > 0);
 	extent_heap_insert(&bin->slabs_nonfull, slab);
-	if (opt_mesh && mesh_slab_is_candidate(slab)) {
+	if (mesh_should_update_shape() && mesh_slab_is_candidate(slab)) {
 		arena_slab_data_t *slab_data = extent_slab_data_get(slab);
 		mesh_slab_shape_add(arena->mesh_arena_data, slab_data, bin_info,
 		    slab);
@@ -1038,7 +1038,7 @@ arena_bin_slabs_nonfull_tryget(arena_t *arena, bin_t *bin,
 	if (slab == NULL) {
 		return NULL;
 	}
-	if (opt_mesh && mesh_slab_is_candidate(slab)) {
+	if (mesh_should_update_shape() && mesh_slab_is_candidate(slab)) {
 		arena_slab_data_t *slab_data = extent_slab_data_get(slab);
 		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data,
 		    bin_info, slab);
@@ -1701,12 +1701,13 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 		arena_dalloc_junk_small(ptr, bin_info);
 	}
 
-	/* If slab is not full, then its mesh shape is tracked 
+	/* If slab is not full, then its mesh shape is tracked
 	   and needs to be invalidated. */
 	bitmap_t *bitmap = arena_slab_data_bitmap_get(slab_data,
 	    &bin_info->bitmap_info);
-	if (opt_mesh && slab != bin->slabcur && mesh_slab_is_candidate(slab) &&
-	    !bitmap_full(bitmap, &bin_info->bitmap_info)) {
+	if (mesh_should_update_shape() && slab != bin->slabcur &&
+	    mesh_slab_is_candidate(slab) && !bitmap_full(
+	    bitmap, &bin_info->bitmap_info)) {
 		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data,
 		bin_info, slab);
 	}
@@ -1719,7 +1720,7 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 	} else if (nfree == 1 && slab != bin->slabcur) {
 		arena_bin_slabs_full_remove(arena, bin, slab);
 		arena_bin_lower_slab(tsdn, arena, slab, bin, bin_info);
-	} else if (opt_mesh && slab != bin->slabcur &&
+	} else if (mesh_should_update_shape() && slab != bin->slabcur &&
 		   mesh_slab_is_candidate(slab) && nfree != bin_info->nregs) {
 		// If slab is not empty, then track its mesh shape
 		mesh_slab_shape_add(arena->mesh_arena_data, slab_data,
@@ -2104,9 +2105,6 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 
 	if (opt_mesh) {
 		arena->mesh_arena_data = mesh_arena_data_new(tsdn, base);
-		if (arena->mesh_arena_data == NULL) {
-			goto label_error;
-		}
 	}
 
 	arena->base = base;

--- a/src/arena.c
+++ b/src/arena.c
@@ -84,8 +84,8 @@ void
 arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
     const char **dss, ssize_t *dirty_decay_ms, ssize_t *muzzy_decay_ms,
     size_t *nactive, size_t *ndirty, size_t *nmuzzy, arena_stats_t *astats,
-    bin_stats_t *bstats, arena_stats_large_t *lstats,
-    arena_stats_extents_t *estats) {
+    bin_stats_t *bstats, mesh_bin_stats_t *mesh_bstats,
+    arena_stats_large_t *lstats, arena_stats_extents_t *estats) {
 	cassert(config_stats);
 
 	arena_basic_stats_merge(tsdn, arena, nthreads, dss, dirty_decay_ms,
@@ -236,8 +236,17 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 
 	for (szind_t i = 0; i < SC_NBINS; i++) {
 		for (unsigned j = 0; j < bin_infos[i].n_shards; j++) {
-			bin_stats_merge(tsdn, &bstats[i],
-			    &arena->bins[i].bin_shards[j]);
+			bin_t *bin = &arena->bins[i].bin_shards[j];
+			malloc_mutex_lock(tsdn, &bin->lock);
+			bin_stats_t *dst_bin_stats = &bstats[i];
+			malloc_mutex_prof_accum(tsdn,
+			    &dst_bin_stats->mutex_data, &bin->lock);
+			bin_stats_merge(tsdn, dst_bin_stats, bin);
+			if (opt_mesh) {
+				mesh_bin_stats_merge(tsdn, &mesh_bstats[i],
+			    arena->mesh_arena_data, bin, i, j);
+			}
+			malloc_mutex_unlock(tsdn, &bin->lock);
 		}
 	}
 }
@@ -1017,14 +1026,16 @@ arena_bin_slabs_nonfull_remove(bin_t *bin, extent_t *slab) {
 }
 
 static extent_t *
-arena_bin_slabs_nonfull_tryget(arena_t *arena, bin_t *bin, const bin_info_t *bin_info) {
+arena_bin_slabs_nonfull_tryget(arena_t *arena, bin_t *bin,
+    const bin_info_t *bin_info) {
 	extent_t *slab = extent_heap_remove_first(&bin->slabs_nonfull);
 	if (slab == NULL) {
 		return NULL;
 	}
 	if (opt_mesh && mesh_slab_is_candidate(slab)) {
 		arena_slab_data_t *slab_data = extent_slab_data_get(slab);
-		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data, bin_info, slab);
+		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data,
+		    bin_info, slab);
 	}
 	if (config_stats) {
 		bin->stats.reslabs++;
@@ -1684,10 +1695,12 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 		arena_dalloc_junk_small(ptr, bin_info);
 	}
 
-	// If slab is not full, then its mesh shape is tracked and needs to be invalidated
+	/* If slab is not full, then its mesh shape is tracked 
+	   and needs to be invalidated. */
 	if (opt_mesh && slab != bin->slabcur && mesh_slab_is_candidate(slab) &&
 	    !bitmap_full(slab_data->bitmap, &bin_info->bitmap_info)) {
-		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data, bin_info, slab);
+		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data,
+		bin_info, slab);
 	}
 
 	arena_slab_reg_dalloc(slab, slab_data, ptr);

--- a/src/arena.c
+++ b/src/arena.c
@@ -6,6 +6,7 @@
 #include "jemalloc/internal/div.h"
 #include "jemalloc/internal/extent_dss.h"
 #include "jemalloc/internal/extent_mmap.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/safety_check.h"
@@ -62,7 +63,7 @@ static bool arena_decay_dirty(tsdn_t *tsdn, arena_t *arena,
 static void arena_dalloc_bin_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
     bin_t *bin);
 static void arena_bin_lower_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
-    bin_t *bin);
+    bin_t *bin, const bin_info_t *bin_info);
 
 /******************************************************************************/
 
@@ -999,9 +1000,15 @@ arena_slab_dalloc(tsdn_t *tsdn, arena_t *arena, extent_t *slab) {
 }
 
 static void
-arena_bin_slabs_nonfull_insert(bin_t *bin, extent_t *slab) {
+arena_bin_slabs_nonfull_insert(arena_t *arena, bin_t *bin,
+    const bin_info_t *bin_info, extent_t *slab) {
 	assert(extent_nfree_get(slab) > 0);
 	extent_heap_insert(&bin->slabs_nonfull, slab);
+	if (opt_mesh && mesh_slab_is_candidate(slab)) {
+		arena_slab_data_t *slab_data = extent_slab_data_get(slab);
+		mesh_slab_shape_add(arena->mesh_arena_data, slab_data, bin_info,
+		    slab);
+	}
 }
 
 static void
@@ -1010,10 +1017,14 @@ arena_bin_slabs_nonfull_remove(bin_t *bin, extent_t *slab) {
 }
 
 static extent_t *
-arena_bin_slabs_nonfull_tryget(bin_t *bin) {
+arena_bin_slabs_nonfull_tryget(arena_t *arena, bin_t *bin, const bin_info_t *bin_info) {
 	extent_t *slab = extent_heap_remove_first(&bin->slabs_nonfull);
 	if (slab == NULL) {
 		return NULL;
+	}
+	if (opt_mesh && mesh_slab_is_candidate(slab)) {
+		arena_slab_data_t *slab_data = extent_slab_data_get(slab);
+		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data, bin_info, slab);
 	}
 	if (config_stats) {
 		bin->stats.reslabs++;
@@ -1248,16 +1259,14 @@ static extent_t *
 arena_bin_nonfull_slab_get(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
     szind_t binind, unsigned binshard) {
 	extent_t *slab;
-	const bin_info_t *bin_info;
+	const bin_info_t *bin_info = &bin_infos[binind];
 
 	/* Look for a usable slab. */
-	slab = arena_bin_slabs_nonfull_tryget(bin);
+	slab = arena_bin_slabs_nonfull_tryget(arena, bin, bin_info);
 	if (slab != NULL) {
 		return slab;
 	}
 	/* No existing slabs have any space available. */
-
-	bin_info = &bin_infos[binind];
 
 	/* Allocate a new slab. */
 	malloc_mutex_unlock(tsdn, &bin->lock);
@@ -1278,7 +1287,7 @@ arena_bin_nonfull_slab_get(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 	 * sufficient memory available while this one dropped bin->lock above,
 	 * so search one more time.
 	 */
-	slab = arena_bin_slabs_nonfull_tryget(bin);
+	slab = arena_bin_slabs_nonfull_tryget(arena, bin, bin_info);
 	if (slab != NULL) {
 		return slab;
 	}
@@ -1322,7 +1331,7 @@ arena_bin_malloc_hard(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 					    bin);
 				} else {
 					arena_bin_lower_slab(tsdn, arena, slab,
-					    bin);
+					    bin, bin_info);
 				}
 			}
 			return ret;
@@ -1639,7 +1648,7 @@ arena_dalloc_bin_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
 
 static void
 arena_bin_lower_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
-    bin_t *bin) {
+    bin_t *bin, const bin_info_t *bin_info) {
 	assert(extent_nfree_get(slab) > 0);
 
 	/*
@@ -1651,7 +1660,8 @@ arena_bin_lower_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
 	if (bin->slabcur != NULL && extent_snad_comp(bin->slabcur, slab) > 0) {
 		/* Switch slabcur. */
 		if (extent_nfree_get(bin->slabcur) > 0) {
-			arena_bin_slabs_nonfull_insert(bin, bin->slabcur);
+			arena_bin_slabs_nonfull_insert(arena, bin, bin_info,
+			    bin->slabcur);
 		} else {
 			arena_bin_slabs_full_insert(arena, bin, bin->slabcur);
 		}
@@ -1660,7 +1670,7 @@ arena_bin_lower_slab(tsdn_t *tsdn, arena_t *arena, extent_t *slab,
 			bin->stats.reslabs++;
 		}
 	} else {
-		arena_bin_slabs_nonfull_insert(bin, slab);
+		arena_bin_slabs_nonfull_insert(arena, bin, bin_info, slab);
 	}
 }
 
@@ -1674,6 +1684,12 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 		arena_dalloc_junk_small(ptr, bin_info);
 	}
 
+	// If slab is not full, then its mesh shape is tracked and needs to be invalidated
+	if (opt_mesh && slab != bin->slabcur && mesh_slab_is_candidate(slab) &&
+	    !bitmap_full(slab_data->bitmap, &bin_info->bitmap_info)) {
+		mesh_slab_shape_remove(arena->mesh_arena_data, slab_data, bin_info, slab);
+	}
+
 	arena_slab_reg_dalloc(slab, slab_data, ptr);
 	unsigned nfree = extent_nfree_get(slab);
 	if (nfree == bin_info->nregs) {
@@ -1681,7 +1697,12 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 		arena_dalloc_bin_slab(tsdn, arena, slab, bin);
 	} else if (nfree == 1 && slab != bin->slabcur) {
 		arena_bin_slabs_full_remove(arena, bin, slab);
-		arena_bin_lower_slab(tsdn, arena, slab, bin);
+		arena_bin_lower_slab(tsdn, arena, slab, bin, bin_info);
+	} else if (opt_mesh && slab != bin->slabcur &&
+		   mesh_slab_is_candidate(slab) && nfree != bin_info->nregs) {
+		// If slab is not empty, then track its mesh shape
+		mesh_slab_shape_add(arena->mesh_arena_data, slab_data,
+		    bin_info, slab);
 	}
 
 	if (config_stats) {
@@ -2059,6 +2080,13 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		}
 	}
 	assert(bin_addr == (uintptr_t)arena + arena_size);
+
+	if (opt_mesh) {
+		arena->mesh_arena_data = mesh_arena_data_new(tsdn, base);
+		if (arena->mesh_arena_data == NULL) {
+			goto label_error;
+		}
+	}
 
 	arena->base = base;
 	/* Set arena before creating background threads. */

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -91,6 +91,7 @@ CTL_PROTO(opt_oversize_threshold)
 CTL_PROTO(opt_background_thread)
 CTL_PROTO(opt_max_background_threads)
 CTL_PROTO(opt_mesh)
+CTL_PROTO(opt_mesh_bin_data_jit)
 CTL_PROTO(opt_dirty_decay_ms)
 CTL_PROTO(opt_muzzy_decay_ms)
 CTL_PROTO(opt_stats_print)
@@ -312,6 +313,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("background_thread"),	CTL(opt_background_thread)},
 	{NAME("max_background_threads"),	CTL(opt_max_background_threads)},
 	{NAME("mesh"),		CTL(opt_mesh)},
+	{NAME("mesh_bin_data_jit"),		CTL(opt_mesh_bin_data_jit)},
 	{NAME("dirty_decay_ms"), CTL(opt_dirty_decay_ms)},
 	{NAME("muzzy_decay_ms"), CTL(opt_muzzy_decay_ms)},
 	{NAME("stats_print"),	CTL(opt_stats_print)},
@@ -1781,6 +1783,7 @@ CTL_RO_NL_GEN(opt_oversize_threshold, opt_oversize_threshold, size_t)
 CTL_RO_NL_GEN(opt_background_thread, opt_background_thread, bool)
 CTL_RO_NL_GEN(opt_max_background_threads, opt_max_background_threads, size_t)
 CTL_RO_NL_GEN(opt_mesh, opt_mesh, bool)
+CTL_RO_NL_GEN(opt_mesh_bin_data_jit, opt_mesh_bin_data_jit, bool)
 CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -6,6 +6,7 @@
 #include "jemalloc/internal/ctl.h"
 #include "jemalloc/internal/extent_dss.h"
 #include "jemalloc/internal/extent_mmap.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/nstime.h"
 #include "jemalloc/internal/sc.h"
@@ -89,6 +90,7 @@ CTL_PROTO(opt_percpu_arena)
 CTL_PROTO(opt_oversize_threshold)
 CTL_PROTO(opt_background_thread)
 CTL_PROTO(opt_max_background_threads)
+CTL_PROTO(opt_mesh)
 CTL_PROTO(opt_dirty_decay_ms)
 CTL_PROTO(opt_muzzy_decay_ms)
 CTL_PROTO(opt_stats_print)
@@ -307,6 +309,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("oversize_threshold"),	CTL(opt_oversize_threshold)},
 	{NAME("background_thread"),	CTL(opt_background_thread)},
 	{NAME("max_background_threads"),	CTL(opt_max_background_threads)},
+	{NAME("mesh"),		CTL(opt_mesh)},
 	{NAME("dirty_decay_ms"), CTL(opt_dirty_decay_ms)},
 	{NAME("muzzy_decay_ms"), CTL(opt_muzzy_decay_ms)},
 	{NAME("stats_print"),	CTL(opt_stats_print)},
@@ -1730,6 +1733,7 @@ CTL_RO_NL_GEN(opt_percpu_arena, percpu_arena_mode_names[opt_percpu_arena],
 CTL_RO_NL_GEN(opt_oversize_threshold, opt_oversize_threshold, size_t)
 CTL_RO_NL_GEN(opt_background_thread, opt_background_thread, bool)
 CTL_RO_NL_GEN(opt_max_background_threads, opt_max_background_threads, size_t)
+CTL_RO_NL_GEN(opt_mesh, opt_mesh, bool)
 CTL_RO_NL_GEN(opt_dirty_decay_ms, opt_dirty_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_muzzy_decay_ms, opt_muzzy_decay_ms, ssize_t)
 CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1239,6 +1239,8 @@ malloc_conf_init(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS]) {
 			}
 			CONF_HANDLE_BOOL(opt_tcache, "tcache")
 			CONF_HANDLE_BOOL(opt_mesh, "mesh")
+			CONF_HANDLE_BOOL(opt_mesh_bin_data_jit,
+			    "mesh_bin_data_jit")
 			CONF_HANDLE_SSIZE_T(opt_lg_tcache_max, "lg_tcache_max",
 			    -1, (sizeof(size_t) << 3) - 1)
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1474,6 +1474,11 @@ malloc_init_hard_a0_locked() {
 		return true;
 	}
 	hook_boot();
+	if (opt_mesh) {
+		if (mesh_boot()) {
+			return true;
+		}
+	}
 	/*
 	 * Create enough scaffolding to allow recursive allocation in
 	 * malloc_ncpus().

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -11,6 +11,7 @@
 #include "jemalloc/internal/jemalloc_internal_types.h"
 #include "jemalloc/internal/log.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/mesh.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/rtree.h"
 #include "jemalloc/internal/safety_check.h"
@@ -1237,6 +1238,7 @@ malloc_conf_init(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS]) {
 				CONF_HANDLE_BOOL(opt_xmalloc, "xmalloc")
 			}
 			CONF_HANDLE_BOOL(opt_tcache, "tcache")
+			CONF_HANDLE_BOOL(opt_mesh, "mesh")
 			CONF_HANDLE_SSIZE_T(opt_lg_tcache_max, "lg_tcache_max",
 			    -1, (sizeof(size_t) << 3) - 1)
 

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -1,0 +1,5 @@
+#define JEMALLOC_MESH_C_
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+bool opt_mesh = false;

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -2,4 +2,130 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
+#include "jemalloc/internal/mesh.h"
+
 bool opt_mesh = false;
+
+unsigned nmeshable_scs;
+unsigned nmeshable_bins_per_arena;
+unsigned binind_to_meshind_table[SC_NBINS];
+// (SC_NBINS - nmeshable_scs) unused at end
+unsigned meshind_to_binind_table[SC_NBINS];
+
+bool
+mesh_slab_is_candidate(extent_t *slab) {
+	szind_t binind = extent_szind_get(slab);
+	unsigned meshind = binind_to_meshind_table[binind];
+	assert(meshind < nmeshable_scs || meshind == SC_NBINS);
+	return meshind != SC_NBINS;
+}
+
+static void
+insert_into_bin_data(mesh_bin_data_t *bin_data, uint8_t key, extent_t *slab) {
+	if (config_stats) {
+		bin_data->stats.shape_counts[key]++;
+	}
+}
+
+static void
+remove_from_bin_data(mesh_bin_data_t *bin_data, uint8_t key, extent_t *slab) {
+	if (config_stats) {
+		assert(bin_data->stats.shape_counts[key] != 0);
+		bin_data->stats.shape_counts[key]--;
+	}
+}
+
+static mesh_bin_data_t *
+get_bin_data_for_slab(mesh_arena_data_t *data, const bin_info_t *bin_info,
+    extent_t *slab) {
+	szind_t binind = extent_szind_get(slab);
+	unsigned meshind = binind_to_meshind_table[binind];
+	assert(meshind != SC_NBINS);
+	unsigned shard = extent_binshard_get(slab);
+	return &data->bin_datas[meshind].bin_data_shards[shard];
+}
+
+void
+mesh_slab_shape_add(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab) {
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+	assert(extent_nfree_get(slab) != bin_info->nregs);
+
+	mesh_bin_data_t *bin_data = get_bin_data_for_slab(data, bin_info, slab);
+	uint8_t key = bitmap_get_first_logical_byte(slab_data->bitmap,
+	    &bin_info->bitmap_info);
+	insert_into_bin_data(bin_data, key, slab);
+}
+
+void
+mesh_slab_shape_remove(mesh_arena_data_t *data, arena_slab_data_t *slab_data,
+    const bin_info_t *bin_info, extent_t *slab) {
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+	assert(extent_nfree_get(slab) != bin_info->nregs);
+
+	mesh_bin_data_t *bin_data = get_bin_data_for_slab(data, bin_info, slab);
+	uint8_t key = bitmap_get_first_logical_byte(slab_data->bitmap,
+	    &bin_info->bitmap_info);
+	remove_from_bin_data(bin_data, key, slab);
+}
+
+static void
+bin_data_init(mesh_bin_data_t *bin_data) {
+	if (config_stats) {
+		memset(&bin_data->stats, 0x0, sizeof(mesh_bin_stats_t));
+	}
+}
+
+mesh_arena_data_t *
+mesh_arena_data_new(tsdn_t *tsdn, base_t *base) {
+	size_t size = sizeof(mesh_arena_data_t) +
+	    nmeshable_scs * sizeof(mesh_bin_datas_t);
+	mesh_arena_data_t *arena_data = (mesh_arena_data_t *)base_alloc(
+	    tsdn, base, size, CACHELINE);
+
+	arena_data->bin_datas = (mesh_bin_datas_t *)(arena_data + 1);
+
+	size = sizeof(mesh_bin_data_t) * nmeshable_bins_per_arena;
+
+	mesh_bin_data_t *bin_data_base = (mesh_bin_data_t *)base_alloc(
+	    tsdn, base, size, CACHELINE);
+	uintptr_t bin_data_addr = (uintptr_t)bin_data_base;
+
+	for (size_t i = 0; i < nmeshable_scs; i++) {
+		mesh_bin_datas_t *mesh_bin_datas = &arena_data->bin_datas[i];
+		mesh_bin_data_t *addr = (mesh_bin_data_t *)bin_data_addr;
+		mesh_bin_datas->bin_data_shards = addr;
+
+		unsigned binind = meshind_to_binind_table[i];
+		bin_data_addr += sizeof(mesh_bin_data_t) *
+		    bin_infos[binind].n_shards;
+	}
+	assert(bin_data_addr == (uintptr_t)bin_data_base + size);
+
+	for (size_t i = 0; i < nmeshable_bins_per_arena; i++) {
+		bin_data_init(&bin_data_base[i]);
+	}
+	return arena_data;
+}
+
+
+bool
+mesh_boot(void) {
+	nmeshable_scs = 0;
+	nmeshable_bins_per_arena = 0;
+	for (unsigned i = 0; i < SC_NBINS; i++) {
+		if (bin_infos[i].nregs <= 8 && bin_infos[i].nregs > 1) {
+			meshind_to_binind_table[nmeshable_scs] = i;
+			binind_to_meshind_table[i] = nmeshable_scs++;
+			nmeshable_bins_per_arena += bin_infos[i].n_shards;
+		} else {
+			binind_to_meshind_table[i] = SC_NBINS;
+		}
+	}
+
+	for (unsigned i = nmeshable_scs; i < SC_NBINS; i++) {
+		meshind_to_binind_table[nmeshable_scs] = SC_NBINS;
+	}
+
+	return nmeshable_scs == 0;
+}


### PR DESCRIPTION
These 3 commits add features that are primarily all behind the new opt_mesh option which defaults to false. Overhead for programs with opt_mesh:false should hopefully be little to none: 1 NULL ptr in arena_t, as well as some branches based off of the value of opt_mesh on removal/insertion into slabs->nonfull and arena_dalloc_bin_locked_impl in src/arena.c

The end result of this stack of commits is that programs with opt_mesh will have stats available on the number of nonfull slabs with each possible 8 bit mesh shape. This should be useful in assessing the possible benefits of a mesh approach based on an exhaustive search of slabs with nregs <= 8.

I'm not a fan of the pervasive (1 << 8) everywhere that needs to logically represent the number of possible 8 bit mesh shapes, so I would definitely welcome feedback on how to improve that.