### PR TITLE
Correct stats for realloc() / rallocx()

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3116,7 +3116,11 @@ do_rallocx(void *ptr, size_t size, int flags, bool is_realloc) {
 	}
 	assert(alignment == 0 || ((uintptr_t)p & (alignment - 1)) == ZU(0));
 
-	*tsd_thread_deallocatedp_get(tsd) += old_usize;
+	if (p == ptr && usize == old_usize) {
+		thread_event_rollback(tsd, usize);
+	} else {
+		*tsd_thread_deallocatedp_get(tsd) += old_usize;
+	}
 
 	UTRACE(ptr, size, p);
 	check_entry_exit_locking(tsd_tsdn(tsd));

--- a/test/unit/zero_realloc_free.c
+++ b/test/unit/zero_realloc_free.c
@@ -2,9 +2,6 @@
 
 static uint64_t
 deallocated() {
-	if (!config_stats) {
-		return 0;
-	}
 	uint64_t deallocated;
 	size_t sz = sizeof(deallocated);
 	assert_d_eq(mallctl("thread.deallocated", (void *)&deallocated, &sz,
@@ -19,10 +16,8 @@ TEST_BEGIN(test_realloc_free) {
 	ptr = realloc(ptr, 0);
 	uint64_t deallocated_after = deallocated();
 	assert_ptr_null(ptr, "Realloc didn't free");
-	if (config_stats) {
-		assert_u64_gt(deallocated_after, deallocated_before,
-		    "Realloc didn't free");
-	}
+	assert_u64_gt(deallocated_after, deallocated_before,
+	    "Realloc didn't free");
 }
 TEST_END
 

--- a/test/unit/zero_realloc_strict.c
+++ b/test/unit/zero_realloc_strict.c
@@ -2,9 +2,6 @@
 
 static uint64_t
 allocated() {
-	if (!config_stats) {
-		return 0;
-	}
 	uint64_t allocated;
 	size_t sz = sizeof(allocated);
 	assert_d_eq(mallctl("thread.allocated", (void *)&allocated, &sz, NULL,
@@ -14,9 +11,6 @@ allocated() {
 
 static uint64_t
 deallocated() {
-	if (!config_stats) {
-		return 0;
-	}
 	uint64_t deallocated;
 	size_t sz = sizeof(deallocated);
 	assert_d_eq(mallctl("thread.deallocated", (void *)&deallocated, &sz,
@@ -32,12 +26,10 @@ TEST_BEGIN(test_realloc_strict) {
 	ptr = realloc(ptr, 0);
 	uint64_t allocated_after = allocated();
 	uint64_t deallocated_after = deallocated();
-	if (config_stats) {
-		assert_u64_lt(allocated_before, allocated_after,
-		    "Unexpected stats change");
-		assert_u64_lt(deallocated_before, deallocated_after,
-		    "Unexpected stats change");
-	}
+	assert_u64_lt(allocated_before, allocated_after,
+	    "Unexpected stats change");
+	assert_u64_lt(deallocated_before, deallocated_after,
+	    "Unexpected stats change");
 	dallocx(ptr, 0);
 }
 TEST_END

--- a/test/unit/zero_realloc_strict.c
+++ b/test/unit/zero_realloc_strict.c
@@ -25,7 +25,7 @@ deallocated() {
 }
 
 TEST_BEGIN(test_realloc_strict) {
-	void *ptr = mallocx(1, 0);
+	void *ptr = mallocx(42, 0);
 	assert_ptr_not_null(ptr, "Unexpected mallocx error");
 	uint64_t allocated_before = allocated();
 	uint64_t deallocated_before = deallocated();


### PR DESCRIPTION
`thread.allocated` and `thread.deallocated` should not be increased
when `realloc()` / `rallocx()` does not change the allocation.  This
also aligns with what `xallocx()` has been doing.
