### PR TITLE
fix compiler warnings with gcc 9

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2970,7 +2970,7 @@ JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
  * be implemented also, so none of glibc's malloc.o functions are added to the
  * link.
  */
-#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), used))
+#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), copy(je_fn)))
 /* To force macro expansion of je_ prefix before stringification. */
 #    define PREALIAS(je_fn)	ALIAS(je_fn)
 #    ifdef JEMALLOC_OVERRIDE___LIBC_CALLOC

--- a/src/prof.c
+++ b/src/prof.c
@@ -613,8 +613,8 @@ prof_dump_prefix_set(tsdn_t *tsdn, const char *prefix) {
 	}
 	assert(prof_dump_prefix != NULL);
 
-	strncpy(prof_dump_prefix, prefix, sizeof(prof_dump_prefix) - 1);
-	prof_dump_prefix[sizeof(prof_dump_prefix) - 1] = '\0';
+	strncpy(prof_dump_prefix, prefix, strlen(prof_dump_prefix) - 1);
+	prof_dump_prefix[strlen(prof_dump_prefix) - 1] = '\0';
 	malloc_mutex_unlock(tsdn, &prof_dump_filename_mtx);
 
 	return false;

--- a/src/prof.c
+++ b/src/prof.c
@@ -613,8 +613,8 @@ prof_dump_prefix_set(tsdn_t *tsdn, const char *prefix) {
 	}
 	assert(prof_dump_prefix != NULL);
 
-	strncpy(prof_dump_prefix, prefix, PROF_DUMP_FILENAME_LEN - 1);
-	prof_dump_prefix[PROF_DUMP_FILENAME_LEN - 1] = '\0';
+	strncpy(prof_dump_prefix, prefix, sizeof(prof_dump_prefix) - 1);
+	prof_dump_prefix[sizeof(prof_dump_prefix) - 1] = '\0';
 	malloc_mutex_unlock(tsdn, &prof_dump_filename_mtx);
 
 	return false;


### PR DESCRIPTION
caused by -Wmissing-attributes and -Wstringop-truncation in my local setup
Refers #1612 
gcc version gcc version 9.1.0 (GCC)
kernel : 4.19.69-1-MANJARO