### PR TITLE
Guard slabcur fetching in extent_util

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3199,7 +3199,8 @@ label_return:
  * otherwise their values are undefined.
  *
  * This API is mainly intended for small class allocations, where extents are
- * used as slab.
+ * used as slab.  Note that if the bin the extent belongs to is completely
+ * full, "(a)" will be NULL.
  *
  * In case of large class allocations, "(a)" will be NULL, and "(e)" and "(f)"
  * will be zero (if stats are enabled; otherwise undefined).  The other three

--- a/src/extent.c
+++ b/src/extent.c
@@ -2124,7 +2124,12 @@ extent_util_stats_verbose_get(tsdn_t *tsdn, const void *ptr,
 	} else {
 		*bin_nfree = *bin_nregs = 0;
 	}
-	*slabcur_addr = extent_addr_get(bin->slabcur);
-	assert(*slabcur_addr != NULL);
+	extent_t *slab;
+	if (bin->slabcur != NULL) {
+		slab = bin->slabcur;
+	} else {
+		slab = extent_heap_first(&bin->slabs_nonfull);
+	}
+	*slabcur_addr = slab != NULL ? extent_addr_get(slab) : NULL;
 	malloc_mutex_unlock(tsdn, &bin->lock);
 }

--- a/test/unit/extent_util.c
+++ b/test/unit/extent_util.c
@@ -94,10 +94,8 @@ TEST_BEGIN(test_query) {
 			    "Extent region count exceeded size");
 			assert_zu_ne(NREGS_READ(out), 0,
 			    "Extent region count must be positive");
-			assert_ptr_not_null(SLABCUR_READ(out),
-			    "Current slab is null");
-			assert_true(NFREE_READ(out) == 0
-			    || SLABCUR_READ(out) <= p,
+			assert_true(NFREE_READ(out) == 0 || (SLABCUR_READ(out)
+			    != NULL && SLABCUR_READ(out) <= p),
 			    "Allocation should follow first fit principle");
 			if (config_stats) {
 				assert_zu_le(BIN_NFREE_READ(out),


### PR DESCRIPTION
`slabcur` can be `NULL`, and in such cases, the extent utilization querying logic should fetch the first extent from the non-full extents, because it will become `slabcur` next. If this fails, then the logic returns `NULL`.