### PR TITLE
Bail out early for muzzy decay.

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -919,7 +919,7 @@ arena_decay_to_limit(tsdn_t *tsdn, arena_t *arena, arena_decay_t *decay,
 	    WITNESS_RANK_CORE, 1);
 	malloc_mutex_assert_owner(tsdn, &decay->mtx);
 
-	if (decay->purging) {
+	if (decay->purging || npages_decay_max == 0) {
 		return;
 	}
 	decay->purging = true;
@@ -988,6 +988,10 @@ arena_decay_dirty(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
 static bool
 arena_decay_muzzy(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
     bool all) {
+	if (eset_npages_get(&arena->eset_muzzy) == 0 &&
+	    arena_muzzy_decay_ms_get(arena) <= 0) {
+		return false;
+	}
 	return arena_decay_impl(tsdn, arena, &arena->decay_muzzy,
 	    &arena->eset_muzzy, is_background_thread, all);
 }


### PR DESCRIPTION
This avoids taking the muzzy decay mutex with the default setting.

Apparently the muzzy decay mutex is taken often, e.g. ~18k / sec:
```
                           n_lock_ops (#/sec)       n_waiting (#/sec)      n_spin_acq (#/sec)  n_owner_switch (#/sec)   total_wait_ns   (#/sec)     max_wait_ns  max_n_thds
decay_dirty                  86828893    9611               0       0              56       0        26608711    2945               0         0               0           0
decay_muzzy                 161508733   17877               0       0             366       0        26308543    2912               0         0               0           0
```
even busier than the dirty decay mutex, due to `arena_decay_to_limit` triggered at [arena.c:L720](https://github.com/jemalloc/jemalloc/pull/1672/files#diff-2010398b2a21c107bdc82bd7eb73cea6R720) (being fixed here).