### PR TITLE
Direct allocation attribution in profiling

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -232,6 +232,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_mdump.c \
 	$(srcroot)test/unit/prof_recent.c \
 	$(srcroot)test/unit/prof_reset.c \
+	$(srcroot)test/unit/prof_surplus.c \
 	$(srcroot)test/unit/prof_tctx.c \
 	$(srcroot)test/unit/prof_thread_name.c \
 	$(srcroot)test/unit/prof_sys_thread_name.c \

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -104,11 +104,11 @@ arena_prof_tctx_reset_sampled(tsd_t *tsd, const void *ptr) {
 }
 
 JEMALLOC_ALWAYS_INLINE void
-arena_prof_info_set(edata_t *edata, prof_tctx_t *tctx) {
+arena_prof_info_set(edata_t *edata, prof_tctx_t *tctx, size_t surplus) {
 	cassert(config_prof);
 
 	assert(!edata_slab_get(edata));
-	large_prof_info_set(edata, tctx);
+	large_prof_info_set(edata, tctx, surplus);
 }
 
 JEMALLOC_ALWAYS_INLINE void

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -104,7 +104,7 @@ arena_prof_tctx_reset_sampled(tsd_t *tsd, const void *ptr) {
 }
 
 JEMALLOC_ALWAYS_INLINE void
-arena_prof_info_set(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx) {
+arena_prof_info_set(edata_t *edata, prof_tctx_t *tctx) {
 	cassert(config_prof);
 
 	assert(!edata_slab_get(edata));

--- a/include/jemalloc/internal/edata.h
+++ b/include/jemalloc/internal/edata.h
@@ -28,6 +28,8 @@ typedef enum extent_head_state_e extent_head_state_t;
 struct e_prof_info_s {
 	/* Time when this was allocated. */
 	nstime_t	e_prof_alloc_time;
+	/* Count of bytes beyond what's needed for triggering the sampling. */
+	size_t		e_prof_surplus;
 	/* Points to a prof_tctx_t. */
 	atomic_p_t	e_prof_tctx;
 	/*
@@ -358,6 +360,11 @@ edata_prof_alloc_time_get(const edata_t *edata) {
 	return &edata->e_prof_info.e_prof_alloc_time;
 }
 
+static inline size_t
+edata_prof_surplus_get(const edata_t *edata) {
+	return edata->e_prof_info.e_prof_surplus;
+}
+
 static inline prof_recent_t *
 edata_prof_recent_alloc_get_dont_call_directly(const edata_t *edata) {
 	return (prof_recent_t *)atomic_load_p(
@@ -486,6 +493,11 @@ edata_prof_tctx_set(edata_t *edata, prof_tctx_t *tctx) {
 static inline void
 edata_prof_alloc_time_set(edata_t *edata, nstime_t *t) {
 	nstime_copy(&edata->e_prof_info.e_prof_alloc_time, t);
+}
+
+static inline void
+edata_prof_surplus_set(edata_t *edata, size_t surplus) {
+	edata->e_prof_info.e_prof_surplus = surplus;
 }
 
 static inline void

--- a/include/jemalloc/internal/large_externs.h
+++ b/include/jemalloc/internal/large_externs.h
@@ -19,6 +19,6 @@ size_t large_salloc(tsdn_t *tsdn, const edata_t *edata);
 void large_prof_info_get(tsd_t *tsd, edata_t *edata, prof_info_t *prof_info,
     bool reset_recent);
 void large_prof_tctx_reset(edata_t *edata);
-void large_prof_info_set(edata_t *edata, prof_tctx_t *tctx);
+void large_prof_info_set(edata_t *edata, prof_tctx_t *tctx, size_t surplus);
 
 #endif /* JEMALLOC_INTERNAL_LARGE_EXTERNS_H */

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -20,6 +20,9 @@ extern char opt_prof_prefix[
 #endif
     1];
 
+/* If true, print total surplus rather than total bytes in prof dumps. */
+extern bool opt_prof_dump_surplus;
+
 /* For recording recent allocations */
 extern ssize_t opt_prof_recent_alloc_max;
 

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -49,7 +49,7 @@ prof_tdata_t *prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata);
 
 void prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx);
 void prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
-    size_t usize, prof_tctx_t *tctx);
+    size_t usize, size_t surplus, prof_tctx_t *tctx);
 void prof_free_sampled_object(tsd_t *tsd, size_t usize, prof_info_t *prof_info);
 prof_tctx_t *prof_tctx_create(tsd_t *tsd);
 void prof_idump(tsdn_t *tsdn);

