### PR TITLE
Track low_water == -1 case explicitly.

### DIFF
--- a/include/jemalloc/internal/tcache_structs.h
+++ b/include/jemalloc/internal/tcache_structs.h
@@ -51,6 +51,8 @@ struct tcache_s {
 	szind_t		next_gc_bin;
 	/* For small bins, fill (ncached_max >> lg_fill_div). */
 	uint8_t		lg_fill_div[SC_NBINS];
+	/* For small bins, whether has been refilled since last GC. */
+	bool		bin_refilled[SC_NBINS];
 	/*
 	 * We put the cache bins for large size classes at the end of the
 	 * struct, since some of them might not get used.  This might end up

--- a/src/arena.c
+++ b/src/arena.c
@@ -1383,10 +1383,10 @@ arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 	unsigned i, nfill, cnt;
 
 	assert(cache_bin_ncached_get(tbin, binind) == 0);
-
 	if (config_prof && arena_prof_accum(tsdn, arena, prof_accumbytes)) {
 		prof_idump(tsdn);
 	}
+	tcache->bin_refilled[binind] = true;
 
 	unsigned binshard;
 	bin_t *bin = arena_bin_choose_lock(tsdn, arena, binind, &binshard);

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -23,7 +23,7 @@ TEST_BEGIN(test_cache_bin) {
 	bool success;
 	void *ret = cache_bin_alloc_easy(bin, &success, 0);
 	assert_false(success, "Empty cache bin should not alloc");
-	assert_true(cache_bin_low_water_get(bin, 0) == - 1,
+	assert_true(cache_bin_low_water_get(bin, 0) == 0,
 	    "Incorrect low water mark");
 
 	cache_bin_ncached_set(bin, 0, 0);


### PR DESCRIPTION
The -1 value of low_water indicates if the cache has been depleted and
refilled.  Track the status explicitly in the tcache struct.

This allows the fast path to check if (cur_ptr > low_water), instead of >=,
which avoids reaching slow path when the last item is allocated.