### PR TITLE
Build a general purpose thread event handler

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -123,11 +123,12 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/prof_log.c \
 	$(srcroot)src/rtree.c \
 	$(srcroot)src/safety_check.c \
-	$(srcroot)src/stats.c \
 	$(srcroot)src/sc.c \
+	$(srcroot)src/stats.c \
 	$(srcroot)src/sz.c \
 	$(srcroot)src/tcache.c \
 	$(srcroot)src/test_hooks.c \
+	$(srcroot)src/thread_event.c \
 	$(srcroot)src/ticker.c \
 	$(srcroot)src/tsd.c \
 	$(srcroot)src/witness.c
@@ -176,9 +177,9 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/background_thread.c \
 	$(srcroot)test/unit/background_thread_enable.c \
 	$(srcroot)test/unit/base.c \
+	$(srcroot)test/unit/binshard.c \
 	$(srcroot)test/unit/bitmap.c \
 	$(srcroot)test/unit/bit_util.c \
-	$(srcroot)test/unit/binshard.c \
 	$(srcroot)test/unit/buf_writer.c \
 	$(srcroot)test/unit/cache_bin.c \
 	$(srcroot)test/unit/ckh.c \
@@ -200,6 +201,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/math.c \
 	$(srcroot)test/unit/mq.c \
 	$(srcroot)test/unit/mtx.c \
+	$(srcroot)test/unit/nstime.c \
 	$(srcroot)test/unit/pack.c \
 	$(srcroot)test/unit/pages.c \
 	$(srcroot)test/unit/ph.c \
@@ -218,9 +220,9 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/retained.c \
 	$(srcroot)test/unit/rtree.c \
 	$(srcroot)test/unit/safety_check.c \
+	$(srcroot)test/unit/sc.c \
 	$(srcroot)test/unit/seq.c \
 	$(srcroot)test/unit/SFMT.c \
-	$(srcroot)test/unit/sc.c \
 	$(srcroot)test/unit/size_classes.c \
 	$(srcroot)test/unit/slab.c \
 	$(srcroot)test/unit/smoothstep.c \
@@ -228,8 +230,8 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/stats.c \
 	$(srcroot)test/unit/stats_print.c \
 	$(srcroot)test/unit/test_hooks.c \
+	$(srcroot)test/unit/thread_event.c \
 	$(srcroot)test/unit/ticker.c \
