### PR TITLE
Optimize cache_bin_alloc_easy for malloc fast path

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2372,7 +2372,7 @@ je_malloc(size_t size) {
 
 	cache_bin_t *bin = tcache_small_bin_get(tcache, ind);
 	bool tcache_success;
-	void *ret = cache_bin_alloc_easy(bin, &tcache_success, ind);
+	void *ret = cache_bin_alloc_easy_reduced(bin, &tcache_success);
 
 	if (tcache_success) {
 		*tsd_thread_allocatedp_get(tsd) += usize;


### PR DESCRIPTION
`tcache_bin_info` is not accessed on malloc fast path but the
compiler reserves a register for it, as well as an additional
register for `tcache_bin_info[ind].stack_size`.  The new optimization
gets rid of the need for the two registers.