### PR TITLE
Fix je_ prefix issue in test

### DIFF
--- a/msvc/test_threads/test_threads.cpp
+++ b/msvc/test_threads/test_threads.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <vector>
 #include <stdio.h>
+#define JEMALLOC_NO_DEMANGLE
 #include <jemalloc/jemalloc.h>
 
 using std::vector;


### PR DESCRIPTION
I have a packaging procedure which runs tests. Unfortunaly at the moment the msvc tests are sensitive to the prefix being exactly `je_`.