### PR TITLE
Fix bug in prof_realloc

### DIFF
--- a/include/jemalloc/internal/prof_inlines_b.h
+++ b/include/jemalloc/internal/prof_inlines_b.h
@@ -203,7 +203,7 @@ prof_realloc(tsd_t *tsd, const void *ptr, size_t usize, prof_tctx_t *tctx,
 	 * counters.
 	 */
 	if (unlikely(old_sampled)) {
-		prof_free_sampled_object(tsd, ptr, old_usize, old_tctx);
+		prof_free_sampled_object(tsd, NULL, old_usize, old_tctx);
 	}
 }
 


### PR DESCRIPTION
Temporarily disallow `prof_realloc()` to pass in the old pointer.

The old pointer has primarily been used for logging purpose.
Logging needs to access the `extent` the old pointer sits in, which
is unfortunately lost at the time `prof_free_sampled_object()` is
called on the `prof_realloc()` code path, and it's not trivial to
refactor the code to properly reserve the `extent` till the time
`prof_free_sampled_object()` is called.

Disallowing `prof_realloc()` to pass in the old pointer will result
in not recording the associated deallocation, which is better than
recording a wrong deallocation.  Given that the majority of the
traffic will go through `prof_malloc()` and `prof_free()` instead of
`prof_realloc()`, this should be the "minimally incorrect" fix in a
short time.