### PR TITLE
Rewrite profiling thread event

### DIFF
--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -53,7 +53,7 @@ void prof_idump_rollback_impl(tsdn_t *tsdn, size_t usize);
 prof_tdata_t *prof_tdata_init(tsd_t *tsd);
 prof_tdata_t *prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata);
 
-void prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx, bool updated);
+void prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx);
 void prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
     size_t usize, prof_tctx_t *tctx);
 void prof_free_sampled_object(tsd_t *tsd, size_t usize, prof_info_t *prof_info);

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -220,6 +220,7 @@ te_ctx_get(tsd_t *tsd, te_ctx_t *ctx, bool is_alloc) {
 
 JEMALLOC_ALWAYS_INLINE bool
 te_prof_sample_event_lookahead(tsd_t *tsd, size_t usize) {
+	assert(usize == sz_s2u(usize));
 	return tsd_thread_allocated_get(tsd) + usize -
 	    tsd_thread_allocated_last_event_get(tsd) >=
 	    tsd_prof_sample_event_wait_get(tsd);

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -218,6 +218,13 @@ te_ctx_get(tsd_t *tsd, te_ctx_t *ctx, bool is_alloc) {
 	}
 }
 
+JEMALLOC_ALWAYS_INLINE bool
+te_prof_sample_event_lookahead(tsd_t *tsd, size_t usize) {
+	return tsd_thread_allocated_get(tsd) + usize -
+	    tsd_thread_allocated_last_event_get(tsd) >=
+	    tsd_prof_sample_event_wait_get(tsd);
+}
+
 JEMALLOC_ALWAYS_INLINE void
 te_event_advance(tsd_t *tsd, size_t usize, bool is_alloc) {
 	te_assert_invariants(tsd);

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -33,7 +33,6 @@ typedef struct te_ctx_s {
 
 void te_assert_invariants_debug(tsd_t *tsd);
 void te_event_trigger(tsd_t *tsd, te_ctx_t *ctx, bool delay_event);
-void te_alloc_rollback(tsd_t *tsd, size_t diff);
 void te_event_update(tsd_t *tsd, bool alloc_event);
 void te_recompute_fast_threshold(tsd_t *tsd);
 void tsd_te_init(tsd_t *tsd);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2168,7 +2168,9 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 	/* If profiling is on, get our profiling context. */
 	if (config_prof && opt_prof) {
 		bool prof_active = prof_active_get_unlocked();
-		prof_tctx_t *tctx = prof_alloc_prep(tsd, usize, prof_active);
+		bool sample_event = te_prof_sample_event_lookahead(tsd, usize);
+		prof_tctx_t *tctx = prof_alloc_prep(tsd, prof_active,
+		    sample_event);
 
 		emap_alloc_ctx_t alloc_ctx;
 		if (likely((uintptr_t)tctx == (uintptr_t)1U)) {
@@ -3075,7 +3077,8 @@ irallocx_prof(tsd_t *tsd, void *old_ptr, size_t old_usize, size_t size,
 	prof_info_t old_prof_info;
 	prof_info_get_and_reset_recent(tsd, old_ptr, alloc_ctx, &old_prof_info);
 	bool prof_active = prof_active_get_unlocked();
-	prof_tctx_t *tctx = prof_alloc_prep(tsd, *usize, prof_active);
+	bool sample_event = te_prof_sample_event_lookahead(tsd, *usize);
+	prof_tctx_t *tctx = prof_alloc_prep(tsd, prof_active, sample_event);
 	void *p;
 	if (unlikely((uintptr_t)tctx != (uintptr_t)1U)) {
 		p = irallocx_prof_sample(tsd_tsdn(tsd), old_ptr, old_usize,
@@ -3102,8 +3105,9 @@ irallocx_prof(tsd_t *tsd, void *old_ptr, size_t old_usize, size_t size,
 		*usize = isalloc(tsd_tsdn(tsd), p);
 	}
 
+	sample_event = te_prof_sample_event_lookahead(tsd, *usize);
 	prof_realloc(tsd, p, size, *usize, tctx, prof_active, old_ptr,
-	    old_usize, &old_prof_info);
+	    old_usize, &old_prof_info, sample_event);
 
 	return p;
 }
@@ -3350,7 +3354,8 @@ ixallocx_prof(tsd_t *tsd, void *ptr, size_t old_usize, size_t size,
 		}
 	}
 	bool prof_active = prof_active_get_unlocked();
-	prof_tctx_t *tctx = prof_alloc_prep(tsd, usize_max, prof_active);
+	bool sample_event = te_prof_sample_event_lookahead(tsd, usize_max);
+	prof_tctx_t *tctx = prof_alloc_prep(tsd, prof_active, sample_event);
 
 	size_t usize;
 	if (unlikely((uintptr_t)tctx != (uintptr_t)1U)) {
@@ -3376,8 +3381,9 @@ ixallocx_prof(tsd_t *tsd, void *ptr, size_t old_usize, size_t size,
 	} else {
 		prof_info_get_and_reset_recent(tsd, ptr, alloc_ctx, &prof_info);
 		assert(usize <= usize_max);
+		sample_event = te_prof_sample_event_lookahead(tsd, usize);
 		prof_realloc(tsd, ptr, size, usize, tctx, prof_active, ptr,
-		    old_usize, &prof_info);
+		    old_usize, &prof_info, sample_event);
 	}
 
 	assert(old_prof_info.alloc_tctx == prof_info.alloc_tctx);

--- a/src/prof.c
+++ b/src/prof.c
@@ -118,27 +118,12 @@ prof_strncpy(char *UNUSED dest, const char *UNUSED src, size_t UNUSED size) {
 }
 
 void
-prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx, bool updated) {
+prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx) {
 	cassert(config_prof);
 
 	if (tsd_reentrancy_level_get(tsd) > 0) {
 		assert((uintptr_t)tctx == (uintptr_t)1U);
 		return;
-	}
-
-	prof_tdata_t *tdata;
-
-	if (updated) {
-		/*
-		 * Compute a new sample threshold.  This isn't very important in
-		 * practice, because this function is rarely executed, so the
-		 * potential for sample bias is minimal except in contrived
-		 * programs.
-		 */
-		tdata = prof_tdata_get(tsd, true);
-		if (tdata != NULL) {
-			prof_sample_threshold_update(tsd);
-		}
 	}
 
 	if ((uintptr_t)tctx > (uintptr_t)1U) {

--- a/src/thread_event.c
+++ b/src/thread_event.c
@@ -78,17 +78,7 @@ te_prof_sample_event_handler(tsd_t *tsd) {
 	if (prof_idump_accum(tsd_tsdn(tsd), last_event - last_sample_event)) {
 		prof_idump(tsd_tsdn(tsd));
 	}
-	if (!prof_active_get_unlocked()) {
-		/*
-		 * If prof_active is off, we reset prof_sample_event_wait to be
-		 * the sample interval when it drops to 0, so that there won't
-		 * be excessive routings to the slow path, and that when
-		 * prof_active is turned on later, the counting for sampling
-		 * can immediately resume as normal.
-		 */
-		te_prof_sample_event_update(tsd,
-		    (uint64_t)(1 << lg_prof_sample));
-	}
+	te_tsd_prof_sample_event_init(tsd);
 }
 
 static void

--- a/test/unit/thread_event.c
+++ b/test/unit/thread_event.c
@@ -27,24 +27,8 @@ TEST_BEGIN(test_next_event_fast) {
 }
 TEST_END
 
-TEST_BEGIN(test_event_rollback) {
-	tsd_t *tsd = tsd_fetch();
-	const uint64_t diff = TE_MAX_INTERVAL >> 2;
-	size_t count = 10;
-	uint64_t thread_allocated = thread_allocated_get(tsd);
-	while (count-- != 0) {
-		te_alloc_rollback(tsd, diff);
-		uint64_t thread_allocated_after = thread_allocated_get(tsd);
-		assert_u64_eq(thread_allocated - thread_allocated_after, diff,
-		    "thread event counters are not properly rolled back");
-		thread_allocated = thread_allocated_after;
-	}
-}
-TEST_END
-
 int
 main(void) {
 	return test(
-	    test_next_event_fast,
-	    test_event_rollback);
+	    test_next_event_fast);
 }


### PR DESCRIPTION
There are a few subtle things here:
- The main change is to always reset the sampling threshold in `prof_alloc_rollback()`. Previously, we only reset when `updated == true`. I think we should also reset when `updated == false`, which is actually more important - otherwise the next allocation would always be sampled because the threshold would still be observed as having been hit. If my reasoning is correct, I feel that the `updated` flag is redundant (in the entire profiling logic), and I'll try to add another commit to remove it.
- A related fix in `xallocx()`. The issue is revealed in `test_xallocx_overflow` in `test/unit/safety_check`. The issue was hidden before my main change in `prof_alloc_rollback()`: when an `xallocx()` does not resize, the next `malloc()` is always sampled, which happens to be what we want in the unit test, only except that the sampling was triggered by the last allocation, rather than by itself. Now `prof_alloc_rollback()` correctly resets the threshold, but a later `te_alloc_rollback()` call further extends the wait time so that the next `malloc()` (of the same size) cannot hit the threshold any more. Extending the wait time for events not yet triggered is the right thing to do in `te_alloc_rollback()`; for events already been hit, `te_alloc_rollback()` shouldn't attempt anything, because it's not equipped with the ability to revert the events. The right way is to call `te_alloc_rollback()` first and then call the rollback functions for each triggered event. To make that happen for `xallocx()`, I also slightly restructured the logic. I think the ideal way is to call the event rollback functions within `te_alloc_rollback()`; I'll try to have another commit later to do that.
- Another separate change, which I put as an individual commit for clarity: I don't think `prof_alloc_rollback()` should create a `tdata` if the `tdata` hasn't been created yet. I think `tdata` is not created only if `prof_alloc_rollback()` is not really rolling back a sampled allocation, and in such a case it'd just better do nothing and exit.