### PR TITLE
Avoid zero the tcache avail array during tcache init.

### DIFF
--- a/src/tcache.c
+++ b/src/tcache.c
@@ -448,7 +448,7 @@ tsd_tcache_data_init(tsd_t *tsd) {
 	/* Avoid false cacheline sharing. */
 	size = sz_sa2u(size, CACHELINE);
 
-	void *avail_array = ipallocztm(tsd_tsdn(tsd), size, CACHELINE, true,
+	void *avail_array = ipallocztm(tsd_tsdn(tsd), size, CACHELINE, false,
 	    NULL, true, arena_get(TSDN_NULL, 0, true));
 	if (avail_array == NULL) {
 		return true;


### PR DESCRIPTION
The tcache avail stack is always accessed / guarded with ncached (i.e. filled
with valid pointer), which means there is no need to zero it out initially.
This may save some pages for threads not accessing many sizes classes.