### PR TITLE
Get rid of lock overlap in prof_recent_alloc_reset

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -167,7 +167,7 @@ DOCS_MAN3 := $(DOCS_XML:$(objroot)%.xml=$(objroot)%.3)
 DOCS := $(DOCS_HTML) $(DOCS_MAN3)
 C_TESTLIB_SRCS := $(srcroot)test/src/btalloc.c $(srcroot)test/src/btalloc_0.c \
 	$(srcroot)test/src/btalloc_1.c $(srcroot)test/src/math.c \
-	$(srcroot)test/src/mtx.c $(srcroot)test/src/mq.c \
+	$(srcroot)test/src/mtx.c $(srcroot)test/src/sleep.c \
 	$(srcroot)test/src/SFMT.c $(srcroot)test/src/test.c \
 	$(srcroot)test/src/thd.c $(srcroot)test/src/timer.c
 ifeq (1, $(link_whole_archive))

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -182,12 +182,15 @@ prof_recent_alloc_reset(tsd_t *tsd, edata_t *edata) {
 		if (dalloc_tctx != NULL) {
 			nstime_update(&recent->dalloc_time);
 			recent->dalloc_tctx = dalloc_tctx;
+			dalloc_tctx = NULL;
 		}
-	} else if (dalloc_tctx != NULL) {
+	}
+	malloc_mutex_unlock(tsd_tsdn(tsd), &prof_recent_alloc_mtx);
+
+	if (dalloc_tctx != NULL) {
 		/* We lost the rase - the allocation record was just gone. */
 		decrement_recent_count(tsd, dalloc_tctx);
 	}
-	malloc_mutex_unlock(tsd_tsdn(tsd), &prof_recent_alloc_mtx);
 }
 
 static void

--- a/test/include/test/jemalloc_test.h.in
+++ b/test/include/test/jemalloc_test.h.in
@@ -124,6 +124,7 @@ static const bool config_debug =
 #include "test/math.h"
 #include "test/mtx.h"
 #include "test/mq.h"
+#include "test/sleep.h"
 #include "test/test.h"
 #include "test/timer.h"
 #include "test/thd.h"

--- a/test/include/test/mq.h
+++ b/test/include/test/mq.h
@@ -1,4 +1,4 @@
-void	mq_nanosleep(unsigned ns);
+#include "test/sleep.h"
 
 /*
  * Simple templated message queue implementation that relies on only mutexes for
@@ -82,7 +82,7 @@ a_prefix##get(a_mq_type *mq) {						\
 									\
 	ns = 1;								\
 	while (true) {							\
-		mq_nanosleep(ns);					\
+		sleep_ns(ns);						\
 		msg = a_prefix##tryget(mq);				\
 		if (msg != NULL) {					\
 			return msg;					\

--- a/test/include/test/sleep.h
+++ b/test/include/test/sleep.h
@@ -1,0 +1,1 @@
+void sleep_ns(unsigned ns);

--- a/test/src/sleep.c
+++ b/test/src/sleep.c
@@ -5,11 +5,11 @@
  * time is guaranteed.
  */
 void
-mq_nanosleep(unsigned ns) {
+sleep_ns(unsigned ns) {
 	assert(ns <= 1000*1000*1000);
 
 #ifdef _WIN32
-	Sleep(ns / 1000);
+	Sleep(ns / 1000 / 1000);
 #else
 	{
 		struct timespec timeout;


### PR DESCRIPTION
The `decrement_recent_count()` call is made to be async, and there's no concurrent lock holdings at any time.

The issue was detected in a stress test I was writing. I'm also appending the stress test to this PR.