### PR TITLE
Fix: assertion could abort on past failures

### DIFF
--- a/test/src/test.c
+++ b/test/src/test.c
@@ -233,11 +233,6 @@ p_test_fail(const char *prefix, const char *message) {
 	test_status = test_status_fail;
 }
 
-bool
-p_test_failed() {
-	return test_status == test_status_fail;
-}
-
 void
 strncpy_cond(void *dst, const char *src, bool cond) {
 	if (cond) {


### PR DESCRIPTION
This bug was introduced in https://github.com/jemalloc/jemalloc/commit/fa615793821219f8ad62e40aa23c848e5136aa5c: if an `expect_*()` failed previously, an `assert_*()` would abort regardless of whether the condition being asserted holds or not.

It was BTW one of my trickiest debugging experiences: when I was working on another project, I spent a long time trying to investigate into why the condition being asserted would fail without ever questioning the validity of the assertion macro itself, until I realized this bug at the very end. :)