### PR TITLE
Rework the bin locking around tcache refill / flush.

### DIFF
--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -63,8 +63,9 @@ void *arena_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize,
 void arena_prof_promote(tsdn_t *tsdn, void *ptr, size_t usize);
 void arena_dalloc_promoted(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
     bool slow_path);
-void arena_dalloc_bin_junked_locked(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
+bool arena_dalloc_bin_junked_locked(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
     szind_t binind, edata_t *edata, void *ptr);
+void arena_slab_dalloc(tsdn_t *tsdn, arena_t *arena, edata_t *slab);
 void arena_dalloc_small(tsdn_t *tsdn, void *ptr);
 bool arena_ralloc_no_move(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size,
     size_t extra, bool zero, size_t *newsize);


### PR DESCRIPTION
    Previously, tcache fill/flush (as well as small alloc/dalloc on the arena) may
    potentially drop the bin lock for slab_alloc and slab_dalloc.  This commit
    refactors the logic so that the slab calls happen in the same function / level
    as the bin lock / unlock.  The main purpose is to be able to use flat combining
    without having to keep track of stack state.
    
    In the meantime, this change reduces the locking, especially for slab_dalloc
    calls, where nothing happens after the call.