-	$(srcroot)test/unit/nstime.c \
 	$(srcroot)test/unit/tsd.c \
 	$(srcroot)test/unit/witness.c \
 	$(srcroot)test/unit/zero.c \

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -1,0 +1,139 @@
+#ifndef JEMALLOC_INTERNAL_THREAD_EVENT_H
+#define JEMALLOC_INTERNAL_THREAD_EVENT_H
+
+#include "jemalloc/internal/tsd.h"
+
+/*
+ * Maximum threshold on thread_allocated_next_event_fast, so that there is no
+ * need to check overflow in malloc fast path. (The allocation size in malloc
+ * fast path never exceeds SC_LOOKUP_MAXCLASS.)
+ */
+#define THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX				\
+    (UINT64_MAX - SC_LOOKUP_MAXCLASS + 1U)
+
+/*
+ * The max interval helps make sure that malloc stays on the fast path in the
+ * common case, i.e. thread_allocated < thread_allocated_next_event_fast.
+ * When thread_allocated is within an event's distance to
+ * THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX above, thread_allocated_next_event_fast
+ * is wrapped around and we fall back to the medium-fast path. The max interval
+ * makes sure that we're not staying on the fallback case for too long, even if
+ * there's no active event or if all active events have long wait times.
+ */
+#define THREAD_EVENT_MAX_INTERVAL ((uint64_t)(4U << 20))
+
+void thread_event_assert_invariants_debug(tsd_t *tsd);
+void thread_event_trigger(tsd_t *tsd, bool delay_event);
+void thread_event_rollback(tsd_t *tsd, size_t diff);
+void thread_event_update(tsd_t *tsd);
+void thread_event_boot();
+
+/*
+ * List of all events, in the following format:
+ *  E(event,		(condition))
+ */
+#define ITERATE_OVER_ALL_EVENTS						\
+    E(prof_sample,	(config_prof && opt_prof))
+
+#define E(event, condition)						\
+    C(event##_event_wait)
+
+/* List of all thread event counters. */
+#define ITERATE_OVER_ALL_COUNTERS					\
+    C(thread_allocated)							\
+    C(thread_allocated_next_event_fast)					\
+    C(thread_allocated_last_event)					\
+    C(thread_allocated_next_event)					\
+    ITERATE_OVER_ALL_EVENTS
+
+/* Getters directly wrap TSD getters. */
+#define C(counter)							\
+JEMALLOC_ALWAYS_INLINE uint64_t						\
+counter##_get(tsd_t *tsd) {						\
+	return tsd_##counter##_get(tsd);				\
+}
+
+ITERATE_OVER_ALL_COUNTERS
+#undef C
+
+/*
+ * Setters call the TSD pointer getters rather than the TSD setters, so that
+ * the counters can be modified even when TSD state is reincarnated or
+ * minimal_initialized: if an event is triggered in such cases, we will
+ * temporarily delay the event and let it be immediately triggered at the next
+ * allocation call.
+ */
+#define C(counter)							\
+JEMALLOC_ALWAYS_INLINE void						\
+counter##_set(tsd_t *tsd, uint64_t v) {					\
+	*tsd_##counter##p_get(tsd) = v;					\
+}
+
+ITERATE_OVER_ALL_COUNTERS
+#undef C
+
+/*
+ * For generating _event_wait getter / setter functions for each individual
+ * event.
+ */
+#undef E
+
+/*
+ * The function checks in debug mode whether the thread event counters are in
+ * a consistent state, which forms the invariants before and after each round
+ * of thread event handling that we can rely on and need to promise.
+ * The invariants are only temporarily violated in the middle of:
+ * (a) thread_event() if an event is triggered (the thread_event_trigger() call
+ *     at the end will restore the invariants),
+ * (b) thread_##event##_event_update() (the thread_event_update() call at the
+ *     end will restore the invariants), or
+ * (c) thread_event_rollback() if the rollback falls below the last_event (the
+ *     thread_event_update() call at the end will restore the invariants).
+ */
+JEMALLOC_ALWAYS_INLINE void
+thread_event_assert_invariants(tsd_t *tsd) {
+	if (config_debug) {
+		thread_event_assert_invariants_debug(tsd);
+	}
+}
+
+JEMALLOC_ALWAYS_INLINE void
+thread_event(tsd_t *tsd, size_t usize) {
+	thread_event_assert_invariants(tsd);
+
+	uint64_t thread_allocated_before = thread_allocated_get(tsd);
+	thread_allocated_set(tsd, thread_allocated_before + usize);
+
+	/* The subtraction is intentionally susceptible to underflow. */
+	if (likely(usize < thread_allocated_next_event_get(tsd) -
+	    thread_allocated_before)) {
+		thread_event_assert_invariants(tsd);
+	} else {
+		thread_event_trigger(tsd, false);
+	}
+}
+
+#define E(event, condition)						\
+JEMALLOC_ALWAYS_INLINE void						\
+thread_##event##_event_update(tsd_t *tsd, uint64_t event_wait) {	\
+	thread_event_assert_invariants(tsd);				\
+	assert(condition);						\
+	assert(tsd_nominal(tsd));					\
+	assert(tsd_reentrancy_level_get(tsd) == 0);			\
+	assert(event_wait > 0U);					\
+	if (THREAD_EVENT_MIN_START_WAIT > 1U &&				\
+	    unlikely(event_wait < THREAD_EVENT_MIN_START_WAIT)) {	\
+		event_wait = THREAD_EVENT_MIN_START_WAIT;		\
+	}								\
+	if (THREAD_EVENT_MAX_START_WAIT < UINT64_MAX &&			\
+	    unlikely(event_wait > THREAD_EVENT_MAX_START_WAIT)) {	\
+		event_wait = THREAD_EVENT_MAX_START_WAIT;		\
+	}								\
+	event##_event_wait_set(tsd, event_wait);			\
+	thread_event_update(tsd);					\
+}
+
+ITERATE_OVER_ALL_EVENTS
+#undef E
+
+#endif /* JEMALLOC_INTERNAL_THREAD_EVENT_H */

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -63,15 +63,16 @@
     <ClCompile Include="..\..\..\..\src\prof_data.c" />
     <ClCompile Include="..\..\..\..\src\prof_log.c" />
     <ClCompile Include="..\..\..\..\src\rtree.c" />
