### PR TITLE
Encapsulate buffer allocation in buffered writer

### DIFF
--- a/include/jemalloc/internal/buf_writer.h
+++ b/include/jemalloc/internal/buf_writer.h
@@ -16,21 +16,21 @@ typedef struct {
 	char *buf;
 	size_t buf_size;
 	size_t buf_end;
-} buf_write_arg_t;
+} buf_writer_t;
 
 JEMALLOC_ALWAYS_INLINE void
-buf_write_init(buf_write_arg_t *arg, void (*write_cb)(void *, const char *),
-    void *cbopaque, char *buf, size_t buf_len) {
-	arg->write_cb = write_cb;
-	arg->cbopaque = cbopaque;
+buf_writer_init(buf_writer_t *buf_writer, void (*write_cb)(void *,
+    const char *), void *cbopaque, char *buf, size_t buf_len) {
+	buf_writer->write_cb = write_cb;
+	buf_writer->cbopaque = cbopaque;
 	assert(buf != NULL);
-	arg->buf = buf;
+	buf_writer->buf = buf;
 	assert(buf_len >= 2);
-	arg->buf_size = buf_len - 1; /* Accommodating '\0' at the end. */
-	arg->buf_end = 0;
+	buf_writer->buf_size = buf_len - 1; /* Allowing for '\0' at the end. */
+	buf_writer->buf_end = 0;
 }
 
-void buf_write_flush(buf_write_arg_t *arg);
-void buf_write_cb(void *buf_write_arg, const char *s);
+void buf_writer_flush(buf_writer_t *buf_writer);
+void buf_writer_cb(void *buf_writer_arg, const char *s);
 
 #endif /* JEMALLOC_INTERNAL_BUF_WRITER_H */

--- a/include/jemalloc/internal/buf_writer.h
+++ b/include/jemalloc/internal/buf_writer.h
@@ -10,27 +10,24 @@
  * some "option like" content for the write_cb, so it doesn't matter.
  */
 
+typedef void (write_cb_t)(void *, const char *);
+
 typedef struct {
-	void (*write_cb)(void *, const char *);
-	void *cbopaque;
+	write_cb_t *public_write_cb;
+	void *public_cbopaque;
+	write_cb_t *private_write_cb;
+	void *private_cbopaque;
 	char *buf;
 	size_t buf_size;
 	size_t buf_end;
+	bool internal_buf;
 } buf_writer_t;
 
-JEMALLOC_ALWAYS_INLINE void
-buf_writer_init(buf_writer_t *buf_writer, void (*write_cb)(void *,
-    const char *), void *cbopaque, char *buf, size_t buf_len) {
-	buf_writer->write_cb = write_cb;
-	buf_writer->cbopaque = cbopaque;
-	assert(buf != NULL);
-	buf_writer->buf = buf;
-	assert(buf_len >= 2);
-	buf_writer->buf_size = buf_len - 1; /* Allowing for '\0' at the end. */
-	buf_writer->buf_end = 0;
-}
-
+bool buf_writer_init(tsdn_t *tsdn, buf_writer_t *buf_writer,
+    write_cb_t *write_cb, void *cbopaque, char *buf, size_t buf_len);
+write_cb_t *buf_writer_get_write_cb(buf_writer_t *buf_writer);
+void *buf_writer_get_cbopaque(buf_writer_t *buf_writer);
 void buf_writer_flush(buf_writer_t *buf_writer);
-void buf_writer_cb(void *buf_writer_arg, const char *s);
+void buf_writer_terminate(tsdn_t *tsdn, buf_writer_t *buf_writer);
 
 #endif /* JEMALLOC_INTERNAL_BUF_WRITER_H */

--- a/src/buf_writer.c
+++ b/src/buf_writer.c
@@ -6,31 +6,31 @@
 #include "jemalloc/internal/malloc_io.h"
 
 void
-buf_write_flush(buf_write_arg_t *arg) {
-	assert(arg->buf_end <= arg->buf_size);
-	arg->buf[arg->buf_end] = '\0';
-	if (arg->write_cb == NULL) {
-		arg->write_cb = je_malloc_message != NULL ?
+buf_writer_flush(buf_writer_t *buf_writer) {
+	assert(buf_writer->buf_end <= buf_writer->buf_size);
+	buf_writer->buf[buf_writer->buf_end] = '\0';
+	if (buf_writer->write_cb == NULL) {
+		buf_writer->write_cb = je_malloc_message != NULL ?
 		    je_malloc_message : wrtmessage;
 	}
-	arg->write_cb(arg->cbopaque, arg->buf);
-	arg->buf_end = 0;
+	buf_writer->write_cb(buf_writer->cbopaque, buf_writer->buf);
+	buf_writer->buf_end = 0;
 }
 
 void
-buf_write_cb(void *buf_write_arg, const char *s) {
-	buf_write_arg_t *arg = (buf_write_arg_t *)buf_write_arg;
+buf_writer_cb(void *buf_writer_arg, const char *s) {
+	buf_writer_t *buf_writer = (buf_writer_t *)buf_writer_arg;
 	size_t i, slen, n, s_remain, buf_remain;
-	assert(arg->buf_end <= arg->buf_size);
+	assert(buf_writer->buf_end <= buf_writer->buf_size);
 	for (i = 0, slen = strlen(s); i < slen; i += n) {
-		if (arg->buf_end == arg->buf_size) {
-			buf_write_flush(arg);
+		if (buf_writer->buf_end == buf_writer->buf_size) {
+			buf_writer_flush(buf_writer);
 		}
 		s_remain = slen - i;
-		buf_remain = arg->buf_size - arg->buf_end;
+		buf_remain = buf_writer->buf_size - buf_writer->buf_end;
 		n = s_remain < buf_remain ? s_remain : buf_remain;
-		memcpy(arg->buf + arg->buf_end, s + i, n);
-		arg->buf_end += n;
+		memcpy(buf_writer->buf + buf_writer->buf_end, s + i, n);
+		buf_writer->buf_end += n;
 	}
 	assert(i == slen);
 }

--- a/src/buf_writer.c
+++ b/src/buf_writer.c
@@ -5,23 +5,114 @@
 #include "jemalloc/internal/buf_writer.h"
 #include "jemalloc/internal/malloc_io.h"
 
-void
-buf_writer_flush(buf_writer_t *buf_writer) {
-	assert(buf_writer->buf_end <= buf_writer->buf_size);
-	buf_writer->buf[buf_writer->buf_end] = '\0';
-	if (buf_writer->write_cb == NULL) {
-		buf_writer->write_cb = je_malloc_message != NULL ?
-		    je_malloc_message : wrtmessage;
+static void *
+buf_writer_allocate_internal_buf(tsdn_t *tsdn, size_t buf_len) {
+#ifdef JEMALLOC_JET
+	if (buf_len > SC_LARGE_MAXCLASS) {
+		return NULL;
 	}
-	buf_writer->write_cb(buf_writer->cbopaque, buf_writer->buf);
+#else
+	assert(buf_len <= SC_LARGE_MAXCLASS);
+#endif
+	return iallocztm(tsdn, buf_len, sz_size2index(buf_len), false, NULL,
+	    true, arena_get(tsdn, 0, false), true);
+}
+
+static void
+buf_writer_free_internal_buf(tsdn_t *tsdn, void *buf) {
+	if (buf != NULL) {
+		idalloctm(tsdn, buf, NULL, NULL, true, true);
+	}
+}
+
+static write_cb_t buf_writer_cb;
+
+static void
+buf_writer_assert(buf_writer_t *buf_writer) {
+	if (buf_writer->buf != NULL) {
+		assert(buf_writer->public_write_cb == buf_writer_cb);
+		assert(buf_writer->public_cbopaque == buf_writer);
+		assert(buf_writer->private_write_cb != buf_writer_cb);
+		assert(buf_writer->private_cbopaque != buf_writer);
+		assert(buf_writer->buf_size > 0);
+	} else {
+		assert(buf_writer->public_write_cb != buf_writer_cb);
+		assert(buf_writer->public_cbopaque != buf_writer);
+		assert(buf_writer->private_write_cb == NULL);
+		assert(buf_writer->private_cbopaque == NULL);
+		assert(buf_writer->buf_size == 0);
+	}
+}
+
+bool
+buf_writer_init(tsdn_t *tsdn, buf_writer_t *buf_writer, write_cb_t *write_cb,
+    void *cbopaque, char *buf, size_t buf_len) {
+	assert(buf_len >= 2);
+	if (buf != NULL) {
+		buf_writer->buf = buf;
+		buf_writer->internal_buf = false;
+	} else {
+		buf_writer->buf = buf_writer_allocate_internal_buf(tsdn,
+		    buf_len);
+		buf_writer->internal_buf = true;
+	}
 	buf_writer->buf_end = 0;
+	if (buf_writer->buf != NULL) {
+		buf_writer->public_write_cb = buf_writer_cb;
+		buf_writer->public_cbopaque = buf_writer;
+		buf_writer->private_write_cb = write_cb;
+		buf_writer->private_cbopaque = cbopaque;
+		buf_writer->buf_size = buf_len - 1; /* Allowing for '\0'. */
+		buf_writer_assert(buf_writer);
+		return false;
+	} else {
+		buf_writer->public_write_cb = write_cb;
+		buf_writer->public_cbopaque = cbopaque;
+		buf_writer->private_write_cb = NULL;
+		buf_writer->private_cbopaque = NULL;
+		buf_writer->buf_size = 0;
+		buf_writer_assert(buf_writer);
+		return true;
+	}
+}
+
+write_cb_t *
+buf_writer_get_write_cb(buf_writer_t *buf_writer) {
+	buf_writer_assert(buf_writer);
+	return buf_writer->public_write_cb;
+}
+
+void *
+buf_writer_get_cbopaque(buf_writer_t *buf_writer) {
+	buf_writer_assert(buf_writer);
+	return buf_writer->public_cbopaque;
 }
 
 void
+buf_writer_flush(buf_writer_t *buf_writer) {
+	buf_writer_assert(buf_writer);
+	if (buf_writer->buf == NULL) {
+		return;
+	}
+	assert(buf_writer->buf_end <= buf_writer->buf_size);
+	buf_writer->buf[buf_writer->buf_end] = '\0';
+	if (buf_writer->private_write_cb == NULL) {
+		buf_writer->private_write_cb = je_malloc_message != NULL ?
+		    je_malloc_message : wrtmessage;
+	}
+	assert(buf_writer->private_write_cb != NULL);
+	buf_writer->private_write_cb(buf_writer->private_cbopaque,
+	    buf_writer->buf);
+	buf_writer->buf_end = 0;
+}
+
+static void
 buf_writer_cb(void *buf_writer_arg, const char *s) {
 	buf_writer_t *buf_writer = (buf_writer_t *)buf_writer_arg;
-	size_t i, slen, n, s_remain, buf_remain;
+	buf_writer_assert(buf_writer);
+	assert(buf_writer->buf != NULL);
 	assert(buf_writer->buf_end <= buf_writer->buf_size);
+	size_t i, slen, n, s_remain, buf_remain;
 	for (i = 0, slen = strlen(s); i < slen; i += n) {
 		if (buf_writer->buf_end == buf_writer->buf_size) {
 			buf_writer_flush(buf_writer);
@@ -33,4 +124,13 @@ buf_writer_cb(void *buf_writer_arg, const char *s) {
 		buf_writer->buf_end += n;
 	}
 	assert(i == slen);
+}
+
+void
+buf_writer_terminate(tsdn_t *tsdn, buf_writer_t *buf_writer) {
+	buf_writer_assert(buf_writer);
+	buf_writer_flush(buf_writer);
+	if (buf_writer->internal_buf) {
+		buf_writer_free_internal_buf(tsdn, buf_writer->buf);
+	}
 }

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3737,11 +3737,11 @@ je_malloc_stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		if (buf == NULL) {
 			stats_print(write_cb, cbopaque, opts);
 		} else {
-			buf_write_arg_t buf_arg;
-			buf_write_init(&buf_arg, write_cb, cbopaque, buf,
+			buf_writer_t buf_writer;
+			buf_writer_init(&buf_writer, write_cb, cbopaque, buf,
 			    STATS_PRINT_BUFSIZE);
-			stats_print(buf_write_cb, &buf_arg, opts);
-			buf_write_flush(&buf_arg);
+			stats_print(buf_writer_cb, &buf_writer, opts);
+			buf_writer_flush(&buf_writer);
 			idalloctm(tsdn, buf, NULL, NULL, true, true);
 		}
 	}

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3731,19 +3731,12 @@ je_malloc_stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	if (config_debug) {
 		stats_print(write_cb, cbopaque, opts);
 	} else {
-		char *buf = (char *)iallocztm(tsdn, STATS_PRINT_BUFSIZE,
-		    sz_size2index(STATS_PRINT_BUFSIZE), false, NULL, true,
-		    arena_get(TSDN_NULL, 0, true), true);
-		if (buf == NULL) {
-			stats_print(write_cb, cbopaque, opts);
-		} else {
-			buf_writer_t buf_writer;
-			buf_writer_init(&buf_writer, write_cb, cbopaque, buf,
-			    STATS_PRINT_BUFSIZE);
-			stats_print(buf_writer_cb, &buf_writer, opts);
-			buf_writer_flush(&buf_writer);
-			idalloctm(tsdn, buf, NULL, NULL, true, true);
-		}
+		buf_writer_t buf_writer;
+		buf_writer_init(tsdn, &buf_writer, write_cb, cbopaque, NULL,
+		    STATS_PRINT_BUFSIZE);
+		stats_print(buf_writer_get_write_cb(&buf_writer),
+		    buf_writer_get_cbopaque(&buf_writer), opts);
+		buf_writer_terminate(tsdn, &buf_writer);
 	}
 
 	check_entry_exit_locking(tsdn);

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -632,15 +632,15 @@ prof_log_stop(tsdn_t *tsdn) {
 	char *buf = (char *)iallocztm(tsdn, PROF_LOG_STOP_BUFSIZE,
 	    sz_size2index(PROF_LOG_STOP_BUFSIZE), false, NULL, true,
 	    arena_get(TSDN_NULL, 0, true), true);
-	buf_write_arg_t buf_arg;
+	buf_writer_t buf_writer;
 	if (buf == NULL) {
 		emitter_init(&emitter, emitter_output_json_compact,
 		    prof_emitter_write_cb, &arg);
 	} else {
-		buf_write_init(&buf_arg, prof_emitter_write_cb, &arg, buf,
+		buf_writer_init(&buf_writer, prof_emitter_write_cb, &arg, buf,
 		    PROF_LOG_STOP_BUFSIZE);
 		emitter_init(&emitter, emitter_output_json_compact,
-		    buf_write_cb, &buf_arg);
+		    buf_writer_cb, &buf_writer);
 	}
 
 	emitter_begin(&emitter);
@@ -651,7 +651,7 @@ prof_log_stop(tsdn_t *tsdn) {
 	emitter_end(&emitter);
 
 	if (buf != NULL) {
-		buf_write_flush(&buf_arg);
+		buf_writer_flush(&buf_writer);
 		idalloctm(tsdn, buf, NULL, NULL, true, true);
 	}
 

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -466,15 +466,15 @@ prof_recent_alloc_dump(tsd_t *tsd, void (*write_cb)(void *, const char *),
 	    sz_size2index(PROF_RECENT_PRINT_BUFSIZE), false, NULL, true,
 	    arena_get(tsd_tsdn(tsd), 0, false), true);
 	emitter_t emitter;
-	buf_write_arg_t buf_arg;
+	buf_writer_t buf_writer;
 	if (buf == NULL) {
 		emitter_init(&emitter, emitter_output_json_compact, write_cb,
 		    cbopaque);
 	} else {
-		buf_write_init(&buf_arg, write_cb, cbopaque, buf,
+		buf_writer_init(&buf_writer, write_cb, cbopaque, buf,
 		    PROF_RECENT_PRINT_BUFSIZE);
 		emitter_init(&emitter, emitter_output_json_compact,
-		    buf_write_cb, &buf_arg);
+		    buf_writer_cb, &buf_writer);
 	}
 	emitter_begin(&emitter);
 
@@ -536,7 +536,7 @@ prof_recent_alloc_dump(tsd_t *tsd, void (*write_cb)(void *, const char *),
 
 	emitter_end(&emitter);
 	if (buf != NULL) {
-		buf_write_flush(&buf_arg);
+		buf_writer_flush(&buf_writer);
 		idalloctm(tsd_tsdn(tsd), buf, NULL, NULL, true, true);
 	}
 }

--- a/test/unit/buf_writer.c
+++ b/test/unit/buf_writer.c
@@ -7,6 +7,7 @@
 
 static size_t test_write_len;
 static char test_buf[TEST_BUF_SIZE];
+static uint64_t arg;
 static uint64_t arg_store;
 
 static void test_write_cb(void *cbopaque, const char *s) {
@@ -17,16 +18,16 @@ static void test_write_cb(void *cbopaque, const char *s) {
 	    "Test write overflowed");
 }
 
-TEST_BEGIN(test_buf_write) {
+static void test_buf_writer_body(tsdn_t *tsdn, buf_writer_t *buf_writer) {
 	char s[UNIT_MAX + 1];
 	size_t n_unit, remain, i;
 	ssize_t unit;
-	uint64_t arg = 4; /* Starting value of random argument. */
-	buf_writer_t buf_writer;
-	buf_writer_init(&buf_writer, test_write_cb, &arg, test_buf,
-	    TEST_BUF_SIZE);
+	assert_ptr_not_null(buf_writer->buf, "Buffer is null");
+	write_cb_t *write_cb = buf_writer_get_write_cb(buf_writer);
+	void *cbopaque = buf_writer_get_cbopaque(buf_writer);
 
 	memset(s, 'a', UNIT_MAX);
+	arg = 4; /* Starting value of random argument. */
 	arg_store = arg;
 	for (unit = UNIT_MAX; unit >= 0; --unit) {
 		/* unit keeps decreasing, so strlen(s) is always unit. */
@@ -36,19 +37,79 @@ TEST_BEGIN(test_buf_write) {
 			remain = 0;
 			for (i = 1; i <= n_unit; ++i) {
 				arg = prng_lg_range_u64(&arg, 64);
-				buf_writer_cb(&buf_writer, s);
+				write_cb(cbopaque, s);
 				remain += unit;
-				if (remain > buf_writer.buf_size) {
+				if (remain > buf_writer->buf_size) {
 					/* Flushes should have happened. */
 					assert_u64_eq(arg_store, arg, "Call "
 					    "back argument didn't get through");
-					remain %= buf_writer.buf_size;
+					remain %= buf_writer->buf_size;
 					if (remain == 0) {
 						/* Last flush should be lazy. */
-						remain += buf_writer.buf_size;
+						remain += buf_writer->buf_size;
 					}
 				}
 				assert_zu_eq(test_write_len + remain, i * unit,
+				    "Incorrect length after writing %zu strings"
+				    " of length %zu", i, unit);
+			}
+			buf_writer_flush(buf_writer);
+			assert_zu_eq(test_write_len, n_unit * unit,
+			    "Incorrect length after flushing at the end of"
+			    " writing %zu strings of length %zu", n_unit, unit);
+		}
+	}
+	buf_writer_terminate(tsdn, buf_writer);
+}
+
+TEST_BEGIN(test_buf_write_static) {
+	buf_writer_t buf_writer;
+	tsdn_t *tsdn = tsdn_fetch();
+	assert_false(buf_writer_init(tsdn, &buf_writer, test_write_cb, &arg,
+	    test_buf, TEST_BUF_SIZE),
+	    "buf_writer_init() should not encounter error on static buffer");
+	test_buf_writer_body(tsdn, &buf_writer);
+}
+TEST_END
+
+TEST_BEGIN(test_buf_write_dynamic) {
+	buf_writer_t buf_writer;
+	tsdn_t *tsdn = tsdn_fetch();
+	assert_false(buf_writer_init(tsdn, &buf_writer, test_write_cb, &arg,
+	    NULL, TEST_BUF_SIZE), "buf_writer_init() should not OOM");
+	test_buf_writer_body(tsdn, &buf_writer);
+}
+TEST_END
+
+TEST_BEGIN(test_buf_write_oom) {
+	buf_writer_t buf_writer;
+	tsdn_t *tsdn = tsdn_fetch();
+	assert_true(buf_writer_init(tsdn, &buf_writer, test_write_cb, &arg,
+	    NULL, SC_LARGE_MAXCLASS + 1), "buf_writer_init() should OOM");
+	assert_ptr_null(buf_writer.buf, "Buffer should be null");
+	write_cb_t *write_cb = buf_writer_get_write_cb(&buf_writer);
+	assert_ptr_eq(write_cb, test_write_cb, "Should use test_write_cb");
+	void *cbopaque = buf_writer_get_cbopaque(&buf_writer);
+	assert_ptr_eq(cbopaque, &arg, "Should use arg");
+
+	char s[UNIT_MAX + 1];
+	size_t n_unit, i;
+	ssize_t unit;
+
+	memset(s, 'a', UNIT_MAX);
+	arg = 4; /* Starting value of random argument. */
+	arg_store = arg;
+	for (unit = UNIT_MAX; unit >= 0; unit -= UNIT_MAX / 4) {
+		/* unit keeps decreasing, so strlen(s) is always unit. */
+		s[unit] = '\0';
+		for (n_unit = 1; n_unit <= 3; ++n_unit) {
+			test_write_len = 0;
+			for (i = 1; i <= n_unit; ++i) {
+				arg = prng_lg_range_u64(&arg, 64);
+				write_cb(cbopaque, s);
+				assert_u64_eq(arg_store, arg,
+				    "Call back argument didn't get through");
+				assert_zu_eq(test_write_len, i * unit,
 				    "Incorrect length after writing %zu strings"
 				    " of length %zu", i, unit);
 			}
@@ -58,10 +119,14 @@ TEST_BEGIN(test_buf_write) {
 			    " writing %zu strings of length %zu", n_unit, unit);
 		}
 	}
+	buf_writer_terminate(tsdn, &buf_writer);
 }
 TEST_END
 
 int
 main(void) {
-	return test(test_buf_write);
+	return test(
+	    test_buf_write_static,
+	    test_buf_write_dynamic,
+	    test_buf_write_oom);
 }

--- a/test/unit/buf_writer.c
+++ b/test/unit/buf_writer.c
@@ -22,8 +22,9 @@ TEST_BEGIN(test_buf_write) {
 	size_t n_unit, remain, i;
 	ssize_t unit;
 	uint64_t arg = 4; /* Starting value of random argument. */
-	buf_write_arg_t test_buf_arg = {test_write_cb, &arg, test_buf,
-	    TEST_BUF_SIZE - 1, 0};
+	buf_writer_t buf_writer;
+	buf_writer_init(&buf_writer, test_write_cb, &arg, test_buf,
+	    TEST_BUF_SIZE);
 
 	memset(s, 'a', UNIT_MAX);
 	arg_store = arg;
@@ -35,23 +36,23 @@ TEST_BEGIN(test_buf_write) {
 			remain = 0;
 			for (i = 1; i <= n_unit; ++i) {
 				arg = prng_lg_range_u64(&arg, 64);
-				buf_write_cb(&test_buf_arg, s);
+				buf_writer_cb(&buf_writer, s);
 				remain += unit;
-				if (remain > test_buf_arg.buf_size) {
+				if (remain > buf_writer.buf_size) {
 					/* Flushes should have happened. */
 					assert_u64_eq(arg_store, arg, "Call "
 					    "back argument didn't get through");
-					remain %= test_buf_arg.buf_size;
+					remain %= buf_writer.buf_size;
 					if (remain == 0) {
 						/* Last flush should be lazy. */
-						remain += test_buf_arg.buf_size;
+						remain += buf_writer.buf_size;
 					}
 				}
 				assert_zu_eq(test_write_len + remain, i * unit,
 				    "Incorrect length after writing %zu strings"
 				    " of length %zu", i, unit);
 			}
-			buf_write_flush(&test_buf_arg);
+			buf_writer_flush(&buf_writer);
 			assert_zu_eq(test_write_len, n_unit * unit,
 			    "Incorrect length after flushing at the end of"
 			    " writing %zu strings of length %zu", n_unit, unit);


### PR DESCRIPTION
This change tries to achieve the following goals:
- Encapsulate buffer allocation within the buffered writer module. I found this to be very useful in simplifying the caller side logic, as well as in supporting additions of more functionalities to the buffered writer module in the future. The buffered writer module is also made to be flexible in accepting a caller supplied buffer.
- Test OOM. This is another main advantage of the encapsulation: now OOM testing can be a unit test for the buffered writer module, rather than multiple tests each for one caller, which are not only redundant but also hard. I'll see later if I can further generalize the OOM testing so that other jemalloc components can benefit.