### PR TITLE
Rewrite cache bin module

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -102,6 +102,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/bin_info.c \
 	$(srcroot)src/bitmap.c \
 	$(srcroot)src/buf_writer.c \
+	$(srcroot)src/cache_bin.c \
 	$(srcroot)src/ckh.c \
 	$(srcroot)src/counter.c \
 	$(srcroot)src/ctl.c \

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,7 @@ if test "x$GCC" = "xyes" ; then
   JE_CFLAGS_ADD([-Wsign-compare])
   JE_CFLAGS_ADD([-Wundef])
   JE_CFLAGS_ADD([-Wno-format-zero-length])
+  JE_CFLAGS_ADD([-Wpointer-arith])
   dnl This warning triggers on the use of the universal zero initializer, which
   dnl is a very handy idiom for things like the tcache static initializer (which
   dnl has lots of nested structs).  See the discussion at.

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -50,11 +50,6 @@ void arena_reset(tsd_t *tsd, arena_t *arena);
 void arena_destroy(tsd_t *tsd, arena_t *arena);
 void arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
     cache_bin_t *tbin, szind_t binind);
-void arena_alloc_junk_small(void *ptr, const bin_info_t *bin_info,
-    bool zero);
-
-typedef void (arena_dalloc_junk_small_t)(void *, const bin_info_t *);
-extern arena_dalloc_junk_small_t *JET_MUTABLE arena_dalloc_junk_small;
 
 void *arena_malloc_hard(tsdn_t *tsdn, arena_t *arena, size_t size,
     szind_t ind, bool zero);
@@ -63,9 +58,9 @@ void *arena_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize,
 void arena_prof_promote(tsdn_t *tsdn, void *ptr, size_t usize);
 void arena_dalloc_promoted(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
     bool slow_path);
-bool arena_dalloc_bin_junked_locked(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
-    szind_t binind, edata_t *edata, void *ptr);
 void arena_slab_dalloc(tsdn_t *tsdn, arena_t *arena, edata_t *slab);
+bool arena_dalloc_bin_locked(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
+    szind_t binind, edata_t *edata, void *ptr);
 void arena_dalloc_small(tsdn_t *tsdn, void *ptr);
 bool arena_ralloc_no_move(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size,
     size_t extra, bool zero, size_t *newsize);

--- a/include/jemalloc/internal/arena_inlines_a.h
+++ b/include/jemalloc/internal/arena_inlines_a.h
@@ -21,26 +21,4 @@ arena_internal_get(arena_t *arena) {
 	return atomic_load_zu(&arena->stats.internal, ATOMIC_RELAXED);
 }
 
-static inline void
-percpu_arena_update(tsd_t *tsd, unsigned cpu) {
-	assert(have_percpu_arena);
-	arena_t *oldarena = tsd_arena_get(tsd);
-	assert(oldarena != NULL);
-	unsigned oldind = arena_ind_get(oldarena);
-
-	if (oldind != cpu) {
-		unsigned newind = cpu;
-		arena_t *newarena = arena_get(tsd_tsdn(tsd), newind, true);
-		assert(newarena != NULL);
-
-		/* Set new arena/tcache associations. */
-		arena_migrate(tsd, oldind, newind);
-		tcache_t *tcache = tcache_get(tsd);
-		if (tcache != NULL) {
-			tcache_arena_reassociate(tsd_tsdn(tsd), tcache,
-			    newarena);
-		}
-	}
-}
-
 #endif /* JEMALLOC_INTERNAL_ARENA_INLINES_A_H */

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -146,6 +146,13 @@ cache_bin_empty_position_get(cache_bin_t *bin, cache_bin_info_t *info) {
 	return ret;
 }
 