+    <ClCompile Include="..\..\..\..\src\safety_check.c" />
     <ClCompile Include="..\..\..\..\src\sc.c" />
     <ClCompile Include="..\..\..\..\src\stats.c" />
     <ClCompile Include="..\..\..\..\src\sz.c" />
     <ClCompile Include="..\..\..\..\src\tcache.c" />
     <ClCompile Include="..\..\..\..\src\test_hooks.c" />
+    <ClCompile Include="..\..\..\..\src\thread_event.c" />
     <ClCompile Include="..\..\..\..\src\ticker.c" />
     <ClCompile Include="..\..\..\..\src\tsd.c" />
     <ClCompile Include="..\..\..\..\src\witness.c" />
-    <ClCompile Include="..\..\..\..\src\safety_check.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8D6BB292-9E1C-413D-9F98-4864BDC1514A}</ProjectGuid>

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="..\..\..\..\src\base.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\bin.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\bitmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -23,6 +26,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\ctl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\div.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\extent.c">
@@ -44,6 +50,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\large.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\log.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\malloc_io.c">
@@ -76,6 +85,9 @@
     <ClCompile Include="..\..\..\..\src\rtree.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\safety_check.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\sc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -91,6 +103,9 @@
     <ClCompile Include="..\..\..\..\src\test_hooks.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\thread_event.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\ticker.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -98,18 +113,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\witness.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\log.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\bin.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\div.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\safety_check.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
@@ -63,15 +63,16 @@
     <ClCompile Include="..\..\..\..\src\prof_data.c" />
     <ClCompile Include="..\..\..\..\src\prof_log.c" />
     <ClCompile Include="..\..\..\..\src\rtree.c" />
+    <ClCompile Include="..\..\..\..\src\safety_check.c" />
     <ClCompile Include="..\..\..\..\src\sc.c" />
     <ClCompile Include="..\..\..\..\src\stats.c" />
     <ClCompile Include="..\..\..\..\src\sz.c" />
     <ClCompile Include="..\..\..\..\src\tcache.c" />
     <ClCompile Include="..\..\..\..\src\test_hooks.c" />
+    <ClCompile Include="..\..\..\..\src\thread_event.c" />
     <ClCompile Include="..\..\..\..\src\ticker.c" />
     <ClCompile Include="..\..\..\..\src\tsd.c" />
     <ClCompile Include="..\..\..\..\src\witness.c" />
-    <ClCompile Include="..\..\..\..\src\safety_check.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8D6BB292-9E1C-413D-9F98-4864BDC1514A}</ProjectGuid>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="..\..\..\..\src\base.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\bin.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\bitmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -23,6 +26,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\ctl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\div.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\extent.c">
@@ -44,6 +50,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\large.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\log.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\malloc_io.c">
@@ -76,6 +85,9 @@
     <ClCompile Include="..\..\..\..\src\rtree.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\safety_check.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\sc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -88,6 +100,12 @@
     <ClCompile Include="..\..\..\..\src\tcache.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\test_hooks.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\thread_event.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\ticker.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -95,21 +113,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\witness.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\log.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\bin.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\div.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\test_hooks.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\safety_check.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/thread_event.c
