### PR TITLE
Store stack_size in tcache_bin_info.

### DIFF
--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -174,8 +174,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_small_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		tcache_bin_flush_small(tsd, tcache, bin, binind,
-		    tcache_bin_info[binind].ncached_max >> 1);
+		unsigned remain = cache_bin_ncached_max_get(binind) >> 1;
+		tcache_bin_flush_small(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);
 	}
@@ -198,8 +198,8 @@ tcache_dalloc_large(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_large_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		tcache_bin_flush_large(tsd, tcache, bin, binind,
-		    tcache_bin_info[binind].ncached_max >> 1);
+		unsigned remain = cache_bin_ncached_max_get(binind) >> 1;
+		tcache_bin_flush_large(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);
 	}

--- a/src/arena.c
+++ b/src/arena.c
@@ -1392,7 +1392,7 @@ arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 	bin_t *bin = arena_bin_choose_lock(tsdn, arena, binind, &binshard);
 
 	void **empty_position = cache_bin_empty_position_get(tbin, binind);
-	for (i = 0, nfill = (tcache_bin_info[binind].ncached_max >>
+	for (i = 0, nfill = (cache_bin_ncached_max_get(binind) >>
 	    tcache->lg_fill_div[binind]); i < nfill; i += cnt) {
 		extent_t *slab;
 		if ((slab = bin->slabcur) != NULL && extent_nfree_get(slab) >

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -10,7 +10,7 @@ TEST_BEGIN(test_cache_bin) {
 
 	assert_ptr_not_null(stack, "Unexpected mallocx failure");
 	/* Initialize to empty; bin 0. */
-	cache_bin_sz_t ncached_max = tcache_bin_info[0].ncached_max;
+	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(0);
 	void **empty_position = stack + ncached_max;
 	bin->cur_ptr.ptr = empty_position;
 	bin->low_water_position = bin->cur_ptr.lowbits;


### PR DESCRIPTION
With the cache bin metadata switched to pointers, ncached_max is usually
accessed and timed by sizeof(ptr). Store the results in tcache_bin_info for
direct access, and add a helper function for the ncached_max value.

On top of #1592