### PR TITLE
Correct thread event unit test

### DIFF
--- a/test/unit/thread_event.c
+++ b/test/unit/thread_event.c
@@ -1,6 +1,6 @@
 #include "test/jemalloc_test.h"
 
-TEST_BEGIN(test_next_event_fast_roll_back) {
+TEST_BEGIN(test_next_event_fast) {
 	tsd_t *tsd = tsd_fetch();
 	te_ctx_t ctx;
 	te_ctx_get(tsd, &ctx, true);
@@ -14,31 +14,16 @@ TEST_BEGIN(test_next_event_fast_roll_back) {
 	}
 	ITERATE_OVER_ALL_EVENTS
 #undef E
+
+	/* Test next_event_fast rolling back to 0. */
 	void *p = malloc(16U);
 	assert_ptr_not_null(p, "malloc() failed");
 	free(p);
-}
-TEST_END
 
-TEST_BEGIN(test_next_event_fast_resume) {
-	tsd_t *tsd = tsd_fetch();
-
-	te_ctx_t ctx;
-	te_ctx_get(tsd, &ctx, true);
-
-	te_ctx_last_event_set(&ctx, 0);
-	te_ctx_current_bytes_set(&ctx, TE_NEXT_EVENT_FAST_MAX + 8U);
-	te_ctx_next_event_set(tsd, &ctx, TE_NEXT_EVENT_FAST_MAX + 16U);
-#define E(event, condition, is_alloc)					\
-	if (is_alloc && condition) {					\
-		event##_event_wait_set(tsd,				\
-		    TE_NEXT_EVENT_FAST_MAX + 16U);			\
-	}
-	ITERATE_OVER_ALL_EVENTS
-#undef E
-	void *p = malloc(SC_LOOKUP_MAXCLASS);
-	assert_ptr_not_null(p, "malloc() failed");
-	free(p);
+	/* Test next_event_fast resuming to be equal to next_event. */
+	void *q = malloc(SC_LOOKUP_MAXCLASS);
+	assert_ptr_not_null(q, "malloc() failed");
+	free(q);
 }
 TEST_END
 
@@ -60,7 +45,6 @@ TEST_END
 int
 main(void) {
 	return test(
-	    test_next_event_fast_roll_back,
-	    test_next_event_fast_resume,
+	    test_next_event_fast,
 	    test_event_rollback);
 }


### PR DESCRIPTION
The `test_next_event_fast_resume` test has an issue even though it didn't fail. Its setup was directly against the thread event design: the wait time plus the allocation exceeded `UINT64_MAX`, causing an overflow here:
https://github.com/jemalloc/jemalloc/blob/305b1f6d962c5b5a76b7ddb4b55b14d88bada9ba/src/thread_event.c#L309

which ended up having `te_event_trigger()` triggering no event. There was no critical harm, but we were not testing what we wanted to test, and the logic did not follow the plan of the code.

The fix is to simply carry out `test_next_event_fast_resume` directly after `test_next_event_fast_roll_back`.