### PR TITLE
Unify buffered writer naming

### DIFF
--- a/include/jemalloc/internal/malloc_io.h
+++ b/include/jemalloc/internal/malloc_io.h
@@ -119,9 +119,9 @@ typedef struct {
 	char *buf;
 	size_t buf_size; /* must be one less than the capacity of buf array */
 	size_t buf_end;
-} buf_writer_arg_t;
+} buf_write_arg_t;
 
-void buf_writer_flush(buf_writer_arg_t *arg);
-void buffered_write_cb(void *buf_writer_arg, const char *s);
+void buf_write_flush(buf_write_arg_t *arg);
+void buf_write_cb(void *buf_write_arg, const char *s);
 
 #endif /* JEMALLOC_INTERNAL_MALLOC_IO_H */

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3696,10 +3696,10 @@ je_malloc_stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		char *stats_print_buf = (char *)iallocztm(tsdn,
 		    STATS_PRINT_BUFSIZE, sz_size2index(STATS_PRINT_BUFSIZE),
 		    false, NULL, true, arena_get(TSDN_NULL, 0, true), true);
-		buf_writer_arg_t stats_print_buf_arg = {write_cb, cbopaque,
+		buf_write_arg_t stats_print_buf_arg = {write_cb, cbopaque,
 		    stats_print_buf, STATS_PRINT_BUFSIZE - 1, 0};
-		stats_print(buffered_write_cb, &stats_print_buf_arg, opts);
-		buf_writer_flush(&stats_print_buf_arg);
+		stats_print(buf_write_cb, &stats_print_buf_arg, opts);
+		buf_write_flush(&stats_print_buf_arg);
 		idalloctm(tsdn, stats_print_buf, NULL, NULL, true, true);
 	}
 

--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -665,7 +665,7 @@ malloc_printf(const char *format, ...) {
 }
 
 void
