### PR TITLE
Restructure setters for profiling info

### DIFF
--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -68,8 +68,7 @@ arena_prof_info_get(tsd_t *tsd, const void *ptr, alloc_ctx_t *alloc_ctx,
 }
 
 JEMALLOC_ALWAYS_INLINE void
-arena_prof_tctx_set(tsd_t *tsd, const void *ptr, alloc_ctx_t *alloc_ctx,
-    prof_tctx_t *tctx) {
+arena_prof_tctx_reset(tsd_t *tsd, const void *ptr, alloc_ctx_t *alloc_ctx) {
 	cassert(config_prof);
 	assert(ptr != NULL);
 
@@ -77,17 +76,17 @@ arena_prof_tctx_set(tsd_t *tsd, const void *ptr, alloc_ctx_t *alloc_ctx,
 	if (alloc_ctx == NULL) {
 		extent_t *extent = iealloc(tsd_tsdn(tsd), ptr);
 		if (unlikely(!extent_slab_get(extent))) {
-			large_prof_tctx_set(extent, tctx);
+			large_prof_tctx_reset(extent);
 		}
 	} else {
 		if (unlikely(!alloc_ctx->slab)) {
-			large_prof_tctx_set(iealloc(tsd_tsdn(tsd), ptr), tctx);
+			large_prof_tctx_reset(iealloc(tsd_tsdn(tsd), ptr));
 		}
 	}
 }
 
-static inline void
-arena_prof_tctx_reset(tsd_t *tsd, const void *ptr, prof_tctx_t *tctx) {
+JEMALLOC_ALWAYS_INLINE void
+arena_prof_tctx_reset_sampled(tsd_t *tsd, const void *ptr) {
 	cassert(config_prof);
 	assert(ptr != NULL);
 
@@ -98,13 +97,13 @@ arena_prof_tctx_reset(tsd_t *tsd, const void *ptr, prof_tctx_t *tctx) {
 }
 
 JEMALLOC_ALWAYS_INLINE void
-arena_prof_alloc_time_set(tsd_t *tsd, const void *ptr, nstime_t *t) {
+arena_prof_info_set(tsd_t *tsd, const void *ptr, prof_tctx_t *tctx) {
 	cassert(config_prof);
 	assert(ptr != NULL);
 
 	extent_t *extent = iealloc(tsd_tsdn(tsd), ptr);
 	assert(!extent_slab_get(extent));
-	large_prof_alloc_time_set(extent, t);
+	large_prof_info_set(extent, tctx);
 }
 
 JEMALLOC_ALWAYS_INLINE void

--- a/include/jemalloc/internal/large_externs.h
+++ b/include/jemalloc/internal/large_externs.h
@@ -23,8 +23,7 @@ void large_dalloc_finish(tsdn_t *tsdn, extent_t *extent);
 void large_dalloc(tsdn_t *tsdn, extent_t *extent);
 size_t large_salloc(tsdn_t *tsdn, const extent_t *extent);
 void large_prof_info_get(const extent_t *extent, prof_info_t *prof_info);
-void large_prof_tctx_set(extent_t *extent, prof_tctx_t *tctx);
 void large_prof_tctx_reset(extent_t *extent);
-void large_prof_alloc_time_set(extent_t *extent, nstime_t *time);
+void large_prof_info_set(extent_t *extent, prof_tctx_t *tctx);
 
 #endif /* JEMALLOC_INTERNAL_LARGE_EXTERNS_H */

--- a/src/large.c
+++ b/src/large.c
@@ -372,7 +372,7 @@ large_prof_info_get(const extent_t *extent, prof_info_t *prof_info) {
 	extent_prof_info_get(extent, prof_info);
 }
 
-void
+static void
 large_prof_tctx_set(extent_t *extent, prof_tctx_t *tctx) {
 	extent_prof_tctx_set(extent, tctx);
 }
@@ -383,6 +383,9 @@ large_prof_tctx_reset(extent_t *extent) {
 }
 
 void
-large_prof_alloc_time_set(extent_t *extent, nstime_t *t) {
-	extent_prof_alloc_time_set(extent, t);
+large_prof_info_set(extent_t *extent, prof_tctx_t *tctx) {
+	large_prof_tctx_set(extent, tctx);
+	nstime_t t;
+	nstime_init_update(&t);
+	extent_prof_alloc_time_set(extent, &t);
 }

--- a/src/prof.c
+++ b/src/prof.c
@@ -162,13 +162,7 @@ prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx, bool updated) {
 void
 prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t usize,
     prof_tctx_t *tctx) {
-	prof_tctx_set(tsd, ptr, NULL, tctx);
-
-	/* Get the current time and set this in the extent_t. We'll read this
-	 * when free() is called. */
-	nstime_t t;
-	nstime_init_update(&t);
-	prof_alloc_time_set(tsd, ptr, &t);
+	prof_info_set(tsd, ptr, tctx);
 
 	malloc_mutex_lock(tsd_tsdn(tsd), tctx->tdata->lock);
 	tctx->cnts.curobjs++;


### PR DESCRIPTION
Explicitly define three setters:
- `prof_tctx_set_not_sampled()`: set `prof_tctx` to `1U`, if we don't know in advance whether the allocation is large or not;
- `prof_tctx_reset()`: set `prof_tctx` to `1U`, if we already know in advance that the allocation is large;
- `prof_info_set()`: set a real `prof_tctx`, and also set other profiling info e.g. the allocation time.

Code structure wise, the prof level is kept as a thin wrapper, the large level only provides low level setter APIs, and the arena level carries out the main logic.