+static inline void
+cache_bin_assert_empty(cache_bin_t *bin, cache_bin_info_t *info) {
+	assert(cache_bin_ncached_get(bin, info) == 0);
+	assert(cache_bin_empty_position_get(bin, info) == bin->cur_ptr.ptr);
+}
+
+
 /* Returns the numeric value of low water in [0, ncached]. */
 static inline cache_bin_sz_t
 cache_bin_low_water_get(cache_bin_t *bin, cache_bin_info_t *info) {

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -354,4 +354,11 @@ void cache_bin_postincrement(cache_bin_info_t *infos, szind_t ninfos,
 void cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
     size_t *cur_offset);
 
+/*
+ * If a cache bin was zero initialized (either because it lives in static or
+ * thread-local storage, or was memset to 0), this function indicates whether or
+ * not cache_bin_init was called on it.
+ */
+bool cache_bin_still_zero_initialized(cache_bin_t *bin);
+
 #endif /* JEMALLOC_INTERNAL_CACHE_BIN_H */

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -35,7 +35,6 @@ struct cache_bin_info_s {
 	/* The size of the bin stack, i.e. ncached_max * sizeof(ptr). */
 	cache_bin_sz_t stack_size;
 };
-extern cache_bin_info_t	*tcache_bin_info;
 
 typedef struct cache_bin_s cache_bin_t;
 struct cache_bin_s {
@@ -115,29 +114,29 @@ struct cache_bin_array_descriptor_s {
 
 /* Returns ncached_max: Upper limit on ncached. */
 static inline cache_bin_sz_t
-cache_bin_ncached_max_get(szind_t ind) {
-	return tcache_bin_info[ind].stack_size / sizeof(void *);
+cache_bin_ncached_max_get(szind_t ind, cache_bin_info_t *infos) {
+	return infos[ind].stack_size / sizeof(void *);
 }
 
 static inline cache_bin_sz_t
-cache_bin_ncached_get(cache_bin_t *bin, szind_t ind) {
-	cache_bin_sz_t n = (cache_bin_sz_t)((tcache_bin_info[ind].stack_size +
+cache_bin_ncached_get(cache_bin_t *bin, szind_t ind, cache_bin_info_t *infos) {
+	cache_bin_sz_t n = (cache_bin_sz_t)((infos[ind].stack_size +
 	    bin->full_position - bin->cur_ptr.lowbits) / sizeof(void *));
-	assert(n <= cache_bin_ncached_max_get(ind));
+	assert(n <= cache_bin_ncached_max_get(ind, infos));
 	assert(n == 0 || *(bin->cur_ptr.ptr) != NULL);
 
 	return n;
 }
 
 static inline void **
-cache_bin_empty_position_get(cache_bin_t *bin, szind_t ind) {
-	void **ret = bin->cur_ptr.ptr + cache_bin_ncached_get(bin, ind);
+cache_bin_empty_position_get(cache_bin_t *bin, szind_t ind,
+    cache_bin_info_t *infos) {
+	void **ret = bin->cur_ptr.ptr + cache_bin_ncached_get(bin, ind, infos);
 	/* Low bits overflow disallowed when allocating the space. */
 	assert((uint32_t)(uintptr_t)ret >= bin->cur_ptr.lowbits);
 
 	/* Can also be computed via (full_position + ncached_max) | highbits. */
-	uintptr_t lowbits = bin->full_position +
-	    tcache_bin_info[ind].stack_size;
+	uintptr_t lowbits = bin->full_position + infos[ind].stack_size;
 	uintptr_t highbits = (uintptr_t)bin->cur_ptr.ptr &
 	    ~(((uint64_t)1 << 32) - 1);
 	assert(ret == (void **)(lowbits | highbits));
@@ -147,32 +146,35 @@ cache_bin_empty_position_get(cache_bin_t *bin, szind_t ind) {
 
 /* Returns the position of the bottom item on the stack; for convenience. */
 static inline void **
-cache_bin_bottom_item_get(cache_bin_t *bin, szind_t ind) {
-	void **bottom = cache_bin_empty_position_get(bin, ind) - 1;
-	assert(cache_bin_ncached_get(bin, ind) == 0 || *bottom != NULL);
+cache_bin_bottom_item_get(cache_bin_t *bin, szind_t ind,
+    cache_bin_info_t *infos) {
+	void **bottom = cache_bin_empty_position_get(bin, ind, infos) - 1;
+	assert(cache_bin_ncached_get(bin, ind, infos) == 0 || *bottom != NULL);
 
 	return bottom;
 }
 
 /* Returns the numeric value of low water in [0, ncached]. */
 static inline cache_bin_sz_t
-cache_bin_low_water_get(cache_bin_t *bin, szind_t ind) {
-	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(ind);
+cache_bin_low_water_get(cache_bin_t *bin, szind_t ind,
+    cache_bin_info_t *infos) {
+	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(ind, infos);
 	cache_bin_sz_t low_water = ncached_max -
 	    (cache_bin_sz_t)((bin->low_water_position - bin->full_position) /
 	    sizeof(void *));
 	assert(low_water <= ncached_max);
-	assert(low_water <= cache_bin_ncached_get(bin, ind));
+	assert(low_water <= cache_bin_ncached_get(bin, ind, infos));
 	assert(bin->low_water_position >= bin->cur_ptr.lowbits);
 
 	return low_water;
 }
 
 static inline void
-cache_bin_ncached_set(cache_bin_t *bin, szind_t ind, cache_bin_sz_t n) {
-	bin->cur_ptr.lowbits = bin->full_position +
-	    tcache_bin_info[ind].stack_size - n * sizeof(void *);
-	assert(n <= cache_bin_ncached_max_get(ind));
+cache_bin_ncached_set(cache_bin_t *bin, szind_t ind, cache_bin_sz_t n,
+    cache_bin_info_t *infos) {
+	bin->cur_ptr.lowbits = bin->full_position + infos[ind].stack_size
+	    - n * sizeof(void *);
+	assert(n <= cache_bin_ncached_max_get(ind, infos));
 	assert(n == 0 || *bin->cur_ptr.ptr != NULL);
 }
 
@@ -188,7 +190,7 @@ cache_bin_array_descriptor_init(cache_bin_array_descriptor_t *descriptor,
 
 JEMALLOC_ALWAYS_INLINE void *
 cache_bin_alloc_easy_impl(cache_bin_t *bin, bool *success, szind_t ind,
-    const bool adjust_low_water) {
+    cache_bin_info_t *infos, const bool adjust_low_water) {
 	/*
 	 * This may read from the empty position; however the loaded value won't
 	 * be used.  It's safe because the stack has one more slot reserved.
@@ -197,14 +199,14 @@ cache_bin_alloc_easy_impl(cache_bin_t *bin, bool *success, szind_t ind,
 	/*
 	 * Check for both bin->ncached == 0 and ncached < low_water in a single
 	 * branch.  When adjust_low_water is true, this also avoids accessing
-	 * tcache_bin_info (which is on a separate cacheline / page) in the
-	 * common case.
+	 * the cache_bin_info_ts (which is on a separate cacheline / page) in
+	 * the common case.
 	 */
 	if (unlikely(bin->cur_ptr.lowbits > bin->low_water_position)) {
 		if (adjust_low_water) {
 			assert(ind != INVALID_SZIND);
 			uint32_t empty_position = bin->full_position +
-			    tcache_bin_info[ind].stack_size;
+			    infos[ind].stack_size;
 			if (unlikely(bin->cur_ptr.lowbits > empty_position)) {
 				/* Over-allocated; revert. */
 				bin->cur_ptr.ptr--;
@@ -237,12 +239,14 @@ cache_bin_alloc_easy_impl(cache_bin_t *bin, bool *success, szind_t ind,
 JEMALLOC_ALWAYS_INLINE void *
 cache_bin_alloc_easy_reduced(cache_bin_t *bin, bool *success) {
 	/* The szind parameter won't be used. */
-	return cache_bin_alloc_easy_impl(bin, success, INVALID_SZIND, false);
+	return cache_bin_alloc_easy_impl(bin, success, INVALID_SZIND,
+	    /* infos */ NULL, false);
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-cache_bin_alloc_easy(cache_bin_t *bin, bool *success, szind_t ind) {
-	return cache_bin_alloc_easy_impl(bin, success, ind, true);
+cache_bin_alloc_easy(cache_bin_t *bin, bool *success, szind_t ind,
+    cache_bin_info_t *infos) {
+	return cache_bin_alloc_easy_impl(bin, success, ind, infos, true);
 }
 
 #undef INVALID_SZIND

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -144,16 +144,6 @@ cache_bin_empty_position_get(cache_bin_t *bin, szind_t ind,
 	return ret;
 }
 
-/* Returns the position of the bottom item on the stack; for convenience. */
-static inline void **
-cache_bin_bottom_item_get(cache_bin_t *bin, szind_t ind,
-    cache_bin_info_t *infos) {
-	void **bottom = cache_bin_empty_position_get(bin, ind, infos) - 1;
-	assert(cache_bin_ncached_get(bin, ind, infos) == 0 || *bottom != NULL);
-
-	return bottom;
-}
-
 /* Returns the numeric value of low water in [0, ncached]. */
 static inline cache_bin_sz_t
 cache_bin_low_water_get(cache_bin_t *bin, szind_t ind,
@@ -261,6 +251,34 @@ cache_bin_dalloc_easy(cache_bin_t *bin, void *ptr) {
 	assert(bin->cur_ptr.lowbits >= bin->full_position);
 
 	return true;
+}
+
+typedef struct cache_bin_ptr_array_s cache_bin_ptr_array_t;
+struct cache_bin_ptr_array_s {
+	cache_bin_sz_t nflush;
+	void **ptr;
+};
+
+#define CACHE_BIN_PTR_ARRAY_DECLARE(name, nflush_val)			\
+    cache_bin_ptr_array_t name;						\
+    name.nflush = (nflush_val)
+
+static inline void
+cache_bin_ptr_array_init(cache_bin_ptr_array_t *arr, cache_bin_t *bin,
+    cache_bin_sz_t nflush, szind_t ind, cache_bin_info_t *infos) {
+	arr->ptr = cache_bin_empty_position_get(bin, ind, infos) - 1;
+	assert(cache_bin_ncached_get(bin, ind, infos) == 0
+	    || *arr->ptr != NULL);
+}
+
+JEMALLOC_ALWAYS_INLINE void *
+cache_bin_ptr_array_get(cache_bin_ptr_array_t *arr, cache_bin_sz_t n) {
+	return *(arr->ptr - n);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+cache_bin_ptr_array_set(cache_bin_ptr_array_t *arr, cache_bin_sz_t n, void *p) {
+	*(arr->ptr - n) = p;
 }
 
 #endif /* JEMALLOC_INTERNAL_CACHE_BIN_H */

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -14,7 +14,10 @@
  * of the tcache at all.
  */
 
-/* The size in bytes of each cache bin stack. */
+/*
+ * The size in bytes of each cache bin stack.  We also use this to indicate
+ * *counts* of individual objects.
+ */
 typedef uint16_t cache_bin_sz_t;
 
 typedef struct cache_bin_stats_s cache_bin_stats_t;
@@ -310,5 +313,32 @@ cache_bin_finish_flush(cache_bin_t *bin, cache_bin_info_t *info,
 		bin->low_water_position = bin->cur_ptr.lowbits;
 	}
 }
+
+/*
+ * Initialize a cache_bin_info to represent up to the given number of items in
+ * the cache_bins it is associated with.
+ */
+void cache_bin_info_init(cache_bin_info_t *bin_info,
+    cache_bin_sz_t ncached_max);
+/*
+ * Given an array of initialized cache_bin_info_ts, determine how big an
+ * allocation is required to initialize a full set of cache_bin_ts.
+ */
+void cache_bin_info_compute_alloc(cache_bin_info_t *infos, szind_t ninfos,
+    size_t *size, size_t *alignment);
+
+/*
+ * Actually initialize some cache bins.  Callers should allocate the backing
+ * memory indicated by a call to cache_bin_compute_alloc.  They should then
+ * preincrement, call init once for each bin and info, and then call
+ * cache_bin_postincrement.  *alloc_cur will then point immediately past the end
+ * of the allocation.
+ */
+void cache_bin_preincrement(cache_bin_info_t *infos, szind_t ninfos,
+    void *alloc, size_t *cur_offset);
+void cache_bin_postincrement(cache_bin_info_t *infos, szind_t ninfos,
+    void *alloc, size_t *cur_offset);
+void cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
+    size_t *cur_offset);
 
 #endif /* JEMALLOC_INTERNAL_CACHE_BIN_H */

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -169,6 +169,10 @@ cache_bin_low_water_set(cache_bin_t *bin) {
 	bin->low_water_position = bin->cur_ptr.lowbits;
 }
 
+/*
+ * This is an internal implementation detail -- users should only affect ncached
+ * via single-item pushes or batch fills.
+ */
 static inline void
 cache_bin_ncached_set(cache_bin_t *bin, cache_bin_info_t *info,
     cache_bin_sz_t n) {

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -255,16 +255,16 @@ cache_bin_dalloc_easy(cache_bin_t *bin, void *ptr) {
 
 typedef struct cache_bin_ptr_array_s cache_bin_ptr_array_t;
 struct cache_bin_ptr_array_s {
-	cache_bin_sz_t nflush;
+	cache_bin_sz_t n;
 	void **ptr;
 };
 
-#define CACHE_BIN_PTR_ARRAY_DECLARE(name, nflush_val)			\
+#define CACHE_BIN_PTR_ARRAY_DECLARE(name, nval)				\
     cache_bin_ptr_array_t name;						\
-    name.nflush = (nflush_val)
+    name.n = (nval)
 
 static inline void
-cache_bin_ptr_array_init(cache_bin_ptr_array_t *arr, cache_bin_t *bin,
+cache_bin_ptr_array_init_for_flush(cache_bin_ptr_array_t *arr, cache_bin_t *bin,
     cache_bin_sz_t nflush, szind_t ind, cache_bin_info_t *infos) {
 	arr->ptr = cache_bin_empty_position_get(bin, ind, infos) - 1;
 	assert(cache_bin_ncached_get(bin, ind, infos) == 0

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -114,15 +114,15 @@ struct cache_bin_array_descriptor_s {
 
 /* Returns ncached_max: Upper limit on ncached. */
 static inline cache_bin_sz_t
-cache_bin_ncached_max_get(szind_t ind, cache_bin_info_t *infos) {
-	return infos[ind].stack_size / sizeof(void *);
+cache_bin_info_ncached_max(cache_bin_info_t *info) {
+	return info->stack_size / sizeof(void *);
 }
 
 static inline cache_bin_sz_t
 cache_bin_ncached_get(cache_bin_t *bin, szind_t ind, cache_bin_info_t *infos) {
 	cache_bin_sz_t n = (cache_bin_sz_t)((infos[ind].stack_size +
 	    bin->full_position - bin->cur_ptr.lowbits) / sizeof(void *));
-	assert(n <= cache_bin_ncached_max_get(ind, infos));
+	assert(n <= cache_bin_info_ncached_max(&infos[ind]));
 	assert(n == 0 || *(bin->cur_ptr.ptr) != NULL);
 
 	return n;
@@ -148,7 +148,7 @@ cache_bin_empty_position_get(cache_bin_t *bin, szind_t ind,
 static inline cache_bin_sz_t
 cache_bin_low_water_get(cache_bin_t *bin, szind_t ind,
     cache_bin_info_t *infos) {
-	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(ind, infos);
+	cache_bin_sz_t ncached_max = cache_bin_info_ncached_max(&infos[ind]);
 	cache_bin_sz_t low_water = ncached_max -
 	    (cache_bin_sz_t)((bin->low_water_position - bin->full_position) /
 	    sizeof(void *));
@@ -164,7 +164,7 @@ cache_bin_ncached_set(cache_bin_t *bin, szind_t ind, cache_bin_sz_t n,
     cache_bin_info_t *infos) {
 	bin->cur_ptr.lowbits = bin->full_position + infos[ind].stack_size
 	    - n * sizeof(void *);
-	assert(n <= cache_bin_ncached_max_get(ind, infos));
+	assert(n <= cache_bin_info_ncached_max(&infos[ind]));
 	assert(n == 0 || *bin->cur_ptr.ptr != NULL);
 }
 

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -160,6 +160,15 @@ cache_bin_low_water_get(cache_bin_t *bin, cache_bin_info_t *info) {
 	return low_water;
 }
 
+/*
+ * Indicates that the current cache bin position should be the low water mark
+ * going forward.
+ */
+static inline void
+cache_bin_low_water_set(cache_bin_t *bin) {
+	bin->low_water_position = bin->cur_ptr.lowbits;
+}
+
 static inline void
 cache_bin_ncached_set(cache_bin_t *bin, cache_bin_info_t *info,
     cache_bin_sz_t n) {
@@ -289,7 +298,7 @@ cache_bin_init_ptr_array_for_flush(cache_bin_t *bin, cache_bin_info_t *info,
 }
 
 /*
- * These accessors are used by the flush pathways -- they reverse ordinary flush
+ * These accessors are used by the flush pathways -- they reverse ordinary array
  * ordering.
  */
 JEMALLOC_ALWAYS_INLINE void *

--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -14,6 +14,8 @@ extern bool opt_confirm_conf;
 extern const char *opt_junk;
 extern bool opt_junk_alloc;
 extern bool opt_junk_free;
+extern void (*junk_free_callback)(void *ptr, size_t size);
+extern void (*junk_alloc_callback)(void *ptr, size_t size);
 extern bool opt_utrace;
 extern bool opt_xmalloc;
 extern bool opt_zero;

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -130,8 +130,8 @@ tcache_available(tsd_t *tsd) {
 	if (likely(tsd_tcache_enabled_get(tsd))) {
 		/* Associated arena == NULL implies tcache init in progress. */
 		assert(tsd_tcachep_get(tsd)->arena == NULL ||
-		    tcache_small_bin_get(tsd_tcachep_get(tsd), 0)->cur_ptr.ptr
-		    != NULL);
+		    !cache_bin_still_zero_initialized(
+		    tcache_small_bin_get(tsd_tcachep_get(tsd), 0)));
 		return true;
 	}
 

--- a/include/jemalloc/internal/large_externs.h
+++ b/include/jemalloc/internal/large_externs.h
@@ -12,13 +12,7 @@ void *large_ralloc(tsdn_t *tsdn, arena_t *arena, void *ptr, size_t usize,
     size_t alignment, bool zero, tcache_t *tcache,
     hook_ralloc_args_t *hook_args);
 
-typedef void (large_dalloc_junk_t)(void *, size_t);
-extern large_dalloc_junk_t *JET_MUTABLE large_dalloc_junk;
-
-typedef void (large_dalloc_maybe_junk_t)(void *, size_t);
-extern large_dalloc_maybe_junk_t *JET_MUTABLE large_dalloc_maybe_junk;
-
-void large_dalloc_prep_junked_locked(tsdn_t *tsdn, edata_t *edata);
+void large_dalloc_prep_locked(tsdn_t *tsdn, edata_t *edata);
 void large_dalloc_finish(tsdn_t *tsdn, edata_t *edata);
 void large_dalloc(tsdn_t *tsdn, edata_t *edata);
 size_t large_salloc(tsdn_t *tsdn, const edata_t *edata);

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -13,6 +13,8 @@ extern unsigned	nhbins;
 /* Maximum cached size class. */
 extern size_t	tcache_maxclass;
 
+extern cache_bin_info_t *tcache_bin_info;
+
 /*
  * Explicit tcaches, managed via the tcache.{create,flush,destroy} mallctls and
  * usable via the MALLOCX_TCACHE() flag.  The automatic per thread tcaches are

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -36,8 +36,8 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 
 	assert(binind < SC_NBINS);
 	bin = tcache_small_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success,
-	    &tcache_bin_info[binind]);
+	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[binind],
+	    &tcache_success);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		bool tcache_hard_success;
@@ -80,8 +80,8 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 	assert(binind >= SC_NBINS &&binind < nhbins);
 	bin = tcache_large_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success,
-	    &tcache_bin_info[binind]);
+	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[binind],
+	    &tcache_success);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		/*

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -129,8 +129,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_small_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		unsigned remain = cache_bin_ncached_max_get(binind,
-		    tcache_bin_info) >> 1;
+		unsigned remain = cache_bin_info_ncached_max(
+		    &tcache_bin_info[binind]) >> 1;
 		tcache_bin_flush_small(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);
@@ -148,8 +148,8 @@ tcache_dalloc_large(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_large_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		unsigned remain = cache_bin_ncached_max_get(binind,
-		    tcache_bin_info) >> 1;
+		unsigned remain = cache_bin_info_ncached_max(
+		    &tcache_bin_info[binind]) >> 1;
 		tcache_bin_flush_large(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -36,7 +36,8 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 
 	assert(binind < SC_NBINS);
 	bin = tcache_small_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success, binind);
+	ret = cache_bin_alloc_easy(bin, &tcache_success, binind,
+	    tcache_bin_info);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		bool tcache_hard_success;
@@ -79,7 +80,8 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 	assert(binind >= SC_NBINS &&binind < nhbins);
 	bin = tcache_large_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success, binind);
+	ret = cache_bin_alloc_easy(bin, &tcache_success, binind,
+	    tcache_bin_info);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		/*
@@ -127,7 +129,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_small_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		unsigned remain = cache_bin_ncached_max_get(binind) >> 1;
+		unsigned remain = cache_bin_ncached_max_get(binind,
+		    tcache_bin_info) >> 1;
 		tcache_bin_flush_small(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);
@@ -145,7 +148,8 @@ tcache_dalloc_large(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 
 	bin = tcache_large_bin_get(tcache, binind);
 	if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {
-		unsigned remain = cache_bin_ncached_max_get(binind) >> 1;
+		unsigned remain = cache_bin_ncached_max_get(binind,
+		    tcache_bin_info) >> 1;
 		tcache_bin_flush_large(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -36,8 +36,8 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 
 	assert(binind < SC_NBINS);
 	bin = tcache_small_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success, binind,
-	    tcache_bin_info);
+	ret = cache_bin_alloc_easy(bin, &tcache_success,
+	    &tcache_bin_info[binind]);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		bool tcache_hard_success;
@@ -80,8 +80,8 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 	assert(binind >= SC_NBINS &&binind < nhbins);
 	bin = tcache_large_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_success, binind,
-	    tcache_bin_info);
+	ret = cache_bin_alloc_easy(bin, &tcache_success,
+	    &tcache_bin_info[binind]);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		/*

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -36,8 +36,7 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 
 	assert(binind < SC_NBINS);
 	bin = tcache_small_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[binind],
-	    &tcache_success);
+	ret = cache_bin_alloc(bin, &tcache_success);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		bool tcache_hard_success;
@@ -80,8 +79,7 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 	assert(binind >= SC_NBINS &&binind < nhbins);
 	bin = tcache_large_bin_get(tcache, binind);
-	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[binind],
-	    &tcache_success);
+	ret = cache_bin_alloc(bin, &tcache_success);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		/*

--- a/include/jemalloc/internal/tcache_structs.h
+++ b/include/jemalloc/internal/tcache_structs.h
@@ -50,6 +50,12 @@ struct tcache_s {
 	/* For small bins, whether has been refilled since last GC. */
 	bool		bin_refilled[SC_NBINS];
 	/*
+	 * The start of the allocation containing the dynamic allocation for
+	 * either the cache bins alone, or the cache bin memory as well as this
+	 * tcache_t.
+	 */
+	void		*dyn_alloc;
+	/*
 	 * We put the cache bins for large size classes at the end of the
 	 * struct, since some of them might not get used.  This might end up
 	 * letting us avoid touching an extra page if we don't have to.

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\..\..\src\bin_info.c" />
     <ClCompile Include="..\..\..\..\src\bitmap.c" />
     <ClCompile Include="..\..\..\..\src\buf_writer.c" />
+    <ClCompile Include="..\..\..\..\src\cache_bin.c" />
     <ClCompile Include="..\..\..\..\src\ckh.c" />
     <ClCompile Include="..\..\..\..\src\counter.c" />
     <ClCompile Include="..\..\..\..\src\ctl.c" />

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClCompile Include="..\..\..\..\src\buf_writer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cache_bin.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\ckh.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\..\..\src\bin_info.c" />
     <ClCompile Include="..\..\..\..\src\bitmap.c" />
     <ClCompile Include="..\..\..\..\src\buf_writer.c" />
+    <ClCompile Include="..\..\..\..\src\cache_bin.c" />
     <ClCompile Include="..\..\..\..\src\ckh.c" />
     <ClCompile Include="..\..\..\..\src\counter.c" />
     <ClCompile Include="..\..\..\..\src\ctl.c" />

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClCompile Include="..\..\..\..\src\buf_writer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cache_bin.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\ckh.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/arena.c
+++ b/src/arena.c
@@ -1325,8 +1325,8 @@ arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 	tcache->bin_refilled[binind] = true;
 
 	const bin_info_t *bin_info = &bin_infos[binind];
-	const unsigned nfill = cache_bin_ncached_max_get(binind,
-	    tcache_bin_info) >> tcache->lg_fill_div[binind];
+	const unsigned nfill = cache_bin_info_ncached_max(
+	    &tcache_bin_info[binind]) >> tcache->lg_fill_div[binind];
 	void **empty_position = cache_bin_empty_position_get(tbin, binind,
 	    tcache_bin_info);
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -1329,9 +1329,8 @@ arena_tcache_fill_small(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 	    &tcache_bin_info[binind]) >> tcache->lg_fill_div[binind];
 
 	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nfill);
-	cache_bin_ptr_array_init_for_fill(&ptrs, tbin, nfill,
-	    &tcache_bin_info[binind]);
-
+	cache_bin_init_ptr_array_for_fill(tbin, &tcache_bin_info[binind], &ptrs,
+	    nfill);
 	/*
 	 * Bin-local resources are used first: 1) bin->slabcur, and 2) nonfull
 	 * slabs.  After both are exhausted, new slabs will be allocated through
@@ -1443,8 +1442,7 @@ label_refill:
 		fresh_slab = NULL;
 	}
 
-	cache_bin_fill_from_ptr_array(tbin, &ptrs, filled,
-	    &tcache_bin_info[binind]);
+	cache_bin_finish_fill(tbin, &tcache_bin_info[binind], &ptrs, filled);
 	arena_decay_tick(tsdn, arena);
 }
 

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -102,3 +102,8 @@ cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
 	assert(cache_bin_ncached_get(bin, info) == 0);
 	assert(cache_bin_empty_position_get(bin, info) == empty_position);
 }
+
+bool
+cache_bin_still_zero_initialized(cache_bin_t *bin) {
+	return bin->cur_ptr.ptr == NULL;
+}

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -8,7 +8,7 @@ cache_bin_info_init(cache_bin_info_t *info,
     cache_bin_sz_t ncached_max) {
 	size_t stack_size = (size_t)ncached_max * sizeof(void *);
 	assert(stack_size < ((size_t)1 << (sizeof(cache_bin_sz_t) * 8)));
-	info->stack_size = (cache_bin_sz_t)stack_size;
+	info->ncached_max = (cache_bin_sz_t)ncached_max;
 }
 
 void
@@ -23,23 +23,14 @@ cache_bin_info_compute_alloc(cache_bin_info_t *infos, szind_t ninfos,
 	 */
 	*size = sizeof(void *) * 2;
 	for (szind_t i = 0; i < ninfos; i++) {
-		*size += infos[i].stack_size;
+		*size += infos[i].ncached_max * sizeof(void *);
 	}
 
 	/*
-	 * 1) Align to at least PAGE, to minimize the # of TLBs needed by the
+	 * Align to at least PAGE, to minimize the # of TLBs needed by the
 	 * smaller sizes; also helps if the larger sizes don't get used at all.
-	 * 2) On 32-bit the pointers won't be compressed; use minimal alignment.
 	 */
-	if (LG_SIZEOF_PTR < 3 || *size < PAGE) {
-		*alignment = PAGE;
-	} else {
-		/*
-		 * Align pow2 to avoid overflow the cache bin compressed
-		 * pointers.
-		 */
-		*alignment = pow2_ceil_zu(*size);
-	}
+	*alignment = PAGE;
 }
 
 void
@@ -53,10 +44,6 @@ cache_bin_preincrement(cache_bin_info_t *infos, szind_t ninfos, void *alloc,
 		cache_bin_info_compute_alloc(infos, ninfos, &computed_size,
 		    &computed_alignment);
 		assert(((uintptr_t)alloc & (computed_alignment - 1)) == 0);
-
-		/* And that alignment should disallow overflow. */
-		uint32_t lowbits = (uint32_t)((uintptr_t)alloc + computed_size);
-		assert((uint32_t)(uintptr_t)alloc < lowbits);
 	}
 	/*
 	 * Leave a noticeable mark pattern on the boundaries, in case a bug
@@ -81,7 +68,6 @@ cache_bin_postincrement(cache_bin_info_t *infos, szind_t ninfos, void *alloc,
 void
 cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
     size_t *cur_offset) {
-	assert(sizeof(bin->cur_ptr) == sizeof(void *));
 	/*
 	 * The full_position points to the lowest available space.  Allocations
 	 * will access the slots toward higher addresses (for the benefit of
@@ -89,21 +75,23 @@ cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
 	 */
 	void *stack_cur = (void *)((uintptr_t)alloc + *cur_offset);
 	void *full_position = stack_cur;
-	uint32_t bin_stack_size = info->stack_size;
+	uint16_t bin_stack_size = info->ncached_max * sizeof(void *);
 
 	*cur_offset += bin_stack_size;
 	void *empty_position = (void *)((uintptr_t)alloc + *cur_offset);
 
 	/* Init to the empty position. */
-	bin->cur_ptr.ptr = empty_position;
-	bin->low_water_position = bin->cur_ptr.lowbits;
-	bin->full_position = (uint32_t)(uintptr_t)full_position;
-	assert(bin->cur_ptr.lowbits - bin->full_position == bin_stack_size);
+	bin->stack_head = (void **)empty_position;
+	bin->low_bits_low_water = (uint16_t)(uintptr_t)bin->stack_head;
+	bin->low_bits_full = (uint16_t)(uintptr_t)full_position;
+	bin->low_bits_empty = (uint16_t)(uintptr_t)empty_position;
+	assert(cache_bin_diff(bin, bin->low_bits_full,
+	    (uint16_t)(uintptr_t) bin->stack_head) == bin_stack_size);
 	assert(cache_bin_ncached_get(bin, info) == 0);
 	assert(cache_bin_empty_position_get(bin, info) == empty_position);
 }
 
 bool
 cache_bin_still_zero_initialized(cache_bin_t *bin) {
-	return bin->cur_ptr.ptr == NULL;
+	return bin->stack_head == NULL;
 }

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -1,0 +1,3 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -1,3 +1,104 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
+#include "jemalloc/internal/bit_util.h"
+
+void
+cache_bin_info_init(cache_bin_info_t *info,
+    cache_bin_sz_t ncached_max) {
+	size_t stack_size = (size_t)ncached_max * sizeof(void *);
+	assert(stack_size < ((size_t)1 << (sizeof(cache_bin_sz_t) * 8)));
+	info->stack_size = (cache_bin_sz_t)stack_size;
+}
+
+void
+cache_bin_info_compute_alloc(cache_bin_info_t *infos, szind_t ninfos,
+    size_t *size, size_t *alignment) {
+	/* For the total bin stack region (per tcache), reserve 2 more slots so
+	 * that
+	 * 1) the empty position can be safely read on the fast path before
+	 *    checking "is_empty"; and
+	 * 2) the cur_ptr can go beyond the empty position by 1 step safely on
+	 * the fast path (i.e. no overflow).
+	 */
+	*size = sizeof(void *) * 2;
+	for (szind_t i = 0; i < ninfos; i++) {
+		*size += infos[i].stack_size;
+	}
+
+	/*
+	 * 1) Align to at least PAGE, to minimize the # of TLBs needed by the
+	 * smaller sizes; also helps if the larger sizes don't get used at all.
+	 * 2) On 32-bit the pointers won't be compressed; use minimal alignment.
+	 */
+	if (LG_SIZEOF_PTR < 3 || *size < PAGE) {
+		*alignment = PAGE;
+	} else {
+		/*
+		 * Align pow2 to avoid overflow the cache bin compressed
+		 * pointers.
+		 */
+		*alignment = pow2_ceil_zu(*size);
+	}
+}
+
+void
+cache_bin_preincrement(cache_bin_info_t *infos, szind_t ninfos, void *alloc,
+    size_t *cur_offset) {
+	if (config_debug) {
+		size_t computed_size;
+		size_t computed_alignment;
+
+		/* Pointer should be as aligned as we asked for. */
+		cache_bin_info_compute_alloc(infos, ninfos, &computed_size,
+		    &computed_alignment);
+		assert(((uintptr_t)alloc & (computed_alignment - 1)) == 0);
+
+		/* And that alignment should disallow overflow. */
+		uint32_t lowbits = (uint32_t)((uintptr_t)alloc + computed_size);
+		assert((uint32_t)(uintptr_t)alloc < lowbits);
+	}
+	/*
+	 * Leave a noticeable mark pattern on the boundaries, in case a bug
+	 * starts leaking those.  Make it look like the junk pattern but be
+	 * distinct from it.
+	 */
+	uintptr_t preceding_ptr_junk = (uintptr_t)0x7a7a7a7a7a7a7a7aULL;
+	*(uintptr_t *)((uintptr_t)alloc + *cur_offset) = preceding_ptr_junk;
+	*cur_offset += sizeof(void *);
+}
+
+void
+cache_bin_postincrement(cache_bin_info_t *infos, szind_t ninfos, void *alloc,
+    size_t *cur_offset) {
+	/* Note: a7 vs. 7a above -- this tells you which pointer leaked. */
+	uintptr_t trailing_ptr_junk = (uintptr_t)0xa7a7a7a7a7a7a7a7ULL;
+	*(uintptr_t *)((uintptr_t)alloc + *cur_offset) = trailing_ptr_junk;
+	*cur_offset += sizeof(void *);
+}
+
+
+void
+cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
+    size_t *cur_offset) {
+	assert(sizeof(bin->cur_ptr) == sizeof(void *));
+	/*
+	 * The full_position points to the lowest available space.  Allocations
+	 * will access the slots toward higher addresses (for the benefit of
+	 * adjacent prefetch).
+	 */
+	void *stack_cur = (void *)((uintptr_t)alloc + *cur_offset);
+	void *full_position = stack_cur;
+	uint32_t bin_stack_size = info->stack_size;
+
+	*cur_offset += bin_stack_size;
+	void *empty_position = (void *)((uintptr_t)alloc + *cur_offset);
+
+	/* Init to the empty position. */
+	bin->cur_ptr.ptr = empty_position;
+	bin->low_water_position = bin->cur_ptr.lowbits;
+	bin->full_position = (uint32_t)(uintptr_t)full_position;
+	assert(bin->cur_ptr.lowbits - bin->full_position == bin_stack_size);
+	assert(cache_bin_ncached_get(bin, info) == 0);
+	assert(cache_bin_empty_position_get(bin, info) == empty_position);
+}

--- a/src/extent.c
+++ b/src/extent.c
@@ -534,8 +534,8 @@ extent_recycle_split(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
     bool slab, szind_t szind, edata_t *edata, bool growing_retained) {
 	edata_t *lead;
 	edata_t *trail;
-	edata_t *to_leak;
-	edata_t *to_salvage;
+	edata_t *to_leak JEMALLOC_CC_SILENCE_INIT(NULL);
+	edata_t *to_salvage JEMALLOC_CC_SILENCE_INIT(NULL);
 
 	extent_split_interior_result_t result = extent_split_interior(
 	    tsdn, arena, ehooks, &edata, &lead, &trail, &to_leak, &to_salvage,
@@ -711,8 +711,8 @@ extent_grow_retained(tsdn_t *tsdn, arena_t *arena, ehooks_t *ehooks,
 
 	edata_t *lead;
 	edata_t *trail;
-	edata_t *to_leak;
-	edata_t *to_salvage;
+	edata_t *to_leak JEMALLOC_CC_SILENCE_INIT(NULL);
+	edata_t *to_salvage JEMALLOC_CC_SILENCE_INIT(NULL);
 
 	extent_split_interior_result_t result = extent_split_interior(tsdn,
 	    arena, ehooks, &edata, &lead, &trail, &to_leak,

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -104,8 +104,7 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 
 	assert(tcache->arena != NULL);
 	arena_tcache_fill_small(tsdn, arena, tcache, tbin, binind);
-	ret = cache_bin_alloc_easy(tbin, &tcache_bin_info[binind],
-	    tcache_success);
+	ret = cache_bin_alloc(tbin, tcache_success);
 
 	return ret;
 }

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -89,7 +89,7 @@ tcache_event_hard(tsd_t *tsd, tcache_t *tcache) {
 		}
 		tcache->bin_refilled[binind] = false;
 	}
-	tbin->low_water_position = tbin->cur_ptr.lowbits;
+	cache_bin_low_water_set(tbin);
 
 	tcache->next_gc_bin++;
 	if (tcache->next_gc_bin == nhbins) {

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -75,8 +75,9 @@ tcache_event_hard(tsd_t *tsd, tcache_t *tcache) {
 			 * Reduce fill count by 2X.  Limit lg_fill_div such that
 			 * the fill count is always at least 1.
 			 */
-			if ((cache_bin_ncached_max_get(binind, tcache_bin_info)
-			    >> (tcache->lg_fill_div[binind] + 1)) >= 1) {
+			if ((cache_bin_info_ncached_max(
+			    &tcache_bin_info[binind]) >>
+			    (tcache->lg_fill_div[binind] + 1)) >= 1) {
 				tcache->lg_fill_div[binind]++;
 			}
 		} else {

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -566,9 +566,7 @@ tcache_destroy(tsd_t *tsd, tcache_t *tcache, bool tsd_tcache) {
 	if (tsd_tcache) {
 		/* Release the avail array for the TSD embedded auto tcache. */
 		cache_bin_t *bin = tcache_small_bin_get(tcache, 0);
-		assert(cache_bin_ncached_get(bin, &tcache_bin_info[0]) == 0);
-		assert(cache_bin_empty_position_get(bin, &tcache_bin_info[0]) ==
-		    bin->cur_ptr.ptr);
+		cache_bin_assert_empty(bin, &tcache_bin_info[0]);
 		void *avail_array = (void *)((uintptr_t)bin->cur_ptr.ptr -
 		    tcache_bin_info[0].stack_size);
 		idalloctm(tsd_tsdn(tsd), avail_array, NULL, NULL, true, true);

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -182,7 +182,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 	VARIABLE_ARRAY(edata_t *, item_edata, nflush + 1);
 	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nflush);
 
-	cache_bin_ptr_array_init(&ptrs, tbin, nflush, binind, tcache_bin_info);
+	cache_bin_ptr_array_init_for_flush(&ptrs, tbin, nflush, binind,
+	    tcache_bin_info);
 
 	/* Look up edata once per item. */
 	if (config_opt_safety_checks) {

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -346,12 +346,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 		}
 	}
 
-	memmove(tbin->cur_ptr.ptr + (ncached - rem), tbin->cur_ptr.ptr, rem *
-	    sizeof(void *));
-	cache_bin_ncached_set(tbin, &tcache_bin_info[binind], rem);
-	if (tbin->cur_ptr.lowbits > tbin->low_water_position) {
-		tbin->low_water_position = tbin->cur_ptr.lowbits;
-	}
+	cache_bin_finish_flush(tbin, &tcache_bin_info[binind], &ptrs,
+	    ncached - rem);
 }
 
 void

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -110,8 +110,8 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 
 	assert(tcache->arena != NULL);
 	arena_tcache_fill_small(tsdn, arena, tcache, tbin, binind);
-	ret = cache_bin_alloc_easy(tbin, tcache_success,
-	    &tcache_bin_info[binind]);
+	ret = cache_bin_alloc_easy(tbin, &tcache_bin_info[binind],
+	    tcache_success);
 
 	return ret;
 }
@@ -182,8 +182,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 	VARIABLE_ARRAY(edata_t *, item_edata, nflush + 1);
 	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nflush);
 
-	cache_bin_ptr_array_init_for_flush(&ptrs, tbin, nflush,
-	    &tcache_bin_info[binind]);
+	cache_bin_init_ptr_array_for_flush(tbin, &tcache_bin_info[binind],
+	    &ptrs, nflush);
 
 	/* Look up edata once per item. */
 	if (config_opt_safety_checks) {
@@ -348,7 +348,7 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 
 	memmove(tbin->cur_ptr.ptr + (ncached - rem), tbin->cur_ptr.ptr, rem *
 	    sizeof(void *));
-	cache_bin_ncached_set(tbin, rem, &tcache_bin_info[binind]);
+	cache_bin_ncached_set(tbin, &tcache_bin_info[binind], rem);
 	if (tbin->cur_ptr.lowbits > tbin->low_water_position) {
 		tbin->low_water_position = tbin->cur_ptr.lowbits;
 	}

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -176,7 +176,7 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 	 */
 	VARIABLE_ARRAY(edata_t *, item_edata, nflush + 1);
 	void **bottom_item = cache_bin_bottom_item_get(tbin, binind);
-	
+
 	/* Look up edata once per item. */
 	if (config_opt_safety_checks) {
 		tbin_edatas_lookup_size_check(tsd, tbin, binind, nflush,
@@ -262,7 +262,7 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 
 				if (tcache_bin_flush_match(edata, cur_arena_ind,
 				    cur_binshard, small)) {
-					large_dalloc_prep_junked_locked(tsdn,
+					large_dalloc_prep_locked(tsdn,
 					    edata);
 				}
 			}
@@ -291,8 +291,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 				continue;
 			}
 			if (small) {
-				if (arena_dalloc_bin_junked_locked(tsdn,
-				    cur_arena, cur_bin, binind, edata, ptr)) {
+				if (arena_dalloc_bin_locked(tsdn, cur_arena,
+				    cur_bin, binind, edata, ptr)) {
 					dalloc_slabs[dalloc_count] = edata;
 					dalloc_count++;
 				}

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -59,8 +59,10 @@ tcache_event_hard(tsd_t *tsd, tcache_t *tcache) {
 		is_small = false;
 	}
 
-	cache_bin_sz_t low_water = cache_bin_low_water_get(tbin, binind);
-	cache_bin_sz_t ncached = cache_bin_ncached_get(tbin, binind);
+	cache_bin_sz_t low_water = cache_bin_low_water_get(tbin, binind,
+	    tcache_bin_info);
+	cache_bin_sz_t ncached = cache_bin_ncached_get(tbin, binind,
+	    tcache_bin_info);
 	if (low_water > 0) {
 		/*
 		 * Flush (ceiling) 3/4 of the objects below the low water mark.
@@ -73,8 +75,8 @@ tcache_event_hard(tsd_t *tsd, tcache_t *tcache) {
 			 * Reduce fill count by 2X.  Limit lg_fill_div such that
 			 * the fill count is always at least 1.
 			 */
-			if ((cache_bin_ncached_max_get(binind) >>
-			     (tcache->lg_fill_div[binind] + 1)) >= 1) {
+			if ((cache_bin_ncached_max_get(binind, tcache_bin_info)
+			    >> (tcache->lg_fill_div[binind] + 1)) >= 1) {
 				tcache->lg_fill_div[binind]++;
 			}
 		} else {
@@ -107,7 +109,8 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
 
 	assert(tcache->arena != NULL);
 	arena_tcache_fill_small(tsdn, arena, tcache, tbin, binind);
-	ret = cache_bin_alloc_easy(tbin, tcache_success, binind);
+	ret = cache_bin_alloc_easy(tbin, tcache_success, binind,
+	    tcache_bin_info);
 
 	return ret;
 }
@@ -126,7 +129,8 @@ tbin_edatas_lookup_size_check(tsd_t *tsd, cache_bin_t *tbin, szind_t binind,
 	 * builds, avoid the branch in the loop.
 	 */
 	size_t szind_sum = binind * nflush;
-	void **bottom_item = cache_bin_bottom_item_get(tbin, binind);
+	void **bottom_item = cache_bin_bottom_item_get(tbin, binind,
+	    tcache_bin_info);
 	for (unsigned i = 0 ; i < nflush; i++) {
 		emap_full_alloc_ctx_t full_alloc_ctx;
 		emap_full_alloc_ctx_lookup(tsd_tsdn(tsd), &emap_global,
@@ -164,7 +168,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 	} else {
 		assert(binind < nhbins);
 	}
-	cache_bin_sz_t ncached = cache_bin_ncached_get(tbin, binind);
+	cache_bin_sz_t ncached = cache_bin_ncached_get(tbin, binind,
+	    tcache_bin_info);
 	assert((cache_bin_sz_t)rem <= ncached);
 	arena_t *tcache_arena = tcache->arena;
 	assert(tcache_arena != NULL);
@@ -175,7 +180,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 	 * touched (it's just included to satisfy the no-zero-length rule).
 	 */
 	VARIABLE_ARRAY(edata_t *, item_edata, nflush + 1);
-	void **bottom_item = cache_bin_bottom_item_get(tbin, binind);
+	void **bottom_item = cache_bin_bottom_item_get(tbin, binind,
+	    tcache_bin_info);
 
 	/* Look up edata once per item. */
 	if (config_opt_safety_checks) {
@@ -340,7 +346,7 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
 
 	memmove(tbin->cur_ptr.ptr + (ncached - rem), tbin->cur_ptr.ptr, rem *
 	    sizeof(void *));
-	cache_bin_ncached_set(tbin, binind, rem);
+	cache_bin_ncached_set(tbin, binind, rem, tcache_bin_info);
 	if (tbin->cur_ptr.lowbits > tbin->low_water_position) {
 		tbin->low_water_position = tbin->cur_ptr.lowbits;
 	}
@@ -445,8 +451,9 @@ tcache_bin_init(cache_bin_t *bin, szind_t ind, uintptr_t *stack_cur) {
 	bin->low_water_position = bin->cur_ptr.lowbits;
 	bin->full_position = (uint32_t)(uintptr_t)full_position;
 	assert(bin->cur_ptr.lowbits - bin->full_position == bin_stack_size);
-	assert(cache_bin_ncached_get(bin, ind) == 0);
-	assert(cache_bin_empty_position_get(bin, ind) == empty_position);
+	assert(cache_bin_ncached_get(bin, ind, tcache_bin_info) == 0);
+	assert(cache_bin_empty_position_get(bin, ind, tcache_bin_info)
+	    == empty_position);
 
 	return false;
 }
@@ -605,8 +612,8 @@ tcache_destroy(tsd_t *tsd, tcache_t *tcache, bool tsd_tcache) {
 	if (tsd_tcache) {
 		/* Release the avail array for the TSD embedded auto tcache. */
 		cache_bin_t *bin = tcache_small_bin_get(tcache, 0);
-		assert(cache_bin_ncached_get(bin, 0) == 0);
-		assert(cache_bin_empty_position_get(bin, 0) ==
+		assert(cache_bin_ncached_get(bin, 0, tcache_bin_info) == 0);
+		assert(cache_bin_empty_position_get(bin, 0, tcache_bin_info) ==
 		    bin->cur_ptr.ptr);
 		void *avail_array = (void *)((uintptr_t)bin->cur_ptr.ptr -
 		    tcache_bin_info[0].stack_size);

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -16,45 +16,45 @@ TEST_BEGIN(test_cache_bin) {
 	bin->cur_ptr.ptr = empty_position;
 	bin->low_water_position = bin->cur_ptr.lowbits;
 	bin->full_position = (uint32_t)(uintptr_t)stack;
-	expect_ptr_eq(cache_bin_empty_position_get(bin, 0, tcache_bin_info),
+	expect_ptr_eq(cache_bin_empty_position_get(bin, &tcache_bin_info[0]),
 	    empty_position, "Incorrect empty position");
 	/* Not using expect_zu etc on cache_bin_sz_t since it may change. */
-	expect_true(cache_bin_ncached_get(bin, 0, tcache_bin_info) == 0,
+	expect_true(cache_bin_ncached_get(bin, &tcache_bin_info[0]) == 0,
 	    "Incorrect cache size");
 
 	bool success;
-	void *ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
+	void *ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
 	expect_false(success, "Empty cache bin should not alloc");
-	expect_true(cache_bin_low_water_get(bin, 0, tcache_bin_info) == 0,
+	expect_true(cache_bin_low_water_get(bin, &tcache_bin_info[0]) == 0,
 	    "Incorrect low water mark");
 
-	cache_bin_ncached_set(bin, 0, 0, tcache_bin_info);
+	cache_bin_ncached_set(bin, 0, &tcache_bin_info[0]);
 	expect_ptr_eq(bin->cur_ptr.ptr, empty_position, "Bin should be empty");
 	for (cache_bin_sz_t i = 1; i < ncached_max + 1; i++) {
 		success = cache_bin_dalloc_easy(bin, (void *)(uintptr_t)i);
-		expect_true(success && cache_bin_ncached_get(bin, 0,
-		    tcache_bin_info) == i, "Bin dalloc failure");
+		expect_true(success && cache_bin_ncached_get(bin,
+		    &tcache_bin_info[0]) == i, "Bin dalloc failure");
 	}
 	success = cache_bin_dalloc_easy(bin, (void *)1);
 	expect_false(success, "Bin should be full");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "Incorrect bin cur_ptr");
 
-	cache_bin_ncached_set(bin, 0, ncached_max, tcache_bin_info);
+	cache_bin_ncached_set(bin, ncached_max, &tcache_bin_info[0]);
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "cur_ptr should not change");
 	/* Emulate low water after refill. */
 	bin->low_water_position = bin->full_position;
 	for (cache_bin_sz_t i = ncached_max; i > 0; i--) {
-		ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
-		cache_bin_sz_t ncached = cache_bin_ncached_get(bin, 0,
-		    tcache_bin_info);
+		ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
+		cache_bin_sz_t ncached = cache_bin_ncached_get(bin,
+		    &tcache_bin_info[0]);
 		expect_true(success && ncached == i - 1,
 		    "Cache bin alloc failure");
 		expect_ptr_eq(ret, (void *)(uintptr_t)i, "Bin alloc failure");
-		expect_true(cache_bin_low_water_get(bin, 0, tcache_bin_info)
+		expect_true(cache_bin_low_water_get(bin, &tcache_bin_info[0])
 		    == ncached, "Incorrect low water mark");
 	}
 
-	ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
+	ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
 	expect_false(success, "Empty cache bin should not alloc.");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack + ncached_max,
 	    "Bin should be empty");

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -1,63 +1,200 @@
 #include "test/jemalloc_test.h"
 
-cache_bin_t test_bin;
+static void
+do_fill_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
+    cache_bin_sz_t ncached_max, cache_bin_sz_t nfill_attempt,
+    cache_bin_sz_t nfill_succeed) {
+	bool success;
+	void *ptr;
+	assert_true(cache_bin_ncached_get(bin, info) == 0, "");
+	CACHE_BIN_PTR_ARRAY_DECLARE(arr, nfill_attempt);
+	cache_bin_init_ptr_array_for_fill(bin, info, &arr, nfill_attempt);
+	for (cache_bin_sz_t i = 0; i < nfill_succeed; i++) {
+		arr.ptr[i] = &ptrs[i];
+	}
+	cache_bin_finish_fill(bin, info, &arr, nfill_succeed);
+	expect_true(cache_bin_ncached_get(bin, info) == nfill_succeed, "");
+	cache_bin_low_water_set(bin);
+
+	for (cache_bin_sz_t i = 0; i < nfill_succeed; i++) {
+		ptr = cache_bin_alloc_easy(bin, info, &success);
+		expect_true(success, "");
+		expect_ptr_eq(ptr, (void *)&ptrs[i],
+		    "Should pop in order filled");
+		expect_true(cache_bin_low_water_get(bin, info)
+		    == nfill_succeed - i - 1, "");
+	}
+	expect_true(cache_bin_ncached_get(bin, info) == 0, "");
+	expect_true(cache_bin_low_water_get(bin, info) == 0, "");
+}
+
+static void
+do_flush_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
+    cache_bin_sz_t nfill, cache_bin_sz_t nflush) {
+	bool success;
+	assert_true(cache_bin_ncached_get(bin, info) == 0, "");
+
+	for (cache_bin_sz_t i = 0; i < nfill; i++) {
+		success = cache_bin_dalloc_easy(bin, &ptrs[i]);
+		expect_true(success, "");
+	}
+
+	CACHE_BIN_PTR_ARRAY_DECLARE(arr, nflush);
+	cache_bin_init_ptr_array_for_flush(bin, info, &arr, nflush);
+	for (cache_bin_sz_t i = 0; i < nflush; i++) {
+		expect_ptr_eq(cache_bin_ptr_array_get(&arr, i), &ptrs[i], "");
+	}
+	cache_bin_finish_flush(bin, info, &arr, nflush);
+
+	expect_true(cache_bin_ncached_get(bin, info) == nfill - nflush, "");
+	while (cache_bin_ncached_get(bin, info) > 0) {
+		cache_bin_alloc_easy(bin, info, &success);
+	}
+}
 
 TEST_BEGIN(test_cache_bin) {
-	cache_bin_t *bin = &test_bin;
-	assert(PAGE > TCACHE_NSLOTS_SMALL_MAX * sizeof(void *));
-	/* Page aligned to make sure lowbits not overflowable. */
-	void **stack = mallocx(PAGE, MALLOCX_TCACHE_NONE | MALLOCX_ALIGN(PAGE));
-
-	expect_ptr_not_null(stack, "Unexpected mallocx failure");
-	/* Initialize to empty; bin 0. */
-	cache_bin_sz_t ncached_max = cache_bin_info_ncached_max(
-	    &tcache_bin_info[0]);
-	void **empty_position = stack + ncached_max;
-	bin->cur_ptr.ptr = empty_position;
-	bin->low_water_position = bin->cur_ptr.lowbits;
-	bin->full_position = (uint32_t)(uintptr_t)stack;
-	expect_ptr_eq(cache_bin_empty_position_get(bin, &tcache_bin_info[0]),
-	    empty_position, "Incorrect empty position");
-	/* Not using expect_zu etc on cache_bin_sz_t since it may change. */
-	expect_true(cache_bin_ncached_get(bin, &tcache_bin_info[0]) == 0,
-	    "Incorrect cache size");
-
 	bool success;
-	void *ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
-	expect_false(success, "Empty cache bin should not alloc");
-	expect_true(cache_bin_low_water_get(bin, &tcache_bin_info[0]) == 0,
-	    "Incorrect low water mark");
+	void *ptr;
 
-	cache_bin_ncached_set(bin, &tcache_bin_info[0], 0);
-	expect_ptr_eq(bin->cur_ptr.ptr, empty_position, "Bin should be empty");
-	for (cache_bin_sz_t i = 1; i < ncached_max + 1; i++) {
-		success = cache_bin_dalloc_easy(bin, (void *)(uintptr_t)i);
-		expect_true(success && cache_bin_ncached_get(bin,
-		    &tcache_bin_info[0]) == i, "Bin dalloc failure");
+	cache_bin_t bin;
+	cache_bin_info_t info;
+	cache_bin_info_init(&info, TCACHE_NSLOTS_SMALL_MAX);
+
+	size_t size;
+	size_t alignment;
+	cache_bin_info_compute_alloc(&info, 1, &size, &alignment);
+	void *mem = mallocx(size, MALLOCX_ALIGN(alignment));
+	assert_ptr_not_null(mem, "Unexpected mallocx failure");
+
+	size_t cur_offset = 0;
+	cache_bin_preincrement(&info, 1, mem, &cur_offset);
+	cache_bin_init(&bin, &info, mem, &cur_offset);
+	cache_bin_postincrement(&info, 1, mem, &cur_offset);
+
+	assert_zu_eq(cur_offset, size, "Should use all requested memory");
+
+	/* Initialize to empty; should then have 0 elements. */
+	cache_bin_sz_t ncached_max = cache_bin_info_ncached_max(&info);
+	expect_true(cache_bin_ncached_get(&bin, &info) == 0, "");
+	expect_true(cache_bin_low_water_get(&bin, &info) == 0, "");
+
+	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	expect_false(success, "Shouldn't successfully allocate when empty");
+	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
+
+	ptr = cache_bin_alloc_easy(&bin, &info, &success);
+	expect_false(success, "Shouldn't successfully allocate when empty");
+	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
+
+	/*
+	 * We allocate one more item than ncached_max, so we can test cache bin
+	 * exhaustion.
+	 */
+	void **ptrs = mallocx(sizeof(void *) * (ncached_max + 1), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+	for  (cache_bin_sz_t i = 0; i < ncached_max; i++) {
+		expect_true(cache_bin_ncached_get(&bin, &info) == i, "");
+		success = cache_bin_dalloc_easy(&bin, &ptrs[i]);
+		expect_true(success,
+		    "Should be able to dalloc into a non-full cache bin.");
+		expect_true(cache_bin_low_water_get(&bin, &info) == 0,
+		    "Pushes and pops shouldn't change low water of zero.");
 	}
-	success = cache_bin_dalloc_easy(bin, (void *)1);
-	expect_false(success, "Bin should be full");
-	expect_ptr_eq(bin->cur_ptr.ptr, stack, "Incorrect bin cur_ptr");
+	expect_true(cache_bin_ncached_get(&bin, &info) == ncached_max, "");
+	success = cache_bin_dalloc_easy(&bin, &ptrs[ncached_max]);
+	expect_false(success, "Shouldn't be able to dalloc into a full bin.");
 
-	cache_bin_ncached_set(bin, &tcache_bin_info[0], ncached_max);
-	expect_ptr_eq(bin->cur_ptr.ptr, stack, "cur_ptr should not change");
-	/* Emulate low water after refill. */
-	bin->low_water_position = bin->full_position;
-	for (cache_bin_sz_t i = ncached_max; i > 0; i--) {
-		ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
-		cache_bin_sz_t ncached = cache_bin_ncached_get(bin,
-		    &tcache_bin_info[0]);
-		expect_true(success && ncached == i - 1,
-		    "Cache bin alloc failure");
-		expect_ptr_eq(ret, (void *)(uintptr_t)i, "Bin alloc failure");
-		expect_true(cache_bin_low_water_get(bin, &tcache_bin_info[0])
-		    == ncached, "Incorrect low water mark");
+	cache_bin_low_water_set(&bin);
+
+	for (cache_bin_sz_t i = 0; i < ncached_max; i++) {
+		expect_true(cache_bin_low_water_get(&bin, &info)
+		    == ncached_max - i, "");
+		expect_true(cache_bin_ncached_get(&bin, &info)
+		    == ncached_max - i, "");
+		/*
+		 * This should fail -- the reduced version can't change low
+		 * water.
+		 */
+		ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+		expect_ptr_null(ptr, "");
+		expect_false(success, "");
+		expect_true(cache_bin_low_water_get(&bin, &info)
+		    == ncached_max - i, "");
+		expect_true(cache_bin_ncached_get(&bin, &info)
+		    == ncached_max - i, "");
+
+		/* This should succeed, though. */
+		ptr = cache_bin_alloc_easy(&bin, &info, &success);
+		expect_true(success, "");
+		expect_ptr_eq(ptr, &ptrs[ncached_max - i - 1],
+		    "Alloc should pop in stack order");
+		expect_true(cache_bin_low_water_get(&bin, &info)
+		    == ncached_max - i - 1, "");
+		expect_true(cache_bin_ncached_get(&bin, &info)
+		    == ncached_max - i - 1, "");
+	}
+	/* Now we're empty -- all alloc attempts should fail. */
+	expect_true(cache_bin_ncached_get(&bin, &info) == 0, "");
+	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	expect_ptr_null(ptr, "");
+	expect_false(success, "");
+	ptr = cache_bin_alloc_easy(&bin, &info, &success);
+	expect_ptr_null(ptr, "");
+	expect_false(success, "");
+
+	for (cache_bin_sz_t i = 0; i < ncached_max / 2; i++) {
+		cache_bin_dalloc_easy(&bin, &ptrs[i]);
+	}
+	cache_bin_low_water_set(&bin);
+
+	for (cache_bin_sz_t i = ncached_max / 2; i < ncached_max; i++) {
+		cache_bin_dalloc_easy(&bin, &ptrs[i]);
+	}
+	expect_true(cache_bin_ncached_get(&bin, &info) == ncached_max, "");
+	for (cache_bin_sz_t i = ncached_max - 1; i >= ncached_max / 2; i--) {
+		/*
+		 * Size is bigger than low water -- the reduced version should
+		 * succeed.
+		 */
+		ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+		expect_true(success, "");
+		expect_ptr_eq(ptr, &ptrs[i], "");
+	}
+	/* But now, we've hit low-water. */
+	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	expect_false(success, "");
+	expect_ptr_null(ptr, "");
+
+	/* We're going to test filling -- we must be empty to start. */
+	while (cache_bin_ncached_get(&bin, &info)) {
+		cache_bin_alloc_easy(&bin, &info, &success);
+		expect_true(success, "");
 	}
 
-	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
-	expect_false(success, "Empty cache bin should not alloc.");
-	expect_ptr_eq(bin->cur_ptr.ptr, stack + ncached_max,
-	    "Bin should be empty");
+	/* Test fill. */
+	/* Try to fill all, succeed fully. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max, ncached_max);
+	/* Try to fill all, succeed partially. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max,
+	    ncached_max / 2);
+	/* Try to fill all, fail completely. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max, 0);
+
+	/* Try to fill some, succeed fully. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max / 2,
+	    ncached_max / 2);
+	/* Try to fill some, succeed partially. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max / 2,
+	    ncached_max / 2);
+	/* Try to fill some, fail completely. */
+	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max / 2, 0);
+
+	do_flush_test(&bin, &info, ptrs, ncached_max, ncached_max);
+	do_flush_test(&bin, &info, ptrs, ncached_max, ncached_max / 2);
+	do_flush_test(&bin, &info, ptrs, ncached_max, 0);
+	do_flush_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 2);
+	do_flush_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 4);
+	do_flush_test(&bin, &info, ptrs, ncached_max / 2, 0);
 }
 TEST_END
 

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -17,7 +17,7 @@ do_fill_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	cache_bin_low_water_set(bin);
 
 	for (cache_bin_sz_t i = 0; i < nfill_succeed; i++) {
-		ptr = cache_bin_alloc_easy(bin, info, &success);
+		ptr = cache_bin_alloc(bin, &success);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, (void *)&ptrs[i],
 		    "Should pop in order filled");
@@ -48,7 +48,7 @@ do_flush_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 
 	expect_true(cache_bin_ncached_get(bin, info) == nfill - nflush, "");
 	while (cache_bin_ncached_get(bin, info) > 0) {
-		cache_bin_alloc_easy(bin, info, &success);
+		cache_bin_alloc(bin, &success);
 	}
 }
 
@@ -78,11 +78,11 @@ TEST_BEGIN(test_cache_bin) {
 	expect_true(cache_bin_ncached_get(&bin, &info) == 0, "");
 	expect_true(cache_bin_low_water_get(&bin, &info) == 0, "");
 
-	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success);
 	expect_false(success, "Shouldn't successfully allocate when empty");
 	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
 
-	ptr = cache_bin_alloc_easy(&bin, &info, &success);
+	ptr = cache_bin_alloc(&bin, &success);
 	expect_false(success, "Shouldn't successfully allocate when empty");
 	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
 
@@ -112,10 +112,10 @@ TEST_BEGIN(test_cache_bin) {
 		expect_true(cache_bin_ncached_get(&bin, &info)
 		    == ncached_max - i, "");
 		/*
-		 * This should fail -- the reduced version can't change low
-		 * water.
+		 * This should fail -- the easy variant can't change the low
+		 * water mark.
 		 */
-		ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+		ptr = cache_bin_alloc_easy(&bin, &success);
 		expect_ptr_null(ptr, "");
 		expect_false(success, "");
 		expect_true(cache_bin_low_water_get(&bin, &info)
@@ -124,7 +124,7 @@ TEST_BEGIN(test_cache_bin) {
 		    == ncached_max - i, "");
 
 		/* This should succeed, though. */
-		ptr = cache_bin_alloc_easy(&bin, &info, &success);
+		ptr = cache_bin_alloc(&bin, &success);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, &ptrs[ncached_max - i - 1],
 		    "Alloc should pop in stack order");
@@ -135,10 +135,10 @@ TEST_BEGIN(test_cache_bin) {
 	}
 	/* Now we're empty -- all alloc attempts should fail. */
 	expect_true(cache_bin_ncached_get(&bin, &info) == 0, "");
-	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success);
 	expect_ptr_null(ptr, "");
 	expect_false(success, "");
-	ptr = cache_bin_alloc_easy(&bin, &info, &success);
+	ptr = cache_bin_alloc(&bin, &success);
 	expect_ptr_null(ptr, "");
 	expect_false(success, "");
 
@@ -156,18 +156,18 @@ TEST_BEGIN(test_cache_bin) {
 		 * Size is bigger than low water -- the reduced version should
 		 * succeed.
 		 */
-		ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+		ptr = cache_bin_alloc_easy(&bin, &success);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, &ptrs[i], "");
 	}
 	/* But now, we've hit low-water. */
-	ptr = cache_bin_alloc_easy_reduced(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success);
 	expect_false(success, "");
 	expect_ptr_null(ptr, "");
 
 	/* We're going to test filling -- we must be empty to start. */
 	while (cache_bin_ncached_get(&bin, &info)) {
-		cache_bin_alloc_easy(&bin, &info, &success);
+		cache_bin_alloc(&bin, &success);
 		expect_true(success, "");
 	}
 

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -10,48 +10,51 @@ TEST_BEGIN(test_cache_bin) {
 
 	expect_ptr_not_null(stack, "Unexpected mallocx failure");
 	/* Initialize to empty; bin 0. */
-	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(0);
+	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(0,
+	    tcache_bin_info);
 	void **empty_position = stack + ncached_max;
 	bin->cur_ptr.ptr = empty_position;
 	bin->low_water_position = bin->cur_ptr.lowbits;
 	bin->full_position = (uint32_t)(uintptr_t)stack;
-	expect_ptr_eq(cache_bin_empty_position_get(bin, 0), empty_position,
-	    "Incorrect empty position");
+	expect_ptr_eq(cache_bin_empty_position_get(bin, 0, tcache_bin_info),
+	    empty_position, "Incorrect empty position");
 	/* Not using expect_zu etc on cache_bin_sz_t since it may change. */
-	expect_true(cache_bin_ncached_get(bin, 0) == 0, "Incorrect cache size");
+	expect_true(cache_bin_ncached_get(bin, 0, tcache_bin_info) == 0,
+	    "Incorrect cache size");
 
 	bool success;
-	void *ret = cache_bin_alloc_easy(bin, &success, 0);
+	void *ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
 	expect_false(success, "Empty cache bin should not alloc");
-	expect_true(cache_bin_low_water_get(bin, 0) == 0,
+	expect_true(cache_bin_low_water_get(bin, 0, tcache_bin_info) == 0,
 	    "Incorrect low water mark");
 
-	cache_bin_ncached_set(bin, 0, 0);
+	cache_bin_ncached_set(bin, 0, 0, tcache_bin_info);
 	expect_ptr_eq(bin->cur_ptr.ptr, empty_position, "Bin should be empty");
 	for (cache_bin_sz_t i = 1; i < ncached_max + 1; i++) {
 		success = cache_bin_dalloc_easy(bin, (void *)(uintptr_t)i);
-		expect_true(success && cache_bin_ncached_get(bin, 0) == i,
-		    "Bin dalloc failure");
+		expect_true(success && cache_bin_ncached_get(bin, 0,
+		    tcache_bin_info) == i, "Bin dalloc failure");
 	}
 	success = cache_bin_dalloc_easy(bin, (void *)1);
 	expect_false(success, "Bin should be full");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "Incorrect bin cur_ptr");
 
-	cache_bin_ncached_set(bin, 0, ncached_max);
+	cache_bin_ncached_set(bin, 0, ncached_max, tcache_bin_info);
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "cur_ptr should not change");
 	/* Emulate low water after refill. */
 	bin->low_water_position = bin->full_position;
 	for (cache_bin_sz_t i = ncached_max; i > 0; i--) {
-		ret = cache_bin_alloc_easy(bin, &success, 0);
-		cache_bin_sz_t ncached = cache_bin_ncached_get(bin, 0);
+		ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
+		cache_bin_sz_t ncached = cache_bin_ncached_get(bin, 0,
+		    tcache_bin_info);
 		expect_true(success && ncached == i - 1,
 		    "Cache bin alloc failure");
 		expect_ptr_eq(ret, (void *)(uintptr_t)i, "Bin alloc failure");
-		expect_true(cache_bin_low_water_get(bin, 0) == ncached,
-		    "Incorrect low water mark");
+		expect_true(cache_bin_low_water_get(bin, 0, tcache_bin_info)
+		    == ncached, "Incorrect low water mark");
 	}
 
-	ret = cache_bin_alloc_easy(bin, &success, 0);
+	ret = cache_bin_alloc_easy(bin, &success, 0, tcache_bin_info);
 	expect_false(success, "Empty cache bin should not alloc.");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack + ncached_max,
 	    "Bin should be empty");

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -10,8 +10,8 @@ TEST_BEGIN(test_cache_bin) {
 
 	expect_ptr_not_null(stack, "Unexpected mallocx failure");
 	/* Initialize to empty; bin 0. */
-	cache_bin_sz_t ncached_max = cache_bin_ncached_max_get(0,
-	    tcache_bin_info);
+	cache_bin_sz_t ncached_max = cache_bin_info_ncached_max(
+	    &tcache_bin_info[0]);
 	void **empty_position = stack + ncached_max;
 	bin->cur_ptr.ptr = empty_position;
 	bin->low_water_position = bin->cur_ptr.lowbits;

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -23,12 +23,12 @@ TEST_BEGIN(test_cache_bin) {
 	    "Incorrect cache size");
 
 	bool success;
-	void *ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
+	void *ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
 	expect_false(success, "Empty cache bin should not alloc");
 	expect_true(cache_bin_low_water_get(bin, &tcache_bin_info[0]) == 0,
 	    "Incorrect low water mark");
 
-	cache_bin_ncached_set(bin, 0, &tcache_bin_info[0]);
+	cache_bin_ncached_set(bin, &tcache_bin_info[0], 0);
 	expect_ptr_eq(bin->cur_ptr.ptr, empty_position, "Bin should be empty");
 	for (cache_bin_sz_t i = 1; i < ncached_max + 1; i++) {
 		success = cache_bin_dalloc_easy(bin, (void *)(uintptr_t)i);
@@ -39,12 +39,12 @@ TEST_BEGIN(test_cache_bin) {
 	expect_false(success, "Bin should be full");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "Incorrect bin cur_ptr");
 
-	cache_bin_ncached_set(bin, ncached_max, &tcache_bin_info[0]);
+	cache_bin_ncached_set(bin, &tcache_bin_info[0], ncached_max);
 	expect_ptr_eq(bin->cur_ptr.ptr, stack, "cur_ptr should not change");
 	/* Emulate low water after refill. */
 	bin->low_water_position = bin->full_position;
 	for (cache_bin_sz_t i = ncached_max; i > 0; i--) {
-		ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
+		ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
 		cache_bin_sz_t ncached = cache_bin_ncached_get(bin,
 		    &tcache_bin_info[0]);
 		expect_true(success && ncached == i - 1,
@@ -54,7 +54,7 @@ TEST_BEGIN(test_cache_bin) {
 		    == ncached, "Incorrect low water mark");
 	}
 
-	ret = cache_bin_alloc_easy(bin, &success, &tcache_bin_info[0]);
+	ret = cache_bin_alloc_easy(bin, &tcache_bin_info[0], &success);
 	expect_false(success, "Empty cache bin should not alloc.");
 	expect_ptr_eq(bin->cur_ptr.ptr, stack + ncached_max,
 	    "Bin should be empty");

--- a/test/unit/junk.c
+++ b/test/unit/junk.c
@@ -1,141 +1,191 @@
 #include "test/jemalloc_test.h"
 
-#include "jemalloc/internal/util.h"
-
-static arena_dalloc_junk_small_t *arena_dalloc_junk_small_orig;
-static large_dalloc_junk_t *large_dalloc_junk_orig;
-static large_dalloc_maybe_junk_t *large_dalloc_maybe_junk_orig;
-static void *watch_for_junking;
-static bool saw_junking;
+#define arraylen(arr) (sizeof(arr)/sizeof(arr[0]))
+static size_t ptr_ind;
+static void *volatile ptrs[100];
+static void *last_junked_ptr;
+static size_t last_junked_usize;
 
 static void
-watch_junking(void *p) {
-	watch_for_junking = p;
-	saw_junking = false;
+reset() {
+	ptr_ind = 0;
+	last_junked_ptr = NULL;
+	last_junked_usize = 0;
 }
 
 static void
-arena_dalloc_junk_small_intercept(void *ptr, const bin_info_t *bin_info) {
-	size_t i;
-
-	arena_dalloc_junk_small_orig(ptr, bin_info);
-	for (i = 0; i < bin_info->reg_size; i++) {
-		expect_u_eq(((uint8_t *)ptr)[i], JEMALLOC_FREE_JUNK,
-		    "Missing junk fill for byte %zu/%zu of deallocated region",
-		    i, bin_info->reg_size);
-	}
-	if (ptr == watch_for_junking) {
-		saw_junking = true;
-	}
+test_junk(void *ptr, size_t usize) {
+	last_junked_ptr = ptr;
+	last_junked_usize = usize;
 }
 
 static void
-large_dalloc_junk_intercept(void *ptr, size_t usize) {
-	size_t i;
-
-	large_dalloc_junk_orig(ptr, usize);
-	for (i = 0; i < usize; i++) {
-		expect_u_eq(((uint8_t *)ptr)[i], JEMALLOC_FREE_JUNK,
-		    "Missing junk fill for byte %zu/%zu of deallocated region",
-		    i, usize);
+do_allocs(size_t size, bool zero, size_t lg_align) {
+#define JUNK_ALLOC(...)							\
+	do {								\
+		assert(ptr_ind + 1 < arraylen(ptrs));			\
+		void *ptr = __VA_ARGS__;				\
+		assert_ptr_not_null(ptr, "");				\
+		ptrs[ptr_ind++] = ptr;					\
+		if (opt_junk_alloc && !zero) {				\
+			expect_ptr_eq(ptr, last_junked_ptr, "");	\
+			expect_zu_eq(last_junked_usize,			\
+			    malloc_usable_size(ptr), "");		\
+		}							\
+	} while (0)
+	if (!zero && lg_align == 0) {
+		JUNK_ALLOC(malloc(size));
 	}
-	if (ptr == watch_for_junking) {
-		saw_junking = true;
+	if (!zero) {
+		JUNK_ALLOC(aligned_alloc(1 << lg_align, size));
+	}
+#ifdef JEMALLOC_OVERRIDE_MEMALIGN
+	if (!zero) {
+		JUNK_ALLOC(je_memalign(1 << lg_align, size));
+	}
+#endif
+#ifdef JEMALLOC_OVERRIDE_VALLOC
+	if (!zero && lg_align == LG_PAGE) {
+		JUNK_ALLOC(je_valloc(size));
+	}
+#endif
+	int zero_flag = zero ? MALLOCX_ZERO : 0;
+	JUNK_ALLOC(mallocx(size, zero_flag | MALLOCX_LG_ALIGN(lg_align)));
+	JUNK_ALLOC(mallocx(size, zero_flag | MALLOCX_LG_ALIGN(lg_align)
+	    | MALLOCX_TCACHE_NONE));
+	if (lg_align >= LG_SIZEOF_PTR) {
+		void *memalign_result;
+		int err = posix_memalign(&memalign_result, (1 << lg_align),
+		    size);
+		assert_d_eq(err, 0, "");
+		JUNK_ALLOC(memalign_result);
 	}
 }
 
-static void
-large_dalloc_maybe_junk_intercept(void *ptr, size_t usize) {
-	large_dalloc_maybe_junk_orig(ptr, usize);
-	if (ptr == watch_for_junking) {
-		saw_junking = true;
-	}
-}
+TEST_BEGIN(test_junk_alloc_free) {
+	bool zerovals[] = {false, true};
+	size_t sizevals[] = {
+		1, 8, 100, 1000, 100*1000
+	/*
+	 * Memory allocation failure is a real possibility in 32-bit mode.
+	 * Rather than try to check in the face of resource exhaustion, we just
+	 * rely more on the 64-bit tests.  This is a little bit white-box-y in
+	 * the sense that this is only a good test strategy if we know that the
+	 * junk pathways don't touch interact with the allocation selection
+	 * mechanisms; but this is in fact the case.
+	 */
+#if LG_SIZEOF_PTR == 3
+		    , 10 * 1000 * 1000
+#endif
+	};
+	size_t lg_alignvals[] = {
+		0, 4, 10, 15, 16, LG_PAGE
+#if LG_SIZEOF_PTR == 3
+		    , 20, 24
+#endif
+	};
 
-static void
-test_junk(size_t sz_min, size_t sz_max) {
-	uint8_t *s;
-	size_t sz_prev, sz, i;
+#define JUNK_FREE(...)							\
+	do {								\
+		do_allocs(size, zero, lg_align);			\
+		for (size_t n = 0; n < ptr_ind; n++) {			\
+			void *ptr = ptrs[n];				\
+			__VA_ARGS__;					\
+			if (opt_junk_free) {				\
+				assert_ptr_eq(ptr, last_junked_ptr,	\
+				    "");				\
+				assert_zu_eq(usize, last_junked_usize,	\
+				    "");				\
+			}						\
+			reset();					\
+		}							\
+	} while (0)
+	for (size_t i = 0; i < arraylen(zerovals); i++) {
+		for (size_t j = 0; j < arraylen(sizevals); j++) {
+			for (size_t k = 0; k < arraylen(lg_alignvals); k++) {
+				bool zero = zerovals[i];
+				size_t size = sizevals[j];
+				size_t lg_align = lg_alignvals[k];
+				size_t usize = nallocx(size,
+				    MALLOCX_LG_ALIGN(lg_align));
 
-	if (opt_junk_free) {
-		arena_dalloc_junk_small_orig = arena_dalloc_junk_small;
-		arena_dalloc_junk_small = arena_dalloc_junk_small_intercept;
-		large_dalloc_junk_orig = large_dalloc_junk;
-		large_dalloc_junk = large_dalloc_junk_intercept;
-		large_dalloc_maybe_junk_orig = large_dalloc_maybe_junk;
-		large_dalloc_maybe_junk = large_dalloc_maybe_junk_intercept;
-	}
-
-	sz_prev = 0;
-	s = (uint8_t *)mallocx(sz_min, 0);
-	expect_ptr_not_null((void *)s, "Unexpected mallocx() failure");
-
-	for (sz = sallocx(s, 0); sz <= sz_max;
-	    sz_prev = sz, sz = sallocx(s, 0)) {
-		if (sz_prev > 0) {
-			expect_u_eq(s[0], 'a',
-			    "Previously allocated byte %zu/%zu is corrupted",
-			    ZU(0), sz_prev);
-			expect_u_eq(s[sz_prev-1], 'a',
-			    "Previously allocated byte %zu/%zu is corrupted",
-			    sz_prev-1, sz_prev);
-		}
-
-		for (i = sz_prev; i < sz; i++) {
-			if (opt_junk_alloc) {
-				expect_u_eq(s[i], JEMALLOC_ALLOC_JUNK,
-				    "Newly allocated byte %zu/%zu isn't "
-				    "junk-filled", i, sz);
+				JUNK_FREE(free(ptr));
+				JUNK_FREE(dallocx(ptr, 0));
+				JUNK_FREE(dallocx(ptr, MALLOCX_TCACHE_NONE));
+				JUNK_FREE(dallocx(ptr, MALLOCX_LG_ALIGN(
+				    lg_align)));
+				JUNK_FREE(sdallocx(ptr, usize, MALLOCX_LG_ALIGN(
+				    lg_align)));
+				JUNK_FREE(sdallocx(ptr, usize,
+				    MALLOCX_TCACHE_NONE | MALLOCX_LG_ALIGN(lg_align)));
+				if (opt_zero_realloc_action
+				    == zero_realloc_action_free) {
+					JUNK_FREE(realloc(ptr, 0));
+				}
 			}
-			s[i] = 'a';
-		}
-
-		if (xallocx(s, sz+1, 0, 0) == sz) {
-			uint8_t *t;
-			watch_junking(s);
-			t = (uint8_t *)rallocx(s, sz+1, 0);
-			expect_ptr_not_null((void *)t,
-			    "Unexpected rallocx() failure");
-			expect_zu_ge(sallocx(t, 0), sz+1,
-			    "Unexpectedly small rallocx() result");
-			if (!background_thread_enabled()) {
-				expect_ptr_ne(s, t,
-				    "Unexpected in-place rallocx()");
-				expect_true(!opt_junk_free || saw_junking,
-				    "Expected region of size %zu to be "
-				    "junk-filled", sz);
-			}
-			s = t;
 		}
 	}
-
-	watch_junking(s);
-	dallocx(s, 0);
-	expect_true(!opt_junk_free || saw_junking,
-	    "Expected region of size %zu to be junk-filled", sz);
-
-	if (opt_junk_free) {
-		arena_dalloc_junk_small = arena_dalloc_junk_small_orig;
-		large_dalloc_junk = large_dalloc_junk_orig;
-		large_dalloc_maybe_junk = large_dalloc_maybe_junk_orig;
-	}
-}
-
-TEST_BEGIN(test_junk_small) {
-	test_skip_if(!config_fill);
-	test_junk(1, SC_SMALL_MAXCLASS - 1);
 }
 TEST_END
 
-TEST_BEGIN(test_junk_large) {
-	test_skip_if(!config_fill);
-	test_junk(SC_SMALL_MAXCLASS + 1, (1U << (SC_LG_LARGE_MINCLASS + 1)));
+TEST_BEGIN(test_realloc_expand) {
+	char *volatile ptr;
+	char *volatile expanded;
+
+	test_skip_if(!opt_junk_alloc);
+
+	/* Realloc */
+	ptr = malloc(SC_SMALL_MAXCLASS);
+	expanded = realloc(ptr, SC_LARGE_MINCLASS);
+	expect_ptr_eq(last_junked_ptr, &expanded[SC_SMALL_MAXCLASS], "");
+	expect_zu_eq(last_junked_usize,
+	    SC_LARGE_MINCLASS - SC_SMALL_MAXCLASS, "");
+	free(expanded);
+
+	/* rallocx(..., 0) */
+	ptr = malloc(SC_SMALL_MAXCLASS);
+	expanded = rallocx(ptr, SC_LARGE_MINCLASS, 0);
+	expect_ptr_eq(last_junked_ptr, &expanded[SC_SMALL_MAXCLASS], "");
+	expect_zu_eq(last_junked_usize,
+	    SC_LARGE_MINCLASS - SC_SMALL_MAXCLASS, "");
+	free(expanded);
+
+	/* rallocx(..., nonzero) */
+	ptr = malloc(SC_SMALL_MAXCLASS);
+	expanded = rallocx(ptr, SC_LARGE_MINCLASS, MALLOCX_TCACHE_NONE);
+	expect_ptr_eq(last_junked_ptr, &expanded[SC_SMALL_MAXCLASS], "");
+	expect_zu_eq(last_junked_usize,
+	    SC_LARGE_MINCLASS - SC_SMALL_MAXCLASS, "");
+	free(expanded);
+
+	/* rallocx(..., MALLOCX_ZERO) */
+	ptr = malloc(SC_SMALL_MAXCLASS);
+	last_junked_ptr = (void *)-1;
+	last_junked_usize = (size_t)-1;
+	expanded = rallocx(ptr, SC_LARGE_MINCLASS, MALLOCX_ZERO);
+	expect_ptr_eq(last_junked_ptr, (void *)-1, "");
+	expect_zu_eq(last_junked_usize, (size_t)-1, "");
+	free(expanded);
+
+	/*
+	 * Unfortunately, testing xallocx reliably is difficult to do portably
+	 * (since allocations can be expanded / not expanded differently on
+	 * different platforms.  We rely on manual inspection there -- the
+	 * xallocx pathway is easy to inspect, though.
+	 *
+	 * Likewise, we don't test the shrinking pathways.  It's difficult to do
+	 * so consistently (because of the risk of split failure or memory
+	 * exhaustion, in which case no junking should happen).  This is fine
+	 * -- junking is a best-effort debug mechanism in the first place.
+	 */
 }
 TEST_END
 
 int
 main(void) {
+	junk_alloc_callback = &test_junk;
+	junk_free_callback = &test_junk;
 	return test(
-	    test_junk_small,
-	    test_junk_large);
+	    test_junk_alloc_free,
+	    test_realloc_expand);
 }


### PR DESCRIPTION
This rewrites the cache bin module to track more of its low water, full, and empty states in the bin itself. This has a few advantages
- It makes the logic easier to reason about
- It unifies the 32-bit and 64-bit implementations
- It makes it easy for the fast paths to change the low-water mark if necessary. This results in around a 4% improvement in cycles-spent-in-malloc in prod workloads (for around a .1% end-to-end improvement).

This also pulls the maintenance logic out of the tcache and arena modules and into the cache_bin module, and documents it; the resulting code is a lot easier to read and maintain.