### PR TITLE
Fix libc reentrancy level

### DIFF
--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -56,7 +56,7 @@ void prof_malloc_sample_object(tsdn_t *tsdn, const void *ptr, size_t usize,
 void prof_free_sampled_object(tsd_t *tsd, const void *ptr, size_t usize,
     prof_tctx_t *tctx);
 void bt_init(prof_bt_t *bt, void **vec);
-void prof_backtrace(prof_bt_t *bt);
+void prof_backtrace(tsd_t *tsd, prof_bt_t *bt);
 prof_tctx_t *prof_lookup(tsd_t *tsd, prof_bt_t *bt);
 #ifdef JEMALLOC_JET
 size_t prof_tdata_count(void);

--- a/include/jemalloc/internal/prof_inlines_b.h
+++ b/include/jemalloc/internal/prof_inlines_b.h
@@ -155,7 +155,7 @@ prof_alloc_prep(tsd_t *tsd, size_t usize, bool prof_active, bool update) {
 		ret = (prof_tctx_t *)(uintptr_t)1U;
 	} else {
 		bt_init(&bt, tdata->vec);
-		prof_backtrace(&bt);
+		prof_backtrace(tsd, &bt);
 		ret = prof_lookup(tsd, &bt);
 	}
 

--- a/src/prof.c
+++ b/src/prof.c
@@ -430,9 +430,8 @@ prof_backtrace_impl(prof_bt_t *bt) {
 #endif
 
 void
-prof_backtrace(prof_bt_t *bt) {
+prof_backtrace(tsd_t *tsd, prof_bt_t *bt) {
 	cassert(config_prof);
-	tsd_t *tsd = tsd_fetch();
 	pre_reentrancy(tsd, NULL);
 	prof_backtrace_impl(bt);
 	post_reentrancy(tsd);

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -246,7 +246,7 @@ prof_try_log(tsd_t *tsd, const void *ptr, size_t usize, prof_tctx_t *tctx) {
 	prof_bt_t bt;
 	/* Initialize the backtrace, using the buffer in tdata to store it. */
 	bt_init(&bt, cons_tdata->vec);
-	prof_backtrace(&bt);
+	prof_backtrace(tsd, &bt);
 	prof_bt_t *cons_bt = &bt;
 
 	/* We haven't destroyed tctx yet, so gctx should be good to read. */


### PR DESCRIPTION
`_Unwind_Backtrace` is most likely not calling `malloc()`/`free()`, but from correctness aspect we should have a guard rather than relying only on trust. From behavior aspect `reentrancy_level` is also important: for example, profiling is turned off when `reentrancy_level > 0`.