### PR TITLE
Fix tcaches mutex pre- / post-fork handling.

### DIFF
--- a/src/tcache.c
+++ b/src/tcache.c
@@ -778,21 +778,15 @@ tcache_boot(tsdn_t *tsdn) {
 
 void
 tcache_prefork(tsdn_t *tsdn) {
-	if (!config_prof && opt_tcache) {
-		malloc_mutex_prefork(tsdn, &tcaches_mtx);
-	}
+	malloc_mutex_prefork(tsdn, &tcaches_mtx);
 }
 
 void
 tcache_postfork_parent(tsdn_t *tsdn) {
-	if (!config_prof && opt_tcache) {
-		malloc_mutex_postfork_parent(tsdn, &tcaches_mtx);
-	}
+	malloc_mutex_postfork_parent(tsdn, &tcaches_mtx);
 }
 
 void
 tcache_postfork_child(tsdn_t *tsdn) {
-	if (!config_prof && opt_tcache) {
-		malloc_mutex_postfork_child(tsdn, &tcaches_mtx);
-	}
+	malloc_mutex_postfork_child(tsdn, &tcaches_mtx);
 }


### PR DESCRIPTION
`tcaches_mtx` isn't really related to config_prof or opt_tcache. It's all about explicit tcaches in fact.

Unconditionally does pre / post fork mutex handling.