+++ b/src/thread_event.c
@@ -1,0 +1,255 @@
+#define JEMALLOC_THREAD_EVENT_C_
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/thread_event.h"
+
+/*
+ * There's no lock for thread_event_active because write is only done in
+ * malloc_init(), where init_lock there serves as the guard, and ever since
+ * then thread_event_active becomes read only.
+ */
+static bool thread_event_active = false;
+
+/* Event handler function signatures. */
+#define E(event, condition)						\
+static void thread_##event##_event_handler(tsd_t *tsd);
+
+ITERATE_OVER_ALL_EVENTS
+#undef E
+
+static uint64_t
+thread_allocated_next_event_compute(tsd_t *tsd) {
+	uint64_t wait = THREAD_EVENT_MAX_START_WAIT;
+	bool no_event_on = true;
+
+#define E(event, condition)						\
+	if (condition) {						\
+		no_event_on = false;					\
+		uint64_t event_wait =					\
+		    event##_event_wait_get(tsd);			\
+		assert(event_wait <= THREAD_EVENT_MAX_START_WAIT);	\
+		if (event_wait > 0U && event_wait < wait) {		\
+			wait = event_wait;				\
+		}							\
+	}
+
+	ITERATE_OVER_ALL_EVENTS
+#undef E
+
+	assert(no_event_on == !thread_event_active);
+	assert(wait <= THREAD_EVENT_MAX_START_WAIT);
+	return wait;
+}
+
+void
+thread_event_assert_invariants_debug(tsd_t *tsd) {
+	uint64_t thread_allocated = thread_allocated_get(tsd);
+	uint64_t last_event = thread_allocated_last_event_get(tsd);
+	uint64_t next_event = thread_allocated_next_event_get(tsd);
+	uint64_t next_event_fast = thread_allocated_next_event_fast_get(tsd);
+
+	assert(last_event != next_event);
+	if (next_event <= THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX) {
+		assert(next_event_fast == next_event);
+	} else {
+		assert(next_event_fast == 0U);
+	}
+
+	/* The subtraction is intentionally susceptible to underflow. */
+	uint64_t interval = next_event - last_event;
+
+	/* The subtraction is intentionally susceptible to underflow. */
+	assert(thread_allocated - last_event < interval);
+
+	uint64_t min_wait = thread_allocated_next_event_compute(tsd);
+
+	/*
+	 * next_event should have been pushed up only except when no event is
+	 * on and the TSD is just initialized.  The last_event == 0U guard
+	 * below is stronger than needed, but having an exactly accurate guard
+	 * is more complicated to implement.
+	 */
+	assert((!thread_event_active && last_event == 0U) ||
+	    interval == min_wait ||
+	    (interval < min_wait && interval == THREAD_EVENT_MAX_INTERVAL));
+}
+
+static void
+thread_event_adjust_thresholds_helper(tsd_t *tsd, uint64_t wait) {
+	assert(wait <= THREAD_EVENT_MAX_START_WAIT);
+	uint64_t next_event = thread_allocated_last_event_get(tsd) + (wait <=
+	    THREAD_EVENT_MAX_INTERVAL ? wait : THREAD_EVENT_MAX_INTERVAL);
+	thread_allocated_next_event_set(tsd, next_event);
+	uint64_t next_event_fast = (next_event <=
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX) ? next_event : 0U;
+	thread_allocated_next_event_fast_set(tsd, next_event_fast);
+}
+
+static void
+thread_prof_sample_event_handler(tsd_t *tsd) {
+	assert(config_prof && opt_prof);
+	assert(prof_sample_event_wait_get(tsd) == 0U);
+	if (!prof_active_get_unlocked()) {
+		/*
+		 * If prof_active is off, we reset prof_sample_event_wait to be
+		 * the sample interval when it drops to 0, so that there won't
+		 * be excessive routings to the slow path, and that when
+		 * prof_active is turned on later, the counting for sampling
+		 * can immediately resume as normal.
+		 */
+		thread_prof_sample_event_update(tsd,
+		    (uint64_t)(1 << lg_prof_sample));
+	}
+}
+
+static uint64_t
+thread_event_trigger_batch_update(tsd_t *tsd, uint64_t accumbytes,
+    bool allow_event_trigger) {
+	uint64_t wait = THREAD_EVENT_MAX_START_WAIT;
+
+#define E(event, condition)						\
+	if (condition) {						\
+		uint64_t event_wait = event##_event_wait_get(tsd);	\
+		assert(event_wait <= THREAD_EVENT_MAX_START_WAIT);	\
+		if (event_wait > accumbytes) {				\
+			event_wait -= accumbytes;			\
+		} else {						\
+			event_wait = 0U;				\
+			if (!allow_event_trigger) {			\
+				event_wait =				\
+				    THREAD_EVENT_MIN_START_WAIT;	\
+			}						\
+		}							\
+		assert(event_wait <= THREAD_EVENT_MAX_START_WAIT);	\
+		event##_event_wait_set(tsd, event_wait);		\
+		/*							\
+		 * If there is a single event, then the remaining wait	\
+		 * time may become zero, and we rely on either the	\
+		 * event handler or a thread_event_update() call later	\
+		 * to properly set next_event; if there are multiple	\
+		 * events, then	here we can get the minimum remaining	\
+		 * wait time to	the next already set event.		\
+		 */							\
+		if (event_wait > 0U && event_wait < wait) {		\
+			wait = event_wait;				\
+		}							\
+	}
+
+	ITERATE_OVER_ALL_EVENTS
+#undef E
+
+	assert(wait <= THREAD_EVENT_MAX_START_WAIT);
+	return wait;
+}
+
+void
+thread_event_trigger(tsd_t *tsd, bool delay_event) {
+	/* usize has already been added to thread_allocated. */
+	uint64_t thread_allocated_after = thread_allocated_get(tsd);
+
+	/* The subtraction is intentionally susceptible to underflow. */
+	uint64_t accumbytes = thread_allocated_after -
+	    thread_allocated_last_event_get(tsd);
+
+	/* Make sure that accumbytes cannot overflow uint64_t. */
+	cassert(THREAD_EVENT_MAX_INTERVAL <=
+	    UINT64_MAX - SC_LARGE_MAXCLASS + 1);
+
+	thread_allocated_last_event_set(tsd, thread_allocated_after);
+	bool allow_event_trigger = !delay_event && tsd_nominal(tsd) &&
+	    tsd_reentrancy_level_get(tsd) == 0;
+	uint64_t wait = thread_event_trigger_batch_update(tsd, accumbytes,
+	    allow_event_trigger);
+	thread_event_adjust_thresholds_helper(tsd, wait);
+
+	thread_event_assert_invariants(tsd);
+
+#define E(event, condition)						\
+	if (condition && event##_event_wait_get(tsd) == 0U) {		\
+		assert(allow_event_trigger);				\
+		thread_##event##_event_handler(tsd);			\
+	}
+
+	ITERATE_OVER_ALL_EVENTS
+#undef E
+
+	thread_event_assert_invariants(tsd);
+}
+
+void
+thread_event_rollback(tsd_t *tsd, size_t diff) {
+	thread_event_assert_invariants(tsd);
+
+	if (diff == 0U) {
+		return;
+	}
+
+	uint64_t thread_allocated = thread_allocated_get(tsd);
+	/* The subtraction is intentionally susceptible to underflow. */
+	uint64_t thread_allocated_rollback = thread_allocated - diff;
+	thread_allocated_set(tsd, thread_allocated_rollback);
+
+	uint64_t last_event = thread_allocated_last_event_get(tsd);
+	/* Both subtractions are intentionally susceptible to underflow. */
+	if (thread_allocated_rollback - last_event <=
+	    thread_allocated - last_event) {
+		thread_event_assert_invariants(tsd);
+		return;
+	}
+
+	thread_allocated_last_event_set(tsd, thread_allocated_rollback);
+
+	/* The subtraction is intentionally susceptible to underflow. */
+	uint64_t wait_diff = last_event - thread_allocated_rollback;
+	assert(wait_diff <= diff);
+
+#define E(event, condition)						\
+	if (condition) {						\
+		uint64_t event_wait = event##_event_wait_get(tsd);	\
+		assert(event_wait <= THREAD_EVENT_MAX_START_WAIT);	\
+		if (event_wait > 0U) {					\
+			if (wait_diff >					\
+			    THREAD_EVENT_MAX_START_WAIT - event_wait) {	\
+				event_wait =				\
+				    THREAD_EVENT_MAX_START_WAIT;	\
+			} else {					\
+				event_wait += wait_diff;		\
+			}						\
+			assert(event_wait <=				\
+			    THREAD_EVENT_MAX_START_WAIT);		\
+			event##_event_wait_set(tsd, event_wait);	\
+		}							\
+	}
+
+	ITERATE_OVER_ALL_EVENTS
+#undef E
+
+	thread_event_update(tsd);
+}
+
+void
+thread_event_update(tsd_t *tsd) {
+	uint64_t wait = thread_allocated_next_event_compute(tsd);
+	thread_event_adjust_thresholds_helper(tsd, wait);
+
+	uint64_t last_event = thread_allocated_last_event_get(tsd);
+
+	/* Both subtractions are intentionally susceptible to underflow. */
+	if (thread_allocated_get(tsd) - last_event >=
+	    thread_allocated_next_event_get(tsd) - last_event) {
+		thread_event_trigger(tsd, true);
+	} else {
+		thread_event_assert_invariants(tsd);
+	}
+}
+
+void thread_event_boot() {
+#define E(event, condition)						\
+	if (condition) {						\
+		thread_event_active = true;				\
+	}
+
+	ITERATE_OVER_ALL_EVENTS
+#undef E
+}

