### PR TITLE
Add max_per_bg stats to reflect the maximum of counters for background thread mutexes.

### DIFF
--- a/include/jemalloc/internal/background_thread_structs.h
+++ b/include/jemalloc/internal/background_thread_structs.h
@@ -48,6 +48,7 @@ struct background_thread_stats_s {
 	size_t num_threads;
 	uint64_t num_runs;
 	nstime_t run_interval;
+	mutex_prof_data_t max_counter_per_thread;
 };
 typedef struct background_thread_stats_s background_thread_stats_t;
 

--- a/include/jemalloc/internal/mutex_prof.h
+++ b/include/jemalloc/internal/mutex_prof.h
@@ -7,6 +7,7 @@
 
 #define MUTEX_PROF_GLOBAL_MUTEXES					\
     OP(background_thread)						\
+    OP(max_per_bg)							\
     OP(ctl)								\
     OP(prof)								\
     OP(prof_thds_data)							\

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -809,6 +809,8 @@ background_thread_stats_read(tsdn_t *tsdn, background_thread_stats_t *stats) {
 		if (info->state != background_thread_stopped) {
 			num_runs += info->tot_n_runs;
 			nstime_add(&stats->run_interval, &info->tot_sleep_time);
+			malloc_mutex_prof_max_update(tsdn,
+				&stats->max_counter_per_thread, &info->mtx);
 		}
 		malloc_mutex_unlock(tsdn, &info->mtx);
 	}

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1113,6 +1113,8 @@ ctl_refresh(tsdn_t *tsdn) {
 		malloc_mutex_prof_read(tsdn,
 		    &ctl_stats->mutex_prof_data[global_prof_mutex_ctl],
 		    &ctl_mtx);
+		ctl_stats->mutex_prof_data[global_prof_mutex_max_per_bg] =
+			ctl_stats->background_thread.max_counter_per_thread;
 #undef READ_GLOBAL_MUTEX_PROF_DATA
 	}
 	ctl_arenas->epoch++;


### PR DESCRIPTION
Added a new stats row to aggregate the maximum value of each counters for background
threads. https://github.com/jemalloc/jemalloc/issues/1511