--- a/include/jemalloc/internal/prof_inlines.h
+++ b/include/jemalloc/internal/prof_inlines.h
@@ -98,12 +98,12 @@ prof_tctx_reset_sampled(tsd_t *tsd, const void *ptr) {
 }
 
 JEMALLOC_ALWAYS_INLINE void
-prof_info_set(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx) {
+prof_info_set(edata_t *edata, prof_tctx_t *tctx) {
 	cassert(config_prof);
 	assert(edata != NULL);
 	assert((uintptr_t)tctx > (uintptr_t)1U);
 
-	arena_prof_info_set(tsd, edata, tctx);
+	arena_prof_info_set(edata, tctx);
 }
 
 JEMALLOC_ALWAYS_INLINE bool

--- a/include/jemalloc/internal/prof_inlines.h
+++ b/include/jemalloc/internal/prof_inlines.h
@@ -147,6 +147,7 @@ prof_malloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
 	cassert(config_prof);
 	assert(ptr != NULL);
 	assert(usize == isalloc(tsd_tsdn(tsd), ptr));
+	assert((uintptr_t)tctx >= (uintptr_t)1U);
 
 	if (unlikely((uintptr_t)tctx > (uintptr_t)1U)) {
 		prof_malloc_sample_object(tsd, ptr, size, usize, tctx);
@@ -162,7 +163,8 @@ prof_realloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
 	bool sampled, old_sampled, moved;
 
 	cassert(config_prof);
-	assert(ptr != NULL || (uintptr_t)tctx <= (uintptr_t)1U);
+	assert(ptr != NULL);
+	assert((uintptr_t)tctx >= (uintptr_t)1U);
 
 	if (prof_active && ptr != NULL) {
 		assert(usize == isalloc(tsd_tsdn(tsd), ptr));
@@ -180,6 +182,7 @@ prof_realloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
 	}
 
 	sampled = ((uintptr_t)tctx > (uintptr_t)1U);
+	assert((uintptr_t)old_prof_info->alloc_tctx >= (uintptr_t)1U);
 	old_sampled = ((uintptr_t)old_prof_info->alloc_tctx > (uintptr_t)1U);
 	moved = (ptr != old_ptr);
 
@@ -237,6 +240,7 @@ prof_free(tsd_t *tsd, const void *ptr, size_t usize,
 
 	cassert(config_prof);
 	assert(usize == isalloc(tsd_tsdn(tsd), ptr));
+	assert((uintptr_t)prof_info.alloc_tctx >= (uintptr_t)1U);
 
 	if (unlikely((uintptr_t)prof_info.alloc_tctx > (uintptr_t)1U)) {
 		assert(prof_sample_aligned(ptr));

--- a/include/jemalloc/internal/prof_structs.h
+++ b/include/jemalloc/internal/prof_structs.h
@@ -25,8 +25,10 @@ struct prof_cnt_s {
 	/* Profiling counters. */
 	uint64_t	curobjs;
 	uint64_t	curbytes;
+	uint64_t	cursurplus;
 	uint64_t	accumobjs;
 	uint64_t	accumbytes;
+	uint64_t	accumsurplus;
 };
 
 typedef enum {
@@ -97,6 +99,8 @@ typedef rb_tree(prof_tctx_t) prof_tctx_tree_t;
 struct prof_info_s {
 	/* Time when the allocation was made. */
 	nstime_t		alloc_time;
+	/* Count of bytes beyond what's needed for triggering the sampling. */
+	size_t			surplus;
 	/* Points to the prof_tctx_t corresponding to the allocation. */
 	prof_tctx_t		*alloc_tctx;
 };

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -130,6 +130,7 @@ CTL_PROTO(opt_prof_gdump)
 CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_accum)
+CTL_PROTO(opt_prof_dump_surplus)
 CTL_PROTO(opt_prof_recent_alloc_max)
 CTL_PROTO(opt_prof_sys_thread_name)
 CTL_PROTO(opt_prof_time_res)
@@ -386,6 +387,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_final"),	CTL(opt_prof_final)},
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
 	{NAME("prof_accum"),	CTL(opt_prof_accum)},
+	{NAME("prof_dump_surplus"),	CTL(opt_prof_dump_surplus)},
 	{NAME("prof_recent_alloc_max"),	CTL(opt_prof_recent_alloc_max)},
 	{NAME("prof_sys_thread_name"),	CTL(opt_prof_sys_thread_name)},
 	{NAME("prof_time_resolution"),	CTL(opt_prof_time_res)},
@@ -1853,6 +1855,7 @@ CTL_RO_NL_CGEN(config_prof, opt_lg_prof_interval, opt_lg_prof_interval, ssize_t)
 CTL_RO_NL_CGEN(config_prof, opt_prof_gdump, opt_prof_gdump, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_final, opt_prof_final, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_leak, opt_prof_leak, bool)
+CTL_RO_NL_CGEN(config_prof, opt_prof_dump_surplus, opt_prof_dump_surplus, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_recent_alloc_max,
     opt_prof_recent_alloc_max, ssize_t)
 CTL_RO_NL_CGEN(config_prof, opt_prof_sys_thread_name, opt_prof_sys_thread_name,

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1493,6 +1493,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 				CONF_HANDLE_BOOL(opt_prof_final, "prof_final")
 				CONF_HANDLE_BOOL(opt_prof_leak, "prof_leak")
 				CONF_HANDLE_BOOL(opt_prof_log, "prof_log")
+				CONF_HANDLE_BOOL(opt_prof_dump_surplus,
+				    "prof_dump_surplus")
 				CONF_HANDLE_SSIZE_T(opt_prof_recent_alloc_max,
 				    "prof_recent_alloc_max", -1, SSIZE_MAX)
 				CONF_HANDLE_BOOL(opt_prof_sys_thread_name,

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2332,7 +2332,9 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 	/* If profiling is on, get our profiling context. */
 	if (config_prof && opt_prof) {
 		bool prof_active = prof_active_get_unlocked();
-		bool sample_event = te_prof_sample_event_lookahead(tsd, usize);
+		size_t surplus;
+		bool sample_event = te_prof_sample_event_lookahead_surplus(tsd,
+		    usize, &surplus);
 		prof_tctx_t *tctx = prof_alloc_prep(tsd, prof_active,
 		    sample_event);
 
@@ -2353,7 +2355,8 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 			prof_alloc_rollback(tsd, tctx);
 			goto label_oom;
 		}
-		prof_malloc(tsd, allocation, size, usize, &alloc_ctx, tctx);
+		prof_malloc(tsd, allocation, size, usize, surplus, &alloc_ctx,
+		    tctx);
 	} else {
 		assert(!opt_prof);
 		allocation = imalloc_no_sample(sopts, dopts, tsd, size, usize,
@@ -3299,9 +3302,11 @@ irallocx_prof(tsd_t *tsd, void *old_ptr, size_t old_usize, size_t size,
 		*usize = isalloc(tsd_tsdn(tsd), p);
 	}
 
-	sample_event = te_prof_sample_event_lookahead(tsd, *usize);
-	prof_realloc(tsd, p, size, *usize, tctx, prof_active, old_ptr,
-	    old_usize, &old_prof_info, sample_event);
+	size_t surplus;
+	sample_event = te_prof_sample_event_lookahead_surplus(tsd, *usize,
+	    &surplus);
+	prof_realloc(tsd, p, size, *usize, sample_event, surplus, tctx,
+	    prof_active, old_ptr, old_usize, &old_prof_info);
 
 	return p;
 }
@@ -3557,9 +3562,11 @@ ixallocx_prof(tsd_t *tsd, void *ptr, size_t old_usize, size_t size,
 	} else {
 		prof_info_get_and_reset_recent(tsd, ptr, alloc_ctx, &prof_info);
 		assert(usize <= usize_max);
-		sample_event = te_prof_sample_event_lookahead(tsd, usize);
-		prof_realloc(tsd, ptr, size, usize, tctx, prof_active, ptr,
-		    old_usize, &prof_info, sample_event);
+		size_t surplus;
+		sample_event = te_prof_sample_event_lookahead_surplus(tsd,
+		    usize, &surplus);
+		prof_realloc(tsd, ptr, size, usize, sample_event, surplus,
+		    tctx, prof_active, ptr, old_usize, &prof_info);
 	}
 
 	assert(old_prof_info.alloc_tctx == prof_info.alloc_tctx);

--- a/src/large.c
+++ b/src/large.c
@@ -281,6 +281,7 @@ large_prof_info_get(tsd_t *tsd, edata_t *edata, prof_info_t *prof_info,
 	if ((uintptr_t)alloc_tctx > (uintptr_t)1U) {
 		nstime_copy(&prof_info->alloc_time,
 		    edata_prof_alloc_time_get(edata));
+		prof_info->surplus = edata_prof_surplus_get(edata);
 		if (reset_recent) {
 			/*
 			 * Reset the pointer on the recent allocation record,
@@ -302,10 +303,11 @@ large_prof_tctx_reset(edata_t *edata) {
 }
 
 void
-large_prof_info_set(edata_t *edata, prof_tctx_t *tctx) {
+large_prof_info_set(edata_t *edata, prof_tctx_t *tctx, size_t surplus) {
 	nstime_t t;
 	nstime_prof_init_update(&t);
 	edata_prof_alloc_time_set(edata, &t);
 	edata_prof_recent_alloc_init(edata);
+	edata_prof_surplus_set(edata, surplus);
 	large_prof_tctx_set(edata, tctx);
 }

--- a/src/prof.c
+++ b/src/prof.c
@@ -30,6 +30,7 @@ bool opt_prof_gdump = false;
 bool opt_prof_final = false;
 bool opt_prof_leak = false;
 bool opt_prof_accum = false;
+bool opt_prof_dump_surplus = false;
 char opt_prof_prefix[PROF_DUMP_FILENAME_LEN];
 bool opt_prof_sys_thread_name = false;
 

--- a/src/prof.c
+++ b/src/prof.c
@@ -94,7 +94,7 @@ prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 
 	edata_t *edata = emap_edata_lookup(tsd_tsdn(tsd), &arena_emap_global,
 	    ptr);
-	prof_info_set(tsd, edata, tctx);
+	prof_info_set(edata, tctx);
 
 	malloc_mutex_lock(tsd_tsdn(tsd), tctx->tdata->lock);
 	tctx->cnts.curobjs++;

--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -540,11 +540,14 @@ prof_tctx_merge_tdata(tsdn_t *tsdn, prof_tctx_t *tctx, prof_tdata_t *tdata) {
 
 		tdata->cnt_summed.curobjs += tctx->dump_cnts.curobjs;
 		tdata->cnt_summed.curbytes += tctx->dump_cnts.curbytes;
+		tdata->cnt_summed.cursurplus += tctx->dump_cnts.cursurplus;
 		if (opt_prof_accum) {
 			tdata->cnt_summed.accumobjs +=
 			    tctx->dump_cnts.accumobjs;
 			tdata->cnt_summed.accumbytes +=
 			    tctx->dump_cnts.accumbytes;
+			tdata->cnt_summed.accumsurplus +=
+			    tctx->dump_cnts.accumsurplus;
 		}
 		break;
 	case prof_tctx_state_dumping:
@@ -559,9 +562,11 @@ prof_tctx_merge_gctx(tsdn_t *tsdn, prof_tctx_t *tctx, prof_gctx_t *gctx) {
 
 	gctx->cnt_summed.curobjs += tctx->dump_cnts.curobjs;
 	gctx->cnt_summed.curbytes += tctx->dump_cnts.curbytes;
+	gctx->cnt_summed.cursurplus += tctx->dump_cnts.cursurplus;
 	if (opt_prof_accum) {
 		gctx->cnt_summed.accumobjs += tctx->dump_cnts.accumobjs;
 		gctx->cnt_summed.accumbytes += tctx->dump_cnts.accumbytes;
+		gctx->cnt_summed.accumsurplus += tctx->dump_cnts.accumsurplus;
 	}
 }
 
@@ -758,10 +763,13 @@ prof_tdata_merge_iter(prof_tdata_tree_t *tdatas, prof_tdata_t *tdata,
 
 		arg->cnt_all->curobjs += tdata->cnt_summed.curobjs;
 		arg->cnt_all->curbytes += tdata->cnt_summed.curbytes;
+		arg->cnt_all->cursurplus += tdata->cnt_summed.cursurplus;
 		if (opt_prof_accum) {
 			arg->cnt_all->accumobjs += tdata->cnt_summed.accumobjs;
 			arg->cnt_all->accumbytes +=
 			    tdata->cnt_summed.accumbytes;
+			arg->cnt_all->accumsurplus +=
+			    tdata->cnt_summed.accumsurplus;
 		}
 	} else {
 		tdata->dumping = false;
@@ -814,8 +822,10 @@ prof_dump_gctx(prof_dump_iter_arg_t *arg, prof_gctx_t *gctx,
 	    (opt_prof_accum && gctx->cnt_summed.accumobjs == 0)) {
 		assert(gctx->cnt_summed.curobjs == 0);
 		assert(gctx->cnt_summed.curbytes == 0);
+		assert(gctx->cnt_summed.cursurplus == 0);
 		assert(gctx->cnt_summed.accumobjs == 0);
 		assert(gctx->cnt_summed.accumbytes == 0);
+		assert(gctx->cnt_summed.accumsurplus == 0);
 		return;
 	}
 
@@ -1162,9 +1172,11 @@ prof_tctx_destroy(tsd_t *tsd, prof_tctx_t *tctx) {
 
 	assert(tctx->cnts.curobjs == 0);
 	assert(tctx->cnts.curbytes == 0);
+	assert(tctx->cnts.cursurplus == 0);
 	assert(!opt_prof_accum);
 	assert(tctx->cnts.accumobjs == 0);
 	assert(tctx->cnts.accumbytes == 0);
+	assert(tctx->cnts.accumsurplus == 0);
 
 	prof_gctx_t *gctx = tctx->gctx;
 

--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -519,7 +519,10 @@ prof_dump_print_cnts(write_cb_t *prof_dump_write, void *cbopaque,
     const prof_cnt_t *cnts) {
 	prof_dump_printf(prof_dump_write, cbopaque,
 	    "%"FMTu64": %"FMTu64" [%"FMTu64": %"FMTu64"]",
-	    cnts->curobjs, cnts->curbytes, cnts->accumobjs, cnts->accumbytes);
+	    cnts->curobjs,
+	    opt_prof_dump_surplus ? cnts->cursurplus : cnts->curbytes,
+	    cnts->accumobjs,
+	    opt_prof_dump_surplus ? cnts->accumsurplus : cnts->accumbytes);
 }
 
 static void

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -191,6 +191,7 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(bool, prof_gdump, prof);
 	TEST_MALLCTL_OPT(bool, prof_final, prof);
 	TEST_MALLCTL_OPT(bool, prof_leak, prof);
+	TEST_MALLCTL_OPT(bool, prof_dump_surplus, prof);
 	TEST_MALLCTL_OPT(ssize_t, prof_recent_alloc_max, prof);
 	TEST_MALLCTL_OPT(bool, prof_sys_thread_name, prof);
 

--- a/test/unit/prof_surplus.c
+++ b/test/unit/prof_surplus.c
@@ -1,0 +1,76 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/prof_data.h"
+
+static void
+verify_prof_cnt_all(prof_cnt_t *cnt_all) {
+	/*
+	 * When lg_prof_sample is 0, the prof sample wait time is always set to
+	 * be 1, and thus the surplus should always be one less than the usize
+	 * for every allocation.  Therefore, the usize sum is always equal to
+	 * the number of allocations plus the surplus sum.
+	 */
+	expect_u64_eq(cnt_all->curobjs + cnt_all->cursurplus,
+	    cnt_all->curbytes, "");
+	expect_u64_eq(cnt_all->accumobjs + cnt_all->accumsurplus,
+	    cnt_all->accumbytes, "");
+}
+
+TEST_BEGIN(test_prof_surplus) {
+	test_skip_if(!config_prof);
+
+	void *p, *q;
+	prof_cnt_t cnt;
+
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+
+	p = malloc(1024);
+	assert_ptr_not_null(p, "Unexpected malloc() failure");
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+	free(p);
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+
+	p = malloc(1024);
+	assert_ptr_not_null(p, "Unexpected malloc() failure");
+	q = malloc(2048);
+	assert_ptr_not_null(q, "Unexpected malloc() failure");
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+	free(q);
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+	free(p);
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+
+	p = malloc(1024);
+	assert_ptr_not_null(p, "Unexpected malloc() failure");
+	q = realloc(p, 2048);
+	assert_ptr_ne(p, q, "Expected move");
+	assert_ptr_not_null(q, "Unexpected realloc() failure");
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+	free(q);
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+
+	p = malloc(1024);
+	assert_ptr_not_null(p, "Unexpected malloc() failure");
+	size_t s = xallocx(p, 2048, 0, 0);
+	assert_zu_eq(s, 1024, "Expected stay");
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+	free(p);
+	prof_cnt_all(&cnt);
+	verify_prof_cnt_all(&cnt);
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_prof_surplus);
+}

--- a/test/unit/prof_surplus.sh
+++ b/test/unit/prof_surplus.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_accum:true"
+fi


### PR DESCRIPTION
This change is not completed yet, but I think it has reached a stage suitable for seeking some early feedback.

The context is in #1751. To enable correct inference, we need to record both the number of sampled bytes and the number of unsampled bytes for each stack trace. The number of sampled bytes is equivalent to `curobjs`, so we only need to record the number of unsampled bytes, which I denote as `surplus` - the amount beyond what's needed for triggering sampling.

`surplus` is relayed in two routes:
- `thread_alloc_event()` -> `prof_malloc_sample_object()`, via a new thread local field `prof_sample_event_surplus`, which is needed because the sampling logic is currently separate from the thread event logic;
- `prof_malloc_sample_object()` -> `prof_free_sampled_object()`, via a new field `e_prof_surplus` on `edata`, which is needed because `free()` needs to roll back the allocation's `surplus` from the stack trace total.

My remaining work involves the following:
- Add unit tests.
- Add an option to actually use the additional information i.e. the `surplus`. (I figured that computing the `surplus` is fairly cheap so I don't really need to guard the computation under any option.)
  - Print the raw `surplus` value as well as some other convenient estimation(s) to the profiling dump.
  - Compute leak checking differently.