--- a/test/unit/thread_event.c
+++ b/test/unit/thread_event.c
@@ -1,0 +1,57 @@
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_next_event_fast_roll_back) {
+	tsd_t *tsd = tsd_fetch();
+	thread_allocated_last_event_set(tsd, 0);
+	thread_allocated_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX - 8U);
+	thread_allocated_next_event_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX);
+	thread_allocated_next_event_fast_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX);
+	prof_sample_event_wait_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX);
+	void *p = malloc(16U);
+	assert_ptr_not_null(p, "malloc() failed");
+	free(p);
+}
+TEST_END
+
+TEST_BEGIN(test_next_event_fast_resume) {
+	tsd_t *tsd = tsd_fetch();
+	thread_allocated_last_event_set(tsd, 0);
+	thread_allocated_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX + 8U);
+	thread_allocated_next_event_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX + 16U);
+	thread_allocated_next_event_fast_set(tsd, 0);
+	prof_sample_event_wait_set(tsd,
+	    THREAD_ALLOCATED_NEXT_EVENT_FAST_MAX + 16U);
+	void *p = malloc(SC_LOOKUP_MAXCLASS);
+	assert_ptr_not_null(p, "malloc() failed");
+	free(p);
+}
+TEST_END
+
+TEST_BEGIN(test_event_rollback) {
+	tsd_t *tsd = tsd_fetch();
+	const uint64_t diff = THREAD_EVENT_MAX_INTERVAL >> 2;
+	size_t count = 10;
+	uint64_t thread_allocated = thread_allocated_get(tsd);
+	while (count-- != 0) {
+		thread_event_rollback(tsd, diff);
+		uint64_t thread_allocated_after = thread_allocated_get(tsd);
+		assert_u64_eq(thread_allocated - thread_allocated_after, diff,
+		    "thread event counters are not properly rolled back");
+		thread_allocated = thread_allocated_after;
+	}
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_next_event_fast_roll_back,
+	    test_next_event_fast_resume,
+	    test_event_rollback);
+}

