### PR TITLE
Tcache: Unify bin flush logic.

### DIFF
--- a/include/jemalloc/internal/ehooks.h
+++ b/include/jemalloc/internal/ehooks.h
@@ -222,9 +222,9 @@ ehooks_destroy(tsdn_t *tsdn, ehooks_t *ehooks, void *addr, size_t size,
     bool committed) {
 	extent_hooks_t *extent_hooks = ehooks_get_extent_hooks_ptr(ehooks);
 	if (extent_hooks == &ehooks_default_extent_hooks) {
-		return ehooks_default_destroy_impl(addr, size);
+		ehooks_default_destroy_impl(addr, size);
 	} else if (extent_hooks->destroy == NULL) {
-		return;
+		/* Do nothing. */
 	} else {
 		ehooks_pre_reentrancy(tsdn);
 		extent_hooks->destroy(extent_hooks, addr, size, committed,

--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -92,4 +92,13 @@ isblank(int c) {
 #endif
 #include <fcntl.h>
 
+/*
+ * The Win32 midl compiler has #define small char; we don't use midl, but
+ * "small" is a nice identifier to have available when talking about size
+ * classes.
+ */
+#ifdef small
+#  undef small
+#endif
+
 #endif /* JEMALLOC_INTERNAL_H */


### PR DESCRIPTION
The small and large pathways share most of their big-picture logic, even if some of the specifics are different (e.g. both have a trick to merge the stats locking with object locking if possible, even though the specific stats kept for small and large allocations are different). Unifying them makes the similarities and differences clearer.

While we're here, beef up the comments.