### PR TITLE
Add mallctl for dumping last-N profiling records

### DIFF
--- a/test/include/test/test.h
+++ b/test/include/test/test.h
@@ -1,8 +1,8 @@
 #define ASSERT_BUFSIZE	256
 
 #define assert_cmp(t, a, b, cmp, neg_cmp, pri, ...) do {		\
-	t a_ = (a);							\
-	t b_ = (b);							\
+	const t a_ = (a);						\
+	const t b_ = (b);						\
 	if (!(a_ cmp b_)) {						\
 		char prefix[ASSERT_BUFSIZE];				\
 		char message[ASSERT_BUFSIZE];				\


### PR DESCRIPTION
I'm currently defining a `write_cb_packet_t` construct in `ctl.c` to represent the `[write_cb, cbopaque]` tuple passed in as input to the `mallctl()`.

Also added extensive unit tests.