### PR TITLE
Make cache_bin_sz_t unsigned.

### DIFF
--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -13,12 +13,8 @@
  * of the tcache at all.
  */
 
-/*
- * The count of the number of cached allocations in a bin.  We make this signed
- * so that negative numbers can encode "invalid" states (e.g. a low water mark
- * of -1 for a cache that has been depleted).
- */
-typedef int32_t cache_bin_sz_t;
+/* The size in bytes of each cache bin stack. */
+typedef uint16_t cache_bin_sz_t;
 
 typedef struct cache_bin_stats_s cache_bin_stats_t;
 struct cache_bin_stats_s {
@@ -126,7 +122,7 @@ static inline cache_bin_sz_t
 cache_bin_ncached_get(cache_bin_t *bin, szind_t ind) {
 	cache_bin_sz_t n = (tcache_bin_info[ind].stack_size +
 	    bin->full_position - bin->cur_ptr.lowbits) / sizeof(void *);
-	assert(n >= 0 && n <= cache_bin_ncached_max_get(ind));
+	assert(n <= cache_bin_ncached_max_get(ind));
 	assert(n == 0 || *(bin->cur_ptr.ptr) != NULL);
 
 	return n;
@@ -157,13 +153,13 @@ cache_bin_bottom_item_get(cache_bin_t *bin, szind_t ind) {
 	return bottom;
 }
 
-/* Returns the numeric value of low water in [-1, ncached]. */
+/* Returns the numeric value of low water in [0, ncached]. */
 static inline cache_bin_sz_t
 cache_bin_low_water_get(cache_bin_t *bin, szind_t ind) {
 	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(ind);
 	cache_bin_sz_t low_water = ncached_max -
 	    (bin->low_water_position - bin->full_position) / sizeof(void *);
-	assert(low_water >= 0 && low_water <= ncached_max);
+	assert(low_water <= ncached_max);
 	assert(low_water <= cache_bin_ncached_get(bin, ind));
 	assert(bin->low_water_position >= bin->cur_ptr.lowbits);
 
@@ -174,7 +170,7 @@ static inline void
 cache_bin_ncached_set(cache_bin_t *bin, szind_t ind, cache_bin_sz_t n) {
 	bin->cur_ptr.lowbits = bin->full_position +
 	    tcache_bin_info[ind].stack_size - n * sizeof(void *);
-	assert(n >= 0 && n <= cache_bin_ncached_max_get(ind));
+	assert(n <= cache_bin_ncached_max_get(ind));
 	assert(n == 0 || *bin->cur_ptr.ptr != NULL);
 }
 

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -187,7 +187,7 @@ cache_bin_array_descriptor_init(cache_bin_array_descriptor_t *descriptor,
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-cache_bin_alloc_easy(cache_bin_t *bin, bool *success, cache_bin_sz_t ind) {
+cache_bin_alloc_easy(cache_bin_t *bin, bool *success, szind_t ind) {
 	/*
 	 * This may read from the empty position; however the loaded value won't
 	 * be used.  It's safe because the stack has one more slot reserved.

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -825,6 +825,8 @@ tcache_boot(tsdn_t *tsdn) {
 			ncached_max = TCACHE_NSLOTS_SMALL_MAX;
 		}
 		unsigned stack_size = ncached_max * sizeof(void *);
+		assert(stack_size < ((uint64_t)1 <<
+		    (sizeof(cache_bin_sz_t) * 8)));
 		tcache_bin_info[i].stack_size = stack_size;
 		total_stack_bytes += stack_size;
 	}


### PR DESCRIPTION
The bin size type was made signed only because the low_water could go -1, which
was already removed.
