### PR TITLE
Fix incorrect usage of cassert.

### DIFF
--- a/src/tcache.c
+++ b/src/tcache.c
@@ -402,7 +402,7 @@ tsd_tcache_enabled_data_init(tsd_t *tsd) {
 
 static bool
 tcache_bin_init(cache_bin_t *bin, szind_t ind, uintptr_t *stack_cur) {
-	cassert(sizeof(bin->cur_ptr) == sizeof(void *));
+	assert(sizeof(bin->cur_ptr) == sizeof(void *));
 	/*
 	 * The full_position points to the lowest available space.  Allocations
 	 * will access the slots toward higher addresses (for the benefit of

--- a/src/thread_event.c
+++ b/src/thread_event.c
@@ -189,8 +189,7 @@ thread_event_trigger(tsd_t *tsd, bool delay_event) {
 	    thread_allocated_last_event_get(tsd);
 
 	/* Make sure that accumbytes cannot overflow uint64_t. */
-	cassert(THREAD_EVENT_MAX_INTERVAL <=
-	    UINT64_MAX - SC_LARGE_MAXCLASS + 1);
+	assert(THREAD_EVENT_MAX_INTERVAL <= UINT64_MAX - SC_LARGE_MAXCLASS + 1);
 
 	thread_allocated_last_event_set(tsd, thread_allocated_after);
 	bool allow_event_trigger = !delay_event && tsd_nominal(tsd) &&

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -4,7 +4,7 @@ cache_bin_t test_bin;
 
 TEST_BEGIN(test_cache_bin) {
 	cache_bin_t *bin = &test_bin;
-	cassert(PAGE > TCACHE_NSLOTS_SMALL_MAX * sizeof(void *));
+	assert(PAGE > TCACHE_NSLOTS_SMALL_MAX * sizeof(void *));
 	/* Page aligned to make sure lowbits not overflowable. */
 	void **stack = mallocx(PAGE, MALLOCX_TCACHE_NONE | MALLOCX_ALIGN(PAGE));
 


### PR DESCRIPTION
I thought cassert was for static assert. Apparently it's intended for config assertion instead.