### PR TITLE
Edata cache and inspect fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -195,6 +195,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/counter.c \
 	$(srcroot)test/unit/decay.c \
 	$(srcroot)test/unit/div.c \
+	$(srcroot)test/unit/edata_cache.c \
 	$(srcroot)test/unit/emitter.c \
 	$(srcroot)test/unit/extent_quantize.c \
 	$(srcroot)test/unit/fork.c \

--- a/include/jemalloc/internal/edata_cache.h
+++ b/include/jemalloc/internal/edata_cache.h
@@ -25,4 +25,32 @@ void edata_cache_prefork(tsdn_t *tsdn, edata_cache_t *edata_cache);
 void edata_cache_postfork_parent(tsdn_t *tsdn, edata_cache_t *edata_cache);
 void edata_cache_postfork_child(tsdn_t *tsdn, edata_cache_t *edata_cache);
 
+typedef struct edata_cache_small_s edata_cache_small_t;
+struct edata_cache_small_s {
+	edata_list_t list;
+	size_t count;
+	edata_cache_t *fallback;
+};
+
+/*
+ * An edata_cache_small is like an edata_cache, but it relies on external
+ * synchronization and avoids first-fit strategies.  You can call "prepare" to
+ * acquire at least num edata_t objects, and then "finish" to flush all
+ * excess ones back to their fallback edata_cache_t.  Once they have been
+ * acquired, they can be allocated without failing (and in fact, this is
+ * required -- it's not permitted to attempt to get an edata_t without first
+ * preparing for it).
+ */
+
+void edata_cache_small_init(edata_cache_small_t *ecs, edata_cache_t *fallback);
+
+/* Returns whether or not an error occurred. */
+bool edata_cache_small_prepare(tsdn_t *tsdn, edata_cache_small_t *ecs,
+    size_t num);
+edata_t *edata_cache_small_get(edata_cache_small_t *ecs);
+
+void edata_cache_small_put(edata_cache_small_t *ecs, edata_t *edata);
+void edata_cache_small_finish(tsdn_t *tsdn, edata_cache_small_t *ecs,
+    size_t num);
+
 #endif /* JEMALLOC_INTERNAL_EDATA_CACHE_H */

--- a/src/edata_cache.c
+++ b/src/edata_cache.c
@@ -27,7 +27,8 @@ edata_cache_get(tsdn_t *tsdn, edata_cache_t *edata_cache) {
 		return base_alloc_edata(tsdn, edata_cache->base);
 	}
 	edata_avail_remove(&edata_cache->avail, edata);
-	atomic_fetch_sub_zu(&edata_cache->count, 1, ATOMIC_RELAXED);
+	size_t count = atomic_load_zu(&edata_cache->count, ATOMIC_RELAXED);
+	atomic_store_zu(&edata_cache->count, count - 1, ATOMIC_RELAXED);
 	malloc_mutex_unlock(tsdn, &edata_cache->mtx);
 	return edata;
 }
@@ -36,7 +37,8 @@ void
 edata_cache_put(tsdn_t *tsdn, edata_cache_t *edata_cache, edata_t *edata) {
 	malloc_mutex_lock(tsdn, &edata_cache->mtx);
 	edata_avail_insert(&edata_cache->avail, edata);
-	atomic_fetch_add_zu(&edata_cache->count, 1, ATOMIC_RELAXED);
+	size_t count = atomic_load_zu(&edata_cache->count, ATOMIC_RELAXED);
+	atomic_store_zu(&edata_cache->count, count + 1, ATOMIC_RELAXED);
 	malloc_mutex_unlock(tsdn, &edata_cache->mtx);
 }
 

--- a/test/unit/edata_cache.c
+++ b/test/unit/edata_cache.c
@@ -1,0 +1,54 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/edata_cache.h"
+
+static void
+test_edata_cache_init(edata_cache_t *edata_cache) {
+	base_t *base = base_new(TSDN_NULL, /* ind */ 1,
+	    &ehooks_default_extent_hooks);
+	assert_ptr_not_null(base, "");
+	bool err = edata_cache_init(edata_cache, base);
+	assert_false(err, "");
+}
+
+static void
+test_edata_cache_destroy(edata_cache_t *edata_cache) {
+	base_delete(TSDN_NULL, edata_cache->base);
+}
+
+TEST_BEGIN(test_edata_cache) {
+	edata_cache_t edc;
+	test_edata_cache_init(&edc);
+
+	/* Get one */
+	edata_t *ed1 = edata_cache_get(TSDN_NULL, &edc);
+	assert_ptr_not_null(ed1, "");
+
+	/* Cache should be empty */
+	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+
+	/* Get another */
+	edata_t *ed2 = edata_cache_get(TSDN_NULL, &edc);
+	assert_ptr_not_null(ed2, "");
+
+	/* Still empty */
+	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+
+	/* Put one back, and the cache should now have one item */
+	edata_cache_put(TSDN_NULL, &edc, ed1);
+	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 1, "");
+
+	/* Reallocating should reuse the item, and leave an empty cache. */
+	edata_t *ed1_again = edata_cache_get(TSDN_NULL, &edc);
+	assert_ptr_eq(ed1, ed1_again, "");
+	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+
+	test_edata_cache_destroy(&edc);
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_edata_cache);
+}