--- a/test/unit/thread_event.sh
+++ b/test/unit/thread_event.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+fi


### PR DESCRIPTION
I haven't added unit tests. Will add later. I want to seek some early feedback on the design first.

A few remarks:

- I turned off the accumulation of allocation bytes on `thread_allocated` when `reentrancy_level > 0`.  Otherwise the implementation would become very tricky, because when `reentrancy_level > 0`, profiling should be turned off by jemalloc design - see https://github.com/jemalloc/jemalloc/blob/785b84e60382515f1bf1a63457da7a7ab5d0a96b/include/jemalloc/internal/prof_inlines_b.h#L135 but if `thread_allocated` keeps increasing, the wait time till the next sampling event would be incorrect, unless we keep some internal state so that when `reentrancy_level` drops back to `0`, we can adjust the wait time; this would require that the store and fetch for the internal state should have a `reentrancy_level` guard. I decided to rather have the guard on `thread_allocated` directly: after all, it's now not just a accumulator for allocations, but a counter for events, and in general it may not be a good idea to have allocations in jemalloc internal calls trigger events in the same way (which is probably why profiling was determined to be turned off for such internal allocations). And, just to be symmetric, I also turned off the incrementation of `thread_deallocated` when `reentrancy_level > 0`.

- The lazy creation of `tdata` made the event counting tricky; it means that the event counters were fooled due to the wrong wait time, and that they need to be recovered to a state as if they had only reacted to the right wait time. See my comments in the code for how I am resolving this issue and why.

