### PR TITLE
Fix a low_water assertion on in cache_bin_alloc_easy_impl.

### DIFF
--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -215,7 +215,7 @@ cache_bin_alloc_easy_impl(cache_bin_t *bin, bool *success, szind_t ind,
 		} else {
 			assert(ind == INVALID_SZIND);
 			bin->cur_ptr.ptr--;
-			assert(bin->cur_ptr.lowbits == bin->low_water_position);
+			assert(bin->cur_ptr.lowbits >= bin->low_water_position);
 			*success = false;
 			return NULL;
 		}


### PR DESCRIPTION
The regression was introduced in https://github.com/jemalloc/jemalloc/commit/05681e387a3202567ff95528dbc460e92e031a3c.

However, as perviously mentioned by @yinan1048576, the assertions are not included in opt builds, while the fast path is not walked in the dbg mode. We'll need to introduce an opt + assert mode later.