### PR TITLE
fix opt.thp:never still use THP with base_map

### DIFF
--- a/src/base.c
+++ b/src/base.c
@@ -39,6 +39,9 @@ base_map(tsdn_t *tsdn, extent_hooks_t *extent_hooks, unsigned ind, size_t size) 
 	size_t alignment = HUGEPAGE;
 	if (extent_hooks == &extent_hooks_default) {
 		addr = extent_alloc_mmap(NULL, size, alignment, &zero, &commit);
+		if (have_madvise_huge && addr) {
+			pages_set_thp_state(addr, size);
+		}
 	} else {
 		/* No arena context as we are creating new arenas. */
 		tsd_t *tsd = tsdn_null(tsdn) ? tsd_fetch() : tsdn_tsd(tsdn);


### PR DESCRIPTION
I found with `export MALLOC_CONF=thp:never` & `/sys/kernel/mm/transparent_hugepage/enabled`'s value: `always`, there's still `AnonHugePages` usage in /proc/`pidof xxx`/smaps.  After tracing, I found all viraddrs which toggle anon huge page fault handler is from base_new, such as:

```
tid: 38746	viraddr: 0xfffba0000000	mmap_start: 0xfffba0000000	AnonHugeFaultHandlerRet: 0	madvised: False 
		os_pages_map+0x0 [xxx]
		_rjem_je_extent_alloc_mmap+0x28 [xxx]
		_rjem_je_base_new+0x308 [xxx]
		_rjem_je_arena_new+0x9c [xxx]
		_rjem_je_arena_choose_hard+0x25c [xxx]
		_rjem_je_tsd_tcache_data_init+0x44c [xxx]
		_rjem_je_tsd_tcache_enabled_data_init+0x40 [xxx]
		_rjem_je_tsd_fetch_slow+0x158 [xxx]
		malloc+0x188 [xxx]
		pthread_getattr_np+0xec [libpthread-2.28.so]
```

So I add `pages_set_thp_state` in `base_map` like `extent_alloc_default_impl` does, then THP go away. 

Please let me know if this fix fits your original intention. Thank you.