- The event handler adopts a lazy approach for wait time reset, so that there's no longer the need to sometimes manually throw the wait time to a huge number (e.g. in the case where `opt_prof` is off), This ends up with cleaner code.

- I also rearranged the `tsd` layout. `prof_tdata` has been no longer needed on the fast path ever since `bytes_until_sample` is extracted out of `tdata`, and now `bytes_until_sample` is also not needed on the fast path though we need an additional `thread_allocated_threshold_fast` on the fast path. We end up needing 8 bytes less on the fast path. So I shifted `rtree_ctx` ahead by 16 bytes (previously we put one extra slow path field ahead of it since it needs to be 16-byte aligned), and put all slow path fields after it. I also changed the layout diagram to reflect that, including adding the span for `binshards` (which takes quite an amount of space and I'm not sure if putting it completely before the `tcache` is optimal).

- My comment in my earlier design #1616 are mostly still relevant -

  - The first two bullets on resolving double counting issue still apply.

  - The third bullet on overwriting `thread_allocated` is no longer relevant: the current implementation never overwrites it so as to be consistent with the promise to the application by jemalloc.

  - The fourth bullet on resolving overflow issue still applies. One slight but visible implementation detail: previously the test for event triggering is a strict less than comparison i.e. `bytes_until_sample < 0`, but now the equal case also counts - the test is now `thread_allocated >= thread_allocated_threshold_fast` (or the real threshold in the slow path). The reason is that when `thread_allocated_threshold_fast` is set to be `0`, we want `thread_allocated >= thread_allocated_threshold_fast` to be always true, so that we can fall back to the slow path.

  - Regarding the fifth bullet on the need of increased delaying due to the delayed incrementation of `thread_allocated`: the issue is now resolved in a cleaner and more intuitive way, via the use of the `thread_allocated_last_event` counter (which is a nice side byproduct of it, since it's not designed for this purpose in the first place).

  - Regarding the sixth bullet on `update` flag being no longer necessary for `prof_sample_check()`: now the logic is even simpler - there's no need for the `prof_sample_check()` function completely, since the `thread_event()` call has adjusted the wait time if and only if an event was triggered, so we only need to check the remaining wait time rather than doing any further comparison.