-buf_writer_flush(buf_writer_arg_t *arg) {
+buf_write_flush(buf_write_arg_t *arg) {
 	assert(arg->buf_end <= arg->buf_size);
 	arg->buf[arg->buf_end] = '\0';
 	if (arg->write_cb == NULL) {
@@ -677,13 +677,13 @@ buf_writer_flush(buf_writer_arg_t *arg) {
 }
 
 void
-buffered_write_cb(void *buf_writer_arg, const char *s) {
-	buf_writer_arg_t *arg = (buf_writer_arg_t *)buf_writer_arg;
+buf_write_cb(void *buf_write_arg, const char *s) {
+	buf_write_arg_t *arg = (buf_write_arg_t *)buf_write_arg;
 	size_t i, slen, n, s_remain, buf_remain;
 	assert(arg->buf_end <= arg->buf_size);
 	for (i = 0, slen = strlen(s); i < slen; i += n) {
 		if (arg->buf_end == arg->buf_size) {
-			buf_writer_flush(arg);
+			buf_write_flush(arg);
 		}
 		s_remain = slen - i;
 		buf_remain = arg->buf_size - arg->buf_end;

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -631,12 +631,12 @@ prof_log_stop(tsdn_t *tsdn) {
 	char *prof_log_stop_buf = (char *)iallocztm(tsdn,
 	    PROF_LOG_STOP_BUFSIZE, sz_size2index(PROF_LOG_STOP_BUFSIZE),
 	    false, NULL, true, arena_get(TSDN_NULL, 0, true), true);
-	buf_writer_arg_t prof_log_stop_buf_arg = {prof_emitter_write_cb, &arg,
+	buf_write_arg_t prof_log_stop_buf_arg = {prof_emitter_write_cb, &arg,
 	    prof_log_stop_buf, PROF_LOG_STOP_BUFSIZE - 1, 0};
 
 	/* Emit to json. */
-	emitter_init(&emitter, emitter_output_json_compact,
-	    buffered_write_cb, &prof_log_stop_buf_arg);
+	emitter_init(&emitter, emitter_output_json_compact, buf_write_cb,
+	    &prof_log_stop_buf_arg);
 
 	emitter_begin(&emitter);
 	prof_log_emit_metadata(&emitter);
@@ -645,7 +645,7 @@ prof_log_stop(tsdn_t *tsdn) {
 	prof_log_emit_allocs(tsd, &emitter);
 	emitter_end(&emitter);
 
-	buf_writer_flush(&prof_log_stop_buf_arg);
+	buf_write_flush(&prof_log_stop_buf_arg);
 	idalloctm(tsdn, prof_log_stop_buf, NULL, NULL, true, true);
 
 	/* Reset global state. */

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -461,10 +461,10 @@ prof_recent_alloc_dump(tsd_t *tsd, void (*write_cb)(void *, const char *),
 	char *buf = (char *)iallocztm(tsd_tsdn(tsd), PROF_RECENT_PRINT_BUFSIZE,
 	    sz_size2index(PROF_RECENT_PRINT_BUFSIZE), false, NULL, true,
 	    arena_get(tsd_tsdn(tsd), 0, false), true);
-	buf_writer_arg_t buf_arg = {write_cb, cbopaque, buf,
+	buf_write_arg_t buf_arg = {write_cb, cbopaque, buf,
 	    PROF_RECENT_PRINT_BUFSIZE - 1, 0};
 	emitter_t emitter;
-	emitter_init(&emitter, emitter_output_json_compact, buffered_write_cb,
+	emitter_init(&emitter, emitter_output_json_compact, buf_write_cb,
 	    &buf_arg);
 	emitter_begin(&emitter);
 
@@ -524,7 +524,7 @@ prof_recent_alloc_dump(tsd_t *tsd, void (*write_cb)(void *, const char *),
 	malloc_mutex_unlock(tsd_tsdn(tsd), &prof_recent_alloc_mtx);
 
 	emitter_end(&emitter);
-	buf_writer_flush(&buf_arg);
+	buf_write_flush(&buf_arg);
 	idalloctm(tsd_tsdn(tsd), buf, NULL, NULL, true, true);
 }
 #undef PROF_RECENT_PRINT_BUFSIZE

--- a/test/unit/buf_writer.c
+++ b/test/unit/buf_writer.c
@@ -20,8 +20,8 @@ TEST_BEGIN(test_buf_write) {
 	size_t n_unit, remain, i;
 	ssize_t unit;
 	uint64_t arg = 4; /* Starting value of random argument. */
-	buf_writer_arg_t test_buf_arg =
-	    {test_write_cb, &arg, test_buf, TEST_BUF_SIZE - 1, 0};
+	buf_write_arg_t test_buf_arg = {test_write_cb, &arg, test_buf,
+	    TEST_BUF_SIZE - 1, 0};
 
 	memset(s, 'a', UNIT_MAX);
 	arg_store = arg;
@@ -33,7 +33,7 @@ TEST_BEGIN(test_buf_write) {
 			remain = 0;
 			for (i = 1; i <= n_unit; ++i) {
 				arg = prng_lg_range_u64(&arg, 64);
-				buffered_write_cb(&test_buf_arg, s);
+				buf_write_cb(&test_buf_arg, s);
 				remain += unit;
 				if (remain > test_buf_arg.buf_size) {
 					/* Flushes should have happened. */
@@ -49,7 +49,7 @@ TEST_BEGIN(test_buf_write) {
 				    "Incorrect length after writing %zu strings"
 				    " of length %zu", i, unit);
 			}
-			buf_writer_flush(&test_buf_arg);
+			buf_write_flush(&test_buf_arg);
 			assert_zu_eq(test_write_len, n_unit * unit,
 			    "Incorrect length after flushing at the end of"
 			    " writing %zu strings of length %zu", n_unit, unit);


### PR DESCRIPTION
Unify the "namespace" of the buffered writer utility to `buf_write_*`.