### PR TITLE
Remove commit parameter to ecache functions.

### DIFF
--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -23,10 +23,10 @@ extern rtree_t extents_rtree;
 
 edata_t *ecache_alloc(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     ecache_t *ecache, void *new_addr, size_t size, size_t pad, size_t alignment,
-    bool slab, szind_t szind, bool *zero, bool *commit);
+    bool slab, szind_t szind, bool *zero);
 edata_t *ecache_alloc_grow(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     ecache_t *ecache, void *new_addr, size_t size, size_t pad, size_t alignment,
-    bool slab, szind_t szind, bool *zero, bool *commit);
+    bool slab, szind_t szind, bool *zero);
 void ecache_dalloc(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     ecache_t *ecache, edata_t *edata);
 edata_t *ecache_evict(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,

--- a/src/arena.c
+++ b/src/arena.c
@@ -433,19 +433,17 @@ arena_extent_alloc_large(tsdn_t *tsdn, arena_t *arena, size_t usize,
 
 	szind_t szind = sz_size2index(usize);
 	size_t mapped_add;
-	bool commit = true;
 	edata_t *edata = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_dirty,
-	    NULL, usize, sz_large_pad, alignment, false, szind, zero, &commit);
+	    NULL, usize, sz_large_pad, alignment, false, szind, zero);
 	if (edata == NULL && arena_may_have_muzzy(arena)) {
 		edata = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_muzzy,
-		    NULL, usize, sz_large_pad, alignment, false, szind, zero,
-		    &commit);
+		    NULL, usize, sz_large_pad, alignment, false, szind, zero);
 	}
 	size_t size = usize + sz_large_pad;
 	if (edata == NULL) {
 		edata = ecache_alloc_grow(tsdn, arena, ehooks,
 		    &arena->ecache_retained, NULL, usize, sz_large_pad,
-		    alignment, false, szind, zero, &commit);
+		    alignment, false, szind, zero);
 		if (config_stats) {
 			/*
 			 * edata may be NULL on OOM, but in that case mapped_add
@@ -1203,15 +1201,14 @@ static edata_t *
 arena_slab_alloc_hard(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     const bin_info_t *bin_info, szind_t szind) {
 	edata_t *slab;
-	bool zero, commit;
+	bool zero;
 
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
 	zero = false;
-	commit = true;
 	slab = ecache_alloc_grow(tsdn, arena, ehooks, &arena->ecache_retained,
-	    NULL, bin_info->slab_size, 0, PAGE, true, szind, &zero, &commit);
+	    NULL, bin_info->slab_size, 0, PAGE, true, szind, &zero);
 
 	if (config_stats && slab != NULL) {
 		arena_stats_mapped_add(tsdn, &arena->stats,
@@ -1230,13 +1227,11 @@ arena_slab_alloc(tsdn_t *tsdn, arena_t *arena, szind_t binind, unsigned binshard
 	ehooks_t *ehooks = arena_get_ehooks(arena);
 	szind_t szind = sz_size2index(bin_info->reg_size);
 	bool zero = false;
-	bool commit = true;
 	edata_t *slab = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_dirty,
-	    NULL, bin_info->slab_size, 0, PAGE, true, binind, &zero, &commit);
+	    NULL, bin_info->slab_size, 0, PAGE, true, binind, &zero);
 	if (slab == NULL && arena_may_have_muzzy(arena)) {
 		slab = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_muzzy,
-		    NULL, bin_info->slab_size, 0, PAGE, true, binind, &zero,
-		    &commit);
+		    NULL, bin_info->slab_size, 0, PAGE, true, binind, &zero);
 	}
 	if (slab == NULL) {
 		slab = arena_slab_alloc_hard(tsdn, arena, ehooks, bin_info,

--- a/src/extent.c
+++ b/src/extent.c
@@ -186,14 +186,15 @@ extent_try_delayed_coalesce(tsdn_t *tsdn, edata_cache_t *edata_cache,
 edata_t *
 ecache_alloc(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks, ecache_t *ecache,
     void *new_addr, size_t size, size_t pad, size_t alignment, bool slab,
-    szind_t szind, bool *zero, bool *commit) {
+    szind_t szind, bool *zero) {
 	assert(size + pad != 0);
 	assert(alignment != 0);
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
+	bool commit = true;
 	edata_t *edata = extent_recycle(tsdn, arena, ehooks, ecache, new_addr,
-	    size, pad, alignment, slab, szind, zero, commit, false);
+	    size, pad, alignment, slab, szind, zero, &commit, false);
 	assert(edata == NULL || edata_dumpable_get(edata));
 	return edata;
 }
@@ -201,14 +202,15 @@ ecache_alloc(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks, ecache_t *ecache,
 edata_t *
 ecache_alloc_grow(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     ecache_t *ecache, void *new_addr, size_t size, size_t pad, size_t alignment,
-    bool slab, szind_t szind, bool *zero, bool *commit) {
+    bool slab, szind_t szind, bool *zero) {
 	assert(size + pad != 0);
 	assert(alignment != 0);
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
+	bool commit = true;
 	edata_t *edata = extent_alloc_retained(tsdn, arena, ehooks, new_addr,
-	    size, pad, alignment, slab, szind, zero, commit);
+	    size, pad, alignment, slab, szind, zero, &commit);
 	if (edata == NULL) {
 		if (opt_retain && new_addr != NULL) {
 			/*
@@ -220,7 +222,7 @@ ecache_alloc_grow(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
 			return NULL;
 		}
 		edata = extent_alloc_wrapper(tsdn, arena, ehooks,
-		    new_addr, size, pad, alignment, slab, szind, zero, commit);
+		    new_addr, size, pad, alignment, slab, szind, zero, &commit);
 	}
 
 	assert(edata == NULL || edata_dumpable_get(edata));

--- a/src/large.c
+++ b/src/large.c
@@ -147,22 +147,21 @@ large_ralloc_no_move_expand(tsdn_t *tsdn, edata_t *edata, size_t usize,
 	 * false.
 	 */
 	bool is_zeroed_trail = zero;
-	bool commit = true;
 	edata_t *trail;
 	bool new_mapping;
 	if ((trail = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_dirty,
 	    edata_past_get(edata), trailsize, 0, CACHELINE, false, SC_NSIZES,
-	    &is_zeroed_trail, &commit)) != NULL
+	    &is_zeroed_trail)) != NULL
 	    || (trail = ecache_alloc(tsdn, arena, ehooks, &arena->ecache_muzzy,
 	    edata_past_get(edata), trailsize, 0, CACHELINE, false, SC_NSIZES,
-	    &is_zeroed_trail, &commit)) != NULL) {
+	    &is_zeroed_trail)) != NULL) {
 		if (config_stats) {
 			new_mapping = false;
 		}
 	} else {
 		if ((trail = ecache_alloc_grow(tsdn, arena, ehooks,
 		    &arena->ecache_retained, edata_past_get(edata), trailsize,
-		    0, CACHELINE, false, SC_NSIZES, &is_zeroed_trail, &commit))
+		    0, CACHELINE, false, SC_NSIZES, &is_zeroed_trail))
 			== NULL) {
 			return true;
 		}


### PR DESCRIPTION
No caller ever wants uncommitted memory.