### PR TITLE
Revert "Fix bug in prof_realloc"

### DIFF
--- a/include/jemalloc/internal/prof_inlines_b.h
+++ b/include/jemalloc/internal/prof_inlines_b.h
@@ -203,7 +203,7 @@ prof_realloc(tsd_t *tsd, const void *ptr, size_t usize, prof_tctx_t *tctx,
 	 * counters.
 	 */
 	if (unlikely(old_sampled)) {
-		prof_free_sampled_object(tsd, old_ptr, old_usize, old_tctx);
+		prof_free_sampled_object(tsd, ptr, old_usize, old_tctx);
 	}
 }
 


### PR DESCRIPTION
Reverts jemalloc/jemalloc#1683

The fix was a wrong fix: the logic in `prof_free_sampled_object()` may try to access the extent `old_ptr` resides in, which could be gone at this moment. The correct fix would be more complicated to implement. Having the wrong fix may lead to a crash whereas reverting it back only causes a logical error, so revert.