### PR TITLE
RFC: fast mutex

### DIFF
--- a/include/jemalloc/internal/background_thread_structs.h
+++ b/include/jemalloc/internal/background_thread_structs.h
@@ -22,7 +22,7 @@ struct background_thread_info_s {
 #ifdef JEMALLOC_BACKGROUND_THREAD
 	/* Background thread is pthread specific. */
 	pthread_t		thread;
-	pthread_cond_t		cond;
+	fast_cond_t		cond;
 #endif
 	malloc_mutex_t		mtx;
 	background_thread_state_t	state;

--- a/include/jemalloc/internal/fast_mutex.h
+++ b/include/jemalloc/internal/fast_mutex.h
@@ -1,0 +1,68 @@
+#include "jemalloc/internal/atomic.h"
+
+#define FAST_MUTEX_INITIALIZER { ATOMIC_INIT(0) }
+
+struct fast_mutex_s {
+  atomic_u64_t word;
+};
+
+typedef struct fast_waiter_s fast_waiter_t;
+struct fast_waiter_s;
+
+struct fast_cond_s {
+  pthread_mutex_t m;
+  fast_waiter_t* w;
+};
+
+typedef struct fast_mutex_s fast_mutex_t;
+typedef struct fast_cond_s fast_cond_t;
+
+void fast_mutex_lock_slow(fast_mutex_t* m);
+void fast_mutex_unlock_slow(fast_mutex_t* m);
+
+static inline void fast_mutex_lock(fast_mutex_t* m) {
+  uint64_t prev = 0;
+  if (!atomic_compare_exchange_weak_u64(&m->word, &prev, 1, ATOMIC_ACQUIRE, ATOMIC_RELAXED)) {
+    fast_mutex_lock_slow(m);
+  }
+}
+
+static inline void fast_mutex_unlock(fast_mutex_t* m) {
+  uint64_t prev = 1;
+  if (!atomic_compare_exchange_strong_u64(&m->word, &prev, 0, ATOMIC_RELEASE, ATOMIC_RELAXED)) {
+    assert((prev& 1) == 1);
+    fast_mutex_unlock_slow(m);
+  }
+}
+
+static inline bool fast_mutex_trylock(fast_mutex_t* m) {
+  uint64_t prev = 0;
+  if (!atomic_compare_exchange_weak_u64(&m->word, &prev, 1, ATOMIC_ACQUIRE, ATOMIC_RELAXED)) {
+    return true;
+  }
+  return false;
+}
+
+static inline bool fast_mutex_locked(fast_mutex_t* m) {
+  return (atomic_load_u64(&m->word, ATOMIC_RELAXED) & 1) != 0;
+}
+
+static inline void fast_mutex_init(fast_mutex_t* m) {
+  atomic_store_u64(&m->word, 0, ATOMIC_RELAXED);
+}
+
+static inline int fast_cond_init(fast_cond_t* c, void* unused) {
+  int ret;
+  ret = pthread_mutex_init(&c->m, NULL);
+  if (ret) {
+    return ret;
+  }
+  c->w = NULL;
+  
+  return 0;
+}
+
+int fast_cond_wait(fast_cond_t* c, fast_mutex_t* m);
+int fast_cond_timedwait(fast_cond_t* c, fast_mutex_t* m, struct timespec*ts);
+void fast_cond_signal(fast_cond_t* c);
+

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -55,7 +55,7 @@ malloc_mutex_lock_slow(malloc_mutex_t *mutex) {
 	int cnt = 0, max_cnt = MALLOC_MUTEX_MAX_SPIN;
 	do {
 		spin_cpu_spinwait();
-		if (!atomic_load_b(&mutex->locked, ATOMIC_RELAXED)
+		if (!MALLOC_MUTEX_LOCKED(mutex)
                     && !malloc_mutex_trylock_final(mutex)) {
 			data->n_spin_acquired++;
 			return;
@@ -157,17 +157,7 @@ malloc_mutex_init(malloc_mutex_t *mutex, const char *name,
 		}
 	}
 #else
-	pthread_mutexattr_t attr;
-
-	if (pthread_mutexattr_init(&attr) != 0) {
-		return true;
-	}
-	pthread_mutexattr_settype(&attr, MALLOC_MUTEX_TYPE);
-	if (pthread_mutex_init(&mutex->lock, &attr) != 0) {
-		pthread_mutexattr_destroy(&attr);
-		return true;
-	}
-	pthread_mutexattr_destroy(&attr);
+        fast_mutex_init(&mutex->lock);
 #endif
 	if (config_debug) {
 		mutex->lock_order = lock_order;
@@ -220,4 +210,203 @@ malloc_mutex_boot(void) {
 	}
 #endif
 	return false;
+}
+
+struct fast_waiter_s {
+  pthread_mutex_t lock;
+  pthread_cond_t cond;
+  bool waiting;
+  fast_waiter_t* next;
+  fast_waiter_t* tail;
+};
+
+
+static void fast_waiter_init(fast_waiter_t* w) {
+  pthread_mutex_init(&w->lock, NULL);
+  pthread_cond_init(&w->cond, NULL);
+  w->waiting = true;
+  w->next = NULL;
+  w->tail = NULL;
+}
+
+static void fast_waiter_destroy(fast_waiter_t* w) {
+  w->next = (void*)1;
+  w->tail = (void*)1;
+  pthread_mutex_destroy(&w->lock);
+  pthread_cond_destroy(&w->cond);
+}
+
+void fast_mutex_lock_slow(fast_mutex_t* m) {
+  
+  uint64_t sleeptime = 1;
+  while (true) {
+    uint64_t prev = atomic_load_u64(&m->word, ATOMIC_RELAXED);
+    if (((prev & 1) == 0) && 
+        atomic_compare_exchange_weak_u64(&m->word, &prev, prev | 1, ATOMIC_ACQUIRE, ATOMIC_RELAXED)) {
+      return;
+    }
+    while (fast_mutex_locked(m)) {
+      if (sleeptime++ > 40) usleep(100);
+      if (sleeptime > 100) break;
+    }
+
+    prev = atomic_load_u64(&m->word, ATOMIC_RELAXED);
+    if ((prev & 1) == 0) continue;
+    if (prev & 2) continue;
+    uint64_t expected = (uint64_t)prev | 2;
+    if (atomic_compare_exchange_weak_u64(&m->word, &prev, expected,
+                                         ATOMIC_ACQUIRE, ATOMIC_RELAXED)) {
+      // Locked for access
+      fast_waiter_t waiter;
+      assert(((uintptr_t)&waiter & 0x3) == 0);
+      fast_waiter_init(&waiter);
+      
+      fast_waiter_t* w = (fast_waiter_t*)(prev & ~(uint64_t)3);
+      if (w) {
+        fast_waiter_t* last = w->tail;
+        last->next = &waiter;
+        w->tail = &waiter;
+      } else {
+        w = &waiter;
+        waiter.tail = &waiter;
+      }
+      
+      atomic_store_u64(&m->word, (uint64_t)w | 1, ATOMIC_RELEASE);
+      // sleep wait
+      pthread_mutex_lock(&waiter.lock);
+      while (waiter.waiting) {
+        pthread_cond_wait(&waiter.cond, &waiter.lock);
+      }
+      pthread_mutex_unlock(&waiter.lock);
+      fast_waiter_destroy(&waiter);
+    }
+  }
+}
+
+void fast_mutex_unlock_slow(fast_mutex_t* m) {
+  uint64_t w = atomic_load_u64(&m->word, ATOMIC_RELAXED);
+  assert((w & 1) == 1);
+  while (true) {
+    while (w & 0x2) {
+      w = atomic_load_u64(&m->word, ATOMIC_RELAXED);
+    }
+    assert((w & 0x2) == 0);
+    if (atomic_compare_exchange_weak_u64(&m->word, &w, w | 2, ATOMIC_ACQUIRE, ATOMIC_RELAXED)) {
+      break;
+    }
+  }
+  assert((w & 1) == 1);
+  w = w | 2;
+  fast_waiter_t* waiter = (fast_waiter_t*)(w & ~(uint64_t)0x3);
+  assert(waiter);
+  fast_waiter_t* next_waiter = waiter->next;
+  if (next_waiter) {
+    next_waiter->tail = waiter->tail;
+  } else {
+    assert(waiter->tail == waiter);
+  }
+  // Note that someone else can still lock/unlock here, so this has to
+  // cas.  We have the list locked though, so the list cannot change
+  // release lock, release queue lock
+  atomic_store_u64(&m->word, (uint64_t)next_waiter, ATOMIC_RELAXED); 
+  pthread_mutex_lock(&waiter->lock);
+  waiter->waiting = false;
+  pthread_cond_signal(&waiter->cond);
+  pthread_mutex_unlock(&waiter->lock);
+}
+
+int fast_cond_wait(fast_cond_t* c, fast_mutex_t* m) {
+  return fast_cond_timedwait(c, m, NULL);
+}
+
+int fast_cond_timedwait(fast_cond_t* c, fast_mutex_t* m, struct timespec* ts) {
+  int ret = 0;
+  fast_waiter_t waiter;
+  assert(((uintptr_t)&waiter & 0x3) == 0);
+  fast_waiter_init(&waiter);
+      
+  pthread_mutex_lock(&c->m);
+  if (!c->w) {
+    c->w = &waiter;
+    waiter.tail = &waiter;
+  } else {
+    fast_waiter_t* last = c->w->tail;
+    last->next = &waiter;
+    c->w->tail = &waiter;
+  }
+  pthread_mutex_unlock(&c->m);
+
+  fast_mutex_unlock(m);
+  
+  pthread_mutex_lock(&waiter.lock);
+  while (waiter.waiting && ret != ETIMEDOUT) {
+    if (ts) {
+      ret = pthread_cond_timedwait(&waiter.cond, &waiter.lock, ts);
+    } else {
+      pthread_cond_wait(&waiter.cond, &waiter.lock);
+    }
+  }
+  pthread_mutex_unlock(&waiter.lock);
+
+  // Try to remove us from queue if we timedout.
+  bool removefail = false;
+  if (ret == ETIMEDOUT) {
+    pthread_mutex_lock(&c->m);
+    fast_waiter_t **last = &c->w;
+    fast_waiter_t *lasttail = c->w;
+    fast_waiter_t *head = c->w;
+    while (head && head != &waiter) {
+      lasttail = head;
+      last = &head->next;
+      head = head->next;
+    }
+    if (head) {
+      assert(head == &waiter);
+      *last = waiter.next;
+      if (c->w && waiter.next == NULL) {
+        c->w->tail = lasttail;
+      }
+    } else {
+      removefail = true;
+    }
+    pthread_mutex_unlock(&c->m);
+  }
+
+  if (removefail) {
+    ret = 0; // Couldn't find our node, wait to be notified.
+    pthread_mutex_lock(&waiter.lock);
+    while (waiter.waiting) {
+      pthread_cond_wait(&waiter.cond, &waiter.lock);
+    }
+    pthread_mutex_unlock(&waiter.lock);
+  }
+  fast_waiter_destroy(&waiter);
+  fast_mutex_lock(m);
+  return ret;
+}
+
+void fast_cond_signal(fast_cond_t* c) {
+  fast_waiter_t* waiter;
+
+  pthread_mutex_lock(&c->m);
+  waiter = c->w;
+  if (waiter) {
+    if (waiter->next) {
+      waiter->next->tail = waiter->tail;
+    }
+    c->w = waiter->next;
+    if (c->w) {
+      assert(c->w->tail = waiter->tail);
+    }
+  }
+  pthread_mutex_unlock(&c->m);
+  
+  if (!waiter) {
+    return;
+  }
+
+  pthread_mutex_lock(&waiter->lock);
+  waiter->waiting = false;
+  pthread_cond_signal(&waiter->cond);
+  pthread_mutex_unlock(&waiter->lock);
 }


### PR DESCRIPTION
There are likely large wins to be had by explicitly controlling the adaptive mutex rate.  We can also experiment with MCS or flat-combining style locks (see also folly::DistributedMutex that we've been rolling out internally). 

This diff reduced P99 tail latencies by ~2% last time I tested it. 

One downside is that the background thread logic also requires a condition variable with timeout support, so that also has to be re-implemented in terms of the new mutex's waiter list.