### PR TITLE
[RFC] Disable cache index randomization by default.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1395,7 +1395,7 @@ else
   enable_cache_oblivious="1"
 fi
 ],
-[enable_cache_oblivious="1"]
+[enable_cache_oblivious="0"]
 )
 if test "x$enable_cache_oblivious" = "x1" ; then
   AC_DEFINE([JEMALLOC_CACHE_OBLIVIOUS], [ ])


### PR DESCRIPTION
As modern architectures adopt smarter cache mapping algorithms, e.g. hashing
combined with set associative, the likelihood of cache thrashing from page
aligned large allocations is reduced.  Turning off the randomization by default
to avoid the overhead (one extra page per large allocation).