### PR TITLE
Stats: Fix tcache_bytes reporting.

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -207,7 +207,8 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 			cache_bin_t *tbin = &descriptor->bins_large[i];
 			arena_stats_accum_zu(&astats->tcache_bytes,
 			    cache_bin_ncached_get(tbin,
-			    &tcache_bin_info[i + SC_NBINS]) * sz_index2size(i));
+			    &tcache_bin_info[i + SC_NBINS])
+			    * sz_index2size(i + SC_NBINS));
 		}
 	}
 	malloc_mutex_prof_read(tsdn,


### PR DESCRIPTION
Previously, large allocations in tcaches would have their sizes reduced during
stats estimation.  Added a test, which fails before this change but passes now.

This fixes a bug introduced in 593484661261c20f75557279931eb2d9ca165185, which
was itself fixing a bug introduced in 9c0549007dcb64f4ff35d37390a9a6a8d3cea880.