### PR TITLE
Optimize max_active_fit in first_fit.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -459,7 +459,6 @@ extents_first_fit_locked(tsdn_t *tsdn, arena_t *arena, extents_t *extents,
 		assert(!extent_heap_empty(&extents->heaps[i]));
 		extent_t *extent = extent_heap_first(&extents->heaps[i]);
 		assert(extent_size_get(extent) >= size);
-                bool size_ok = true;
 		/*
 		 * In order to reduce fragmentation, avoid reusing and splitting
 		 * large extents for much smaller sizes.
@@ -468,10 +467,9 @@ extents_first_fit_locked(tsdn_t *tsdn, arena_t *arena, extents_t *extents,
 		 */
 		if (extents->delay_coalesce &&
 		    (sz_pind2sz(i) >> opt_lg_extent_max_active_fit) > size) {
-			size_ok = false;
+			break;
 		}
-		if (size_ok &&
-		    (ret == NULL || extent_snad_comp(extent, ret) < 0)) {
+		if (ret == NULL || extent_snad_comp(extent, ret) < 0) {
 			ret = extent;
 		}
 		if (i == SC_NPSIZES) {


### PR DESCRIPTION
Stop scanning once reached the first max_active_fit size.

max_active_fit was moved from best fit to first fit in b62d126df894dac00772eb5f3d170a1c1d3d1614