### PR TITLE
No tdata creation for backtracing on dying thread

### DIFF
--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -406,7 +406,7 @@ prof_lookup(tsd_t *tsd, prof_bt_t *bt) {
 
 prof_tctx_t *
 prof_tctx_create(tsd_t *tsd) {
-	if (tsd_reentrancy_level_get(tsd) > 0) {
+	if (!tsd_nominal(tsd) || tsd_reentrancy_level_get(tsd) > 0) {
 		return NULL;
 	}
 


### PR DESCRIPTION
The allocation record in the last-N list will still be reset, but there's no deallocation time / `tctx` recorded.