### PR TITLE
Make small size section of tcache_bin_info static

### DIFF
--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -4,7 +4,8 @@
 extern bool	opt_tcache;
 extern ssize_t	opt_lg_tcache_max;
 
-extern cache_bin_info_t	*tcache_bin_info;
+extern cache_bin_info_t	tcache_small_bin_info[];
+extern cache_bin_info_t	*tcache_large_bin_info;
 
 /*
  * Number of tcache bins.  There are SC_NBINS small-object bins, plus 0 or more

--- a/src/arena.c
+++ b/src/arena.c
@@ -1390,7 +1390,7 @@ arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 	unsigned binshard;
 	bin_t *bin = arena_bin_choose_lock(tsdn, arena, binind, &binshard);
 
-	for (i = 0, nfill = (tcache_bin_info[binind].ncached_max >>
+	for (i = 0, nfill = (tcache_small_bin_info_get(binind)->ncached_max >>
 	    tcache->lg_fill_div[binind]); i < nfill; i += cnt) {
 		extent_t *slab;
 		if ((slab = bin->slabcur) != NULL && extent_nfree_get(slab) >

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2846,7 +2846,7 @@ bool free_fastpath(void *ptr, size_t size, bool size_hint) {
 	}
 
 	cache_bin_t *bin = tcache_small_bin_get(tcache, alloc_ctx.szind);
-	cache_bin_info_t *bin_info = &tcache_bin_info[alloc_ctx.szind];
+	cache_bin_info_t *bin_info = tcache_small_bin_info_get(alloc_ctx.szind);
 	if (!cache_bin_dalloc_easy(bin, bin_info, ptr)) {
 		return false;
 	}


### PR DESCRIPTION
Optimization of free fast path - there's one less redirection.
The total memory consumption is kept unchanged.