### PR TITLE
Fine-grained sharding: add default bins for auto arenas.

### DIFF
--- a/include/jemalloc/internal/arena_structs.h
+++ b/include/jemalloc/internal/arena_structs.h
@@ -175,11 +175,12 @@ struct arena_s {
 	edata_cache_t		edata_cache;
 
 	/*
-	 * bins is used to store heaps of free regions.
+	 * Bins for a0 and non auto arenas.  Null for auto arenas which will use
+	 * the default bins which live outside of arena.
 	 *
 	 * Synchronization: internal.
 	 */
-	bins_t			bins[SC_NBINS];
+	bin_t			*manual_bins;
 
 	/*
 	 * Base allocator, from which arena metadata are allocated.

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -39,12 +39,17 @@ struct bin_s {
 };
 
 /* A set of sharded bins of the same size class. */
-typedef struct bins_s bins_t;
-struct bins_s {
-	/* Sharded bins.  Dynamically sized. */
-	bin_t *bin_shards;
+typedef struct sharded_bins_s sharded_bins_t;
+struct sharded_bins_s {
+	/* Total # of shards for this bin. */
+	unsigned n_shards;
+	/* Sharded bins w/ the size above. */
+	bin_t **bin_shards;
 };
 
+extern sharded_bins_t default_bins[SC_NBINS];
+
+bool default_bins_boot(tsd_t *tsd, unsigned narenas_auto);
 void bin_shard_sizes_boot(unsigned bin_shards[SC_NBINS]);
 bool bin_update_shard_size(unsigned bin_shards[SC_NBINS], size_t start_size,
     size_t end_size, size_t nshards);

--- a/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -70,10 +70,15 @@ arena_ichoose(tsd_t *tsd, arena_t *arena) {
 }
 
 static inline bool
-arena_is_auto(arena_t *arena) {
+arena_ind_is_auto(unsigned ind) {
 	assert(narenas_auto > 0);
 
-	return (arena_ind_get(arena) < manual_arena_base);
+	return ind < manual_arena_base;
+}
+
+static inline bool
+arena_is_auto(arena_t *arena) {
+	return arena_ind_is_auto(arena_ind_get(arena));
 }
 
 JEMALLOC_ALWAYS_INLINE edata_t *

--- a/src/bin.c
+++ b/src/bin.c
@@ -6,6 +6,9 @@
 #include "jemalloc/internal/sc.h"
 #include "jemalloc/internal/witness.h"
 
+/* Default set of bins used to store heaps of free regions. */
+sharded_bins_t default_bins[SC_NBINS];
+
 bool
 bin_update_shard_size(unsigned bin_shard_sizes[SC_NBINS], size_t start_size,
     size_t end_size, size_t nshards) {
@@ -36,6 +39,35 @@ bin_shard_sizes_boot(unsigned bin_shard_sizes[SC_NBINS]) {
 	for (unsigned i = 0; i < SC_NBINS; i++) {
 		bin_shard_sizes[i] = N_BIN_SHARDS_DEFAULT;
 	}
+}
+
+bool
+default_bins_boot(tsd_t *tsd, unsigned narenas_auto) {
+	unsigned n_total_shards = 0;
+	for (unsigned i = 0; i < SC_NBINS; i++) {
+		n_total_shards += bin_infos[i].n_shards;
+	}
+	n_total_shards *= narenas_auto;
+
+	/* Init the pointer array.  Actual bins are allocated on demand. */
+	bin_t **bin_ptrs = base_alloc(tsd_tsdn(tsd), b0get(),
+	    n_total_shards * sizeof(bin_t *), CACHELINE);
+	if (bin_ptrs == NULL) {
+		return true;
+	}
+	memset(bin_ptrs, 0, n_total_shards * sizeof(bin_t *));
+
+	bin_t **next_bin = bin_ptrs;
+	for (unsigned i = 0; i < SC_NBINS; i++) {
+		default_bins[i].bin_shards = next_bin;
+
+		unsigned nbins = bin_infos[i].n_shards * narenas_auto;
+		default_bins[i].n_shards = nbins;
+		next_bin += nbins;
+	}
+	assert(next_bin == bin_ptrs + n_total_shards);
+
+	return false;
 }
 
 bool

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3030,8 +3030,9 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib,
 		MUTEX_PROF_RESET(arena->base->mtx);
 
 		for (szind_t j = 0; j < SC_NBINS; j++) {
-			for (unsigned k = 0; k < bin_infos[j].n_shards; k++) {
-				bin_t *bin = &arena->bins[j].bin_shards[k];
+			for (unsigned k = 0; k < arena_bin_nshards_get(arena,
+			    j); k++) {
+				bin_t *bin = arena_bin_get(arena, j, k);
 				MUTEX_PROF_RESET(bin->lock);
 			}
 		}

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3029,9 +3029,9 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib,
 		MUTEX_PROF_RESET(arena->tcache_ql_mtx);
 		MUTEX_PROF_RESET(arena->base->mtx);
 
-		for (szind_t i = 0; i < SC_NBINS; i++) {
-			for (unsigned j = 0; j < bin_infos[i].n_shards; j++) {
-				bin_t *bin = &arena->bins[i].bin_shards[j];
+		for (szind_t j = 0; j < SC_NBINS; j++) {
+			for (unsigned k = 0; k < bin_infos[j].n_shards; k++) {
+				bin_t *bin = &arena->bins[j].bin_shards[k];
 				MUTEX_PROF_RESET(bin->lock);
 			}
 		}

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -52,11 +52,11 @@ inspect_extent_util_stats_verbose_get(tsdn_t *tsdn, const void *ptr,
 	assert(*nfree <= *nregs);
 	assert(*nfree * edata_usize_get(edata) <= *size);
 
-	const arena_t *arena = (arena_t *)atomic_load_p(
+	arena_t *arena = (arena_t *)atomic_load_p(
 	    &arenas[edata_arena_ind_get(edata)], ATOMIC_RELAXED);
 	assert(arena != NULL);
 	const unsigned binshard = edata_binshard_get(edata);
-	bin_t *bin = &arena->bins[szind].bin_shards[binshard];
+	bin_t *bin = arena_bin_get(arena, szind, binshard);
 
 	malloc_mutex_lock(tsdn, &bin->lock);
 	if (config_stats) {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1588,7 +1588,6 @@ malloc_init_hard_a0_locked() {
 	 */
 	narenas_auto = 1;
 	manual_arena_base = narenas_auto + 1;
-	memset(arenas, 0, sizeof(arena_t *) * narenas_auto);
 	/*
 	 * Initialize one arena here.  The rest are lazily created in
 	 * arena_choose_hard().
@@ -1808,7 +1807,9 @@ malloc_init_hard(void) {
 	/* Set reentrancy level to 1 during init. */
 	pre_reentrancy(tsd, NULL);
 	/* Initialize narenas before prof_boot2 (for allocation). */
-	if (malloc_init_narenas() || background_thread_boot1(tsd_tsdn(tsd))) {
+	if (malloc_init_narenas() ||
+	    default_bins_boot(tsd, narenas_auto) ||
+	    background_thread_boot1(tsd_tsdn(tsd))) {
 		UNLOCK_RETURN(tsd_tsdn(tsd), true, true)
 	}
 	if (config_prof && prof_boot2(tsd)) {

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -175,7 +175,7 @@ tcache_bin_flush_small(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 		    false);
 		unsigned binshard = edata_binshard_get(edata);
 		assert(binshard < bin_infos[binind].n_shards);
-		bin_t *bin = &bin_arena->bins[binind].bin_shards[binshard];
+		bin_t *bin = arena_bin_get(bin_arena, binind, binshard);
 
 		malloc_mutex_lock(tsd_tsdn(tsd), &bin->lock);
 		if (config_stats && bin_arena == arena && !merged_stats) {

--- a/test/unit/binshard.sh
+++ b/test/unit/binshard.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="narenas:1,bin_shards:1-160:16|129-512:4|256-256:8"
+export MALLOC_CONF="narenas:2,bin_shards:1-160:16|129-512:4|256-256:8"


### PR DESCRIPTION
Make the default bins live outside of the auto arenas.  This will help
implementing a thread-to-bin binding w/o relying on arena.

This still assumes the current bin-arena binding strategy, however the
`default_bins` will allow us to change that soon.