### PR TITLE
 Enforce page alignment for sampled allocations

### DIFF
--- a/include/jemalloc/internal/safety_check.h
+++ b/include/jemalloc/internal/safety_check.h
@@ -1,6 +1,7 @@
 #ifndef JEMALLOC_INTERNAL_SAFETY_CHECK_H
 #define JEMALLOC_INTERNAL_SAFETY_CHECK_H
 
+void safety_check_fail_sized_dealloc(bool current_dealloc);
 void safety_check_fail(const char *format, ...);
 /* Can set to NULL for a default. */
 void safety_check_set_abort(void (*abort_fn)(const char *));

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2632,7 +2632,11 @@ isfree(tsd_t *tsd, void *ptr, size_t usize, tcache_t *tcache, bool slow_path) {
 			rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree,
 			    rtree_ctx, (uintptr_t)ptr, true, &ctx->szind,
 			    &ctx->slab);
-			assert(ctx->szind == sz_size2index(usize));
+			/* Small alloc may have !slab (sampled). */
+			bool sz_correct = (ctx->szind == sz_size2index(usize));
+			if (config_opt_safety_checks && !sz_correct) {
+				safety_check_fail_sized_dealloc(true);
+			}
 		} else {
 			ctx = NULL;
 		}

--- a/src/safety_check.c
+++ b/src/safety_check.c
@@ -3,6 +3,18 @@
 
 static void (*safety_check_abort)(const char *message);
 
+void safety_check_fail_sized_dealloc(bool current_dealloc) {
+	assert(config_opt_safety_checks);
+	char *src = current_dealloc ? "the current pointer being freed" :
+	    "in thread cache, possibly from previous deallocations";
+
+	safety_check_fail("<jemalloc>: size mismatch detected, likely caused by"
+	   " application sized deallocation bugs (source: %s). Suggest building"
+	    "with --enable-debug or address sanitizer for debugging. Abort.\n",
+	    src);
+	abort();
+}
+
 void safety_check_set_abort(void (*abort_fn)(const char *)) {
 	safety_check_abort = abort_fn;
 }

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -135,10 +135,7 @@ tbin_edatas_lookup_size_check(tsdn_t *tsdn, cache_bin_t *tbin, szind_t binind,
 		sz_sum -= szind;
 	}
 	if (sz_sum != 0) {
-		safety_check_fail("<jemalloc>: size mismatch in thread cache "
-		    "detected, likely caused by sized deallocation bugs by "
-		    "application. Abort.\n");
-		abort();
+		safety_check_fail_sized_dealloc(false);
 	}
 }
 

--- a/test/integration/extent.c
+++ b/test/integration/extent.c
@@ -59,8 +59,8 @@ test_extent_body(unsigned arena_ind) {
 		assert_true(called_decommit, "Expected decommit call");
 		assert_true(did_purge_lazy || did_purge_forced,
 		    "Expected purge");
+		assert_true(called_split, "Expected split call");
 	}
-	assert_true(called_split, "Expected split call");
 	dallocx(p, flags);
 	try_dalloc = true;
 


### PR DESCRIPTION
This allows sampled allocations to be checked through alignment, therefore enable sized deallocation regardless of cache_oblivious.

Enables the speed up of sized deallocation, in `test/integration/stress`:
before:

    100000000 iterations, dallocx=1254009us, sdallocx=1222009us, ratio=1:1.026

with this PR:

    100000000 iterations, dallocx=1259009us, sdallocx=759005us, ratio=1:1.659

Resolves #1697 