### PR TITLE
Add piping API to buffered writer

### DIFF
--- a/include/jemalloc/internal/buf_writer.h
+++ b/include/jemalloc/internal/buf_writer.h
@@ -27,4 +27,8 @@ void buf_writer_flush(buf_writer_t *buf_writer);
 write_cb_t buf_writer_cb;
 void buf_writer_terminate(tsdn_t *tsdn, buf_writer_t *buf_writer);
 
+typedef ssize_t (read_cb_t)(void *read_cbopaque, void *buf, size_t limit);
+void buf_writer_pipe(buf_writer_t *buf_writer, read_cb_t *read_cb,
+    void *read_cbopaque);
+
 #endif /* JEMALLOC_INTERNAL_BUF_WRITER_H */

--- a/include/jemalloc/internal/buf_writer.h
+++ b/include/jemalloc/internal/buf_writer.h
@@ -13,10 +13,8 @@
 typedef void (write_cb_t)(void *, const char *);
 
 typedef struct {
-	write_cb_t *public_write_cb;
-	void *public_cbopaque;
-	write_cb_t *private_write_cb;
-	void *private_cbopaque;
+	write_cb_t *write_cb;
+	void *cbopaque;
 	char *buf;
 	size_t buf_size;
 	size_t buf_end;
@@ -25,9 +23,8 @@ typedef struct {
 
 bool buf_writer_init(tsdn_t *tsdn, buf_writer_t *buf_writer,
     write_cb_t *write_cb, void *cbopaque, char *buf, size_t buf_len);
-write_cb_t *buf_writer_get_write_cb(buf_writer_t *buf_writer);
-void *buf_writer_get_cbopaque(buf_writer_t *buf_writer);
 void buf_writer_flush(buf_writer_t *buf_writer);
+write_cb_t buf_writer_cb;
 void buf_writer_terminate(tsdn_t *tsdn, buf_writer_t *buf_writer);
 
 #endif /* JEMALLOC_INTERNAL_BUF_WRITER_H */

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3815,8 +3815,7 @@ je_malloc_stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 		buf_writer_t buf_writer;
 		buf_writer_init(tsdn, &buf_writer, write_cb, cbopaque, NULL,
 		    STATS_PRINT_BUFSIZE);
-		stats_print(buf_writer_get_write_cb(&buf_writer),
-		    buf_writer_get_cbopaque(&buf_writer), opts);
+		stats_print(buf_writer_cb, &buf_writer, opts);
 		buf_writer_terminate(tsdn, &buf_writer);
 	}
 

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -632,9 +632,8 @@ prof_log_stop(tsdn_t *tsdn) {
 	buf_writer_t buf_writer;
 	buf_writer_init(tsdn, &buf_writer, prof_emitter_write_cb, &arg, NULL,
 	    PROF_LOG_STOP_BUFSIZE);
-	emitter_init(&emitter, emitter_output_json_compact,
-	    buf_writer_get_write_cb(&buf_writer),
-	    buf_writer_get_cbopaque(&buf_writer));
+	emitter_init(&emitter, emitter_output_json_compact, buf_writer_cb,
+	    &buf_writer);
 
 	emitter_begin(&emitter);
 	prof_log_emit_metadata(&emitter);

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -466,9 +466,8 @@ prof_recent_alloc_dump(tsd_t *tsd, void (*write_cb)(void *, const char *),
 	buf_writer_init(tsd_tsdn(tsd), &buf_writer, write_cb, cbopaque, NULL,
 	    PROF_RECENT_PRINT_BUFSIZE);
 	emitter_t emitter;
-	emitter_init(&emitter, emitter_output_json_compact,
-	    buf_writer_get_write_cb(&buf_writer),
-	    buf_writer_get_cbopaque(&buf_writer));
+	emitter_init(&emitter, emitter_output_json_compact, buf_writer_cb,
+	    &buf_writer);
 	emitter_begin(&emitter);
 
 	malloc_mutex_lock(tsd_tsdn(tsd), &prof_recent_alloc_mtx);


### PR DESCRIPTION
The first commit cleans up the current buffered writer API -
- Previously, buffered writer has two getter functions respectively for the callback function and for the callback argument: if the buffer allocation failed, the getter functions just return the callback function and argument the buffered writer was originally given; otherwise, the getter functions return the buffered writer's internal write callback function and the buffered writer object itself.
- Now, regardless of whether the buffer allocation failed or not, the caller always calls buffered writer's internal write callback function with the buffered writer object itself, and the internal callback function decides to whether route the write call directly to the original callback function or buffer the write. There is thus no longer the need for the getter functions, and the caller side code is simplified.

The second commit adds a piping API to the buffered writer, for the usage case where what's given to the write callback function may be a read callback function instead of a simple string. This is useful for prof dumping, and it may also be a generally useful API to have. The signature of the read callback function is current designed to be analogous to the `read()` system call (as well as our `malloc_read_fd()` wrapper). It looks pretty general to me, but it can be changed if needed.