### PR TITLE
Add indent to individual options for confirm_conf.

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1059,9 +1059,10 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 #define CONF_CONTINUE	{						\
 				if (!initial_call && opt_confirm_conf	\
 				    && cur_opt_valid) {			\
-					malloc_printf("<jemalloc>: Set "\
-					    "conf value: %.*s:%.*s\n",	\
-					    (int)klen, k, (int)vlen, v);\
+					malloc_printf("<jemalloc>: -- "	\
+					    "Set conf value: %.*s:%.*s"	\
+					    "\n", (int)klen, k,		\
+					    (int)vlen, v);		\
 				}					\
 				continue;				\
 			}


### PR DESCRIPTION
Should make the output from `confirm_conf` a bit clearer, e.g. 

    <jemalloc>: malloc_conf #1 (string specified via --with-malloc-conf): "narenas:10"
    <jemalloc>: -- Set conf value: narenas:10
    <jemalloc>: malloc_conf #2 (string pointed to by the global variable malloc_conf): "narenas:20"
    <jemalloc>: -- Set conf value: narenas:20
