### PR TITLE
Buffer prof_accumbytes using bytes_until_sample

### DIFF
--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -93,9 +93,6 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 	if (config_stats) {
 		bin->tstats.nrequests++;
 	}
-	if (config_prof) {
-		tcache->prof_accumbytes += usize;
-	}
 	tcache_event(tsd, tcache);
 	return ret;
 }
@@ -150,9 +147,6 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 		if (config_stats) {
 			bin->tstats.nrequests++;
-		}
-		if (config_prof) {
-			tcache->prof_accumbytes += usize;
 		}
 	}
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2342,6 +2342,10 @@ je_malloc(size_t size) {
 		tsd_bytes_until_sample_set(tsd, bytes_until_sample);
 
 		if (unlikely(bytes_until_sample < 0)) {
+			tcache->prof_accumbytes +=
+			    (uint64_t)-bytes_until_sample +
+			    ((uint64_t)1U << lg_prof_sample);
+
 			/*
 			 * Avoid a prof_active check on the fastpath.
 			 * If prof_active is false, set bytes_until_sample to
@@ -2363,9 +2367,6 @@ je_malloc(size_t size) {
 		if (config_stats) {
 			*tsd_thread_allocatedp_get(tsd) += usize;
 			bin->tstats.nrequests++;
-		}
-		if (config_prof) {
-			tcache->prof_accumbytes += usize;
 		}
 
 		LOG("core.malloc.exit", "result: %p", ret);


### PR DESCRIPTION
`prof_accumbytes` in `tcache` and `bytes_until_sample` in `tsd`
move in sync with each other, so trying to buffer the more slowly
cycling one i.e. `prof_accumbytes` using the faster cycling one i.e.
`bytes_until_sample`, in order to save some cycles in fast path.