--- a/test/unit/edata_cache.c
+++ b/test/unit/edata_cache.c
@@ -17,38 +17,75 @@ test_edata_cache_destroy(edata_cache_t *edata_cache) {
 }
 
 TEST_BEGIN(test_edata_cache) {
-	edata_cache_t edc;
-	test_edata_cache_init(&edc);
+	edata_cache_t ec;
+	test_edata_cache_init(&ec);
 
 	/* Get one */
-	edata_t *ed1 = edata_cache_get(TSDN_NULL, &edc);
+	edata_t *ed1 = edata_cache_get(TSDN_NULL, &ec);
 	assert_ptr_not_null(ed1, "");
 
 	/* Cache should be empty */
-	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
 
 	/* Get another */
-	edata_t *ed2 = edata_cache_get(TSDN_NULL, &edc);
+	edata_t *ed2 = edata_cache_get(TSDN_NULL, &ec);
 	assert_ptr_not_null(ed2, "");
 
 	/* Still empty */
-	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
 
 	/* Put one back, and the cache should now have one item */
-	edata_cache_put(TSDN_NULL, &edc, ed1);
-	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 1, "");
+	edata_cache_put(TSDN_NULL, &ec, ed1);
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 1, "");
 
 	/* Reallocating should reuse the item, and leave an empty cache. */
-	edata_t *ed1_again = edata_cache_get(TSDN_NULL, &edc);
+	edata_t *ed1_again = edata_cache_get(TSDN_NULL, &ec);
 	assert_ptr_eq(ed1, ed1_again, "");
-	assert_zu_eq(atomic_load_zu(&edc.count, ATOMIC_RELAXED), 0, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
 
-	test_edata_cache_destroy(&edc);
+	test_edata_cache_destroy(&ec);
+}
+TEST_END
+
+TEST_BEGIN(test_edata_cache_small) {
+	edata_cache_t ec;
+	edata_cache_small_t ecs;
+
+	test_edata_cache_init(&ec);
+	edata_cache_small_init(&ecs, &ec);
+
+	bool err = edata_cache_small_prepare(TSDN_NULL, &ecs, 2);
+	assert_false(err, "");
+	assert_zu_eq(ecs.count, 2, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
+
+	edata_t *ed1 = edata_cache_small_get(&ecs);
+	assert_zu_eq(ecs.count, 1, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
+
+	edata_t *ed2 = edata_cache_small_get(&ecs);
+	assert_zu_eq(ecs.count, 0, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
+
+	edata_cache_small_put(&ecs, ed1);
+	assert_zu_eq(ecs.count, 1, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
+
+	edata_cache_small_put(&ecs, ed2);
+	assert_zu_eq(ecs.count, 2, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 0, "");
+
+	edata_cache_small_finish(TSDN_NULL, &ecs, 1);
+	assert_zu_eq(ecs.count, 1, "");
+	assert_zu_eq(atomic_load_zu(&ec.count, ATOMIC_RELAXED), 1, "");
+
+	test_edata_cache_destroy(&ec);
 }
 TEST_END
 
 int
 main(void) {
 	return test(
-	    test_edata_cache);
+	    test_edata_cache,
+	    test_edata_cache_small);
 }


### PR DESCRIPTION
This adds:
- Unit tests for the edata_cache_t (which was previously tested only via the extent tests).
- A slight performance improvement to it (an atomic fetch-add which can just be a load-then-store).
- An unsynchronized edata_cache_small_t, which can amortize locking and allocations. (This is not actually used anywhere yet, but I've got several branches that all could use this and an early merge would be helpful from a workflow perspective).
- A minor fix to the inspect unit test (some of its assumptions stop being correct if profiling is enabled).