### PR TITLE
Restructure thread event handling

### DIFF
--- a/include/jemalloc/internal/prof_data.h
+++ b/include/jemalloc/internal/prof_data.h
@@ -13,7 +13,7 @@ bool prof_data_init(tsd_t *tsd);
 bool prof_dump(tsd_t *tsd, bool propagate_err, const char *filename,
     bool leakcheck);
 prof_tdata_t * prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid,
-    uint64_t thr_discrim, char *thread_name, bool active, bool reset_interval);
+    uint64_t thr_discrim, char *thread_name, bool active);
 void prof_tdata_detach(tsd_t *tsd, prof_tdata_t *tdata);
 void bt_init(prof_bt_t *bt, void **vec);
 void prof_backtrace(tsd_t *tsd, prof_bt_t *bt);

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -74,7 +74,6 @@ void prof_cnt_all(uint64_t *curobjs, uint64_t *curbytes, uint64_t *accumobjs,
 #endif
 int prof_getpid(void);
 void prof_get_default_filename(tsdn_t *tsdn, char *filename, uint64_t ind);
-bool prof_idump_accum(tsdn_t *tsdn, uint64_t accumbytes);
 void prof_idump(tsdn_t *tsdn);
 bool prof_mdump(tsd_t *tsd, const char *filename);
 void prof_gdump(tsdn_t *tsdn);
@@ -99,7 +98,9 @@ void prof_prefork0(tsdn_t *tsdn);
 void prof_prefork1(tsdn_t *tsdn);
 void prof_postfork_parent(tsdn_t *tsdn);
 void prof_postfork_child(tsdn_t *tsdn);
-void prof_sample_threshold_update(tsd_t *tsd);
+/* Only accessed by thread event. */
+uint64_t prof_sample_new_event_wait(tsd_t *tsd);
+bool prof_idump_accum(tsdn_t *tsdn, uint64_t accumbytes);
 
 bool prof_log_start(tsdn_t *tsdn, const char *filename);
 bool prof_log_stop(tsdn_t *tsdn);

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -98,8 +98,10 @@ void prof_prefork0(tsdn_t *tsdn);
 void prof_prefork1(tsdn_t *tsdn);
 void prof_postfork_parent(tsdn_t *tsdn);
 void prof_postfork_child(tsdn_t *tsdn);
+
 /* Only accessed by thread event. */
 uint64_t prof_sample_new_event_wait(tsd_t *tsd);
+uint64_t prof_sample_postponed_event_wait(tsd_t *tsd);
 bool prof_idump_accum(tsdn_t *tsdn, uint64_t accumbytes);
 
 bool prof_log_start(tsdn_t *tsdn, const char *filename);

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -102,7 +102,7 @@ void prof_postfork_child(tsdn_t *tsdn);
 /* Only accessed by thread event. */
 uint64_t prof_sample_new_event_wait(tsd_t *tsd);
 uint64_t prof_sample_postponed_event_wait(tsd_t *tsd);
-bool prof_idump_accum(tsdn_t *tsdn, uint64_t accumbytes);
+void prof_sample_event_handler(tsd_t *tsd, uint64_t elapsed);
 
 bool prof_log_start(tsdn_t *tsdn, const char *filename);
 bool prof_log_stop(tsdn_t *tsdn);

--- a/include/jemalloc/internal/stats.h
+++ b/include/jemalloc/internal/stats.h
@@ -39,6 +39,7 @@ extern char opt_stats_interval_opts[stats_print_tot_num_options+1];
 
 /* Only accessed by thread event. */
 uint64_t stats_interval_new_event_wait(tsd_t *tsd);
+uint64_t stats_interval_postponed_event_wait(tsd_t *tsd);
 bool stats_interval_accum(tsd_t *tsd, uint64_t bytes);
 
 /* Implements je_malloc_stats_print. */

--- a/include/jemalloc/internal/stats.h
+++ b/include/jemalloc/internal/stats.h
@@ -37,7 +37,8 @@ extern char opt_stats_interval_opts[stats_print_tot_num_options+1];
 #define STATS_INTERVAL_ACCUM_LG_BATCH_SIZE 6
 #define STATS_INTERVAL_ACCUM_BATCH_MAX (4 << 20)
 
-uint64_t stats_interval_accum_batch_size(void);
+/* Only accessed by thread event. */
+uint64_t stats_interval_new_event_wait(tsd_t *tsd);
 bool stats_interval_accum(tsd_t *tsd, uint64_t bytes);
 
 /* Implements je_malloc_stats_print. */

--- a/include/jemalloc/internal/stats.h
+++ b/include/jemalloc/internal/stats.h
@@ -40,7 +40,7 @@ extern char opt_stats_interval_opts[stats_print_tot_num_options+1];
 /* Only accessed by thread event. */
 uint64_t stats_interval_new_event_wait(tsd_t *tsd);
 uint64_t stats_interval_postponed_event_wait(tsd_t *tsd);
-bool stats_interval_accum(tsd_t *tsd, uint64_t bytes);
+void stats_interval_event_handler(tsd_t *tsd, uint64_t elapsed);
 
 /* Implements je_malloc_stats_print. */
 void stats_print(void (*write_cb)(void *, const char *), void *cbopaque,

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -55,7 +55,9 @@ void tcache_assert_initialized(tcache_t *tcache);
 
 /* Only accessed by thread event. */
 uint64_t tcache_gc_new_event_wait(tsd_t *tsd);
+uint64_t tcache_gc_postponed_event_wait(tsd_t *tsd);
 uint64_t tcache_gc_dalloc_new_event_wait(tsd_t *tsd);
+uint64_t tcache_gc_dalloc_postponed_event_wait(tsd_t *tsd);
 void tcache_event_hard(tsd_t *tsd, tcache_slow_t *tcache_slow,
     tcache_t *tcache);
 

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -26,8 +26,6 @@ extern cache_bin_info_t *tcache_bin_info;
 extern tcaches_t	*tcaches;
 
 size_t	tcache_salloc(tsdn_t *tsdn, const void *ptr);
-void	tcache_event_hard(tsd_t *tsd, tcache_slow_t *tcache_slow,
-    tcache_t *tcache);
 void	*tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
     cache_bin_t *tbin, szind_t binind, bool *tcache_success);
 
@@ -54,5 +52,11 @@ bool tsd_tcache_data_init(tsd_t *tsd);
 bool tsd_tcache_enabled_data_init(tsd_t *tsd);
 
 void tcache_assert_initialized(tcache_t *tcache);
+
+/* Only accessed by thread event. */
+uint64_t tcache_gc_new_event_wait(tsd_t *tsd);
+uint64_t tcache_gc_dalloc_new_event_wait(tsd_t *tsd);
+void tcache_event_hard(tsd_t *tsd, tcache_slow_t *tcache_slow,
+    tcache_t *tcache);
 
 #endif /* JEMALLOC_INTERNAL_TCACHE_EXTERNS_H */

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -56,9 +56,9 @@ void tcache_assert_initialized(tcache_t *tcache);
 /* Only accessed by thread event. */
 uint64_t tcache_gc_new_event_wait(tsd_t *tsd);
 uint64_t tcache_gc_postponed_event_wait(tsd_t *tsd);
+void tcache_gc_event_handler(tsd_t *tsd, uint64_t elapsed);
 uint64_t tcache_gc_dalloc_new_event_wait(tsd_t *tsd);
 uint64_t tcache_gc_dalloc_postponed_event_wait(tsd_t *tsd);
-void tcache_event_hard(tsd_t *tsd, tcache_slow_t *tcache_slow,
-    tcache_t *tcache);
+void tcache_gc_dalloc_event_handler(tsd_t *tsd, uint64_t elapsed);
 
 #endif /* JEMALLOC_INTERNAL_TCACHE_EXTERNS_H */

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -23,6 +23,12 @@
  */
 #define TE_MAX_INTERVAL ((uint64_t)(4U << 20))
 
+/*
+ * Invalid elapsed time, for situations where elapsed time is not needed.  See
+ * comments in thread_event.c for more info.
+ */
+#define TE_INVALID_ELAPSED UINT64_MAX
+
 typedef struct te_ctx_s {
 	bool is_alloc;
 	uint64_t *current;

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -6,6 +6,12 @@
 /* "te" is short for "thread_event" */
 
 /*
+ * TE_MIN_START_WAIT should not exceed the minimal allocation usize.
+ */
+#define TE_MIN_START_WAIT ((uint64_t)1U)
+#define TE_MAX_START_WAIT UINT64_MAX
+
+/*
  * Maximum threshold on thread_(de)allocated_next_event_fast, so that there is
  * no need to check overflow in malloc fast path. (The allocation size in malloc
  * fast path never exceeds SC_LOOKUP_MAXCLASS.)

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -33,7 +33,6 @@ typedef struct te_ctx_s {
 
 void te_assert_invariants_debug(tsd_t *tsd);
 void te_event_trigger(tsd_t *tsd, te_ctx_t *ctx, bool delay_event);
-void te_event_update(tsd_t *tsd, bool alloc_event);
 void te_recompute_fast_threshold(tsd_t *tsd);
 void tsd_te_init(tsd_t *tsd);
 
@@ -250,28 +249,5 @@ JEMALLOC_ALWAYS_INLINE void
 thread_alloc_event(tsd_t *tsd, size_t usize) {
 	te_event_advance(tsd, usize, true);
 }
-
-#define E(event, condition, is_alloc)					\
-JEMALLOC_ALWAYS_INLINE void						\
-te_##event##_event_update(tsd_t *tsd, uint64_t event_wait) {		\
-	te_assert_invariants(tsd);					\
-	assert(condition);						\
-	assert(tsd_nominal(tsd));					\
-	assert(tsd_reentrancy_level_get(tsd) == 0);			\
-	assert(event_wait > 0U);					\
-	if (TE_MIN_START_WAIT > 1U &&					\
-	    unlikely(event_wait < TE_MIN_START_WAIT)) {			\
-		event_wait = TE_MIN_START_WAIT;				\
-	}								\
-	if (TE_MAX_START_WAIT < UINT64_MAX &&				\
-	    unlikely(event_wait > TE_MAX_START_WAIT)) {			\
-		event_wait = TE_MAX_START_WAIT;				\
-	}								\
-	event##_event_wait_set(tsd, event_wait);			\
-	te_event_update(tsd, is_alloc);					\
-}
-
-ITERATE_OVER_ALL_EVENTS
-#undef E
 
 #endif /* JEMALLOC_INTERNAL_THREAD_EVENT_H */

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -32,7 +32,7 @@ typedef struct te_ctx_s {
 } te_ctx_t;
 
 void te_assert_invariants_debug(tsd_t *tsd);
-void te_event_trigger(tsd_t *tsd, te_ctx_t *ctx, bool delay_event);
+void te_event_trigger(tsd_t *tsd, te_ctx_t *ctx);
 void te_recompute_fast_threshold(tsd_t *tsd);
 void tsd_te_init(tsd_t *tsd);
 
@@ -183,11 +183,9 @@ te_ctx_next_event_set(tsd_t *tsd, te_ctx_t *ctx, uint64_t v) {
  * The function checks in debug mode whether the thread event counters are in
  * a consistent state, which forms the invariants before and after each round
  * of thread event handling that we can rely on and need to promise.
- * The invariants are only temporarily violated in the middle of:
- * (a) event_advance() if an event is triggered (the te_event_trigger() call
- *     at the end will restore the invariants), or
- * (b) te_##event##_event_update() (the te_event_update() call at the
- *     end will restore the invariants).
+ * The invariants are only temporarily violated in the middle of
+ * te_event_advance() if an event is triggered (the te_event_trigger() call at
+ * the end will restore the invariants).
  */
 JEMALLOC_ALWAYS_INLINE void
 te_assert_invariants(tsd_t *tsd) {
@@ -236,7 +234,7 @@ te_event_advance(tsd_t *tsd, size_t usize, bool is_alloc) {
 	if (likely(usize < te_ctx_next_event_get(&ctx) - bytes_before)) {
 		te_assert_invariants(tsd);
 	} else {
-		te_event_trigger(tsd, &ctx, false);
+		te_event_trigger(tsd, &ctx);
 	}
 }
 

--- a/include/jemalloc/internal/thread_event.h
+++ b/include/jemalloc/internal/thread_event.h
@@ -186,11 +186,9 @@ te_ctx_next_event_set(tsd_t *tsd, te_ctx_t *ctx, uint64_t v) {
  * of thread event handling that we can rely on and need to promise.
  * The invariants are only temporarily violated in the middle of:
  * (a) event_advance() if an event is triggered (the te_event_trigger() call
- *     at the end will restore the invariants),
+ *     at the end will restore the invariants), or
  * (b) te_##event##_event_update() (the te_event_update() call at the
- *     end will restore the invariants), or
- * (c) te_alloc_rollback() if the rollback falls below the last_event
- *     (the te_event_update() call at the end will restore the invariants).
+ *     end will restore the invariants).
  */
 JEMALLOC_ALWAYS_INLINE void
 te_assert_invariants(tsd_t *tsd) {

--- a/include/jemalloc/internal/tsd.h
+++ b/include/jemalloc/internal/tsd.h
@@ -86,14 +86,14 @@ typedef ql_elm(tsd_t) tsd_link_t;
     /* reentrancy_level */	0,					\
     /* narenas_tdata */		0,					\
     /* thread_allocated_last_event */	0,				\
-    /* thread_allocated_next_event */	TE_MIN_START_WAIT,		\
+    /* thread_allocated_next_event */	0,				\
     /* thread_deallocated_last_event */	0,				\
-    /* thread_deallocated_next_event */	TE_MIN_START_WAIT,		\
-    /* tcache_gc_event_wait */		TE_MIN_START_WAIT,		\
-    /* tcache_gc_dalloc_event_wait */	TE_MIN_START_WAIT,		\
-    /* prof_sample_event_wait */	TE_MIN_START_WAIT,		\
+    /* thread_deallocated_next_event */	0,				\
+    /* tcache_gc_event_wait */		0,				\
+    /* tcache_gc_dalloc_event_wait */	0,				\
+    /* prof_sample_event_wait */	0,				\
     /* prof_sample_last_event */	0,				\
-    /* stats_interval_event_wait */	TE_MIN_START_WAIT,		\
+    /* stats_interval_event_wait */	0,				\
     /* stats_interval_last_event */	0,				\
     /* prof_tdata */		NULL,					\
     /* prng_state */		0,					\
@@ -130,12 +130,6 @@ typedef ql_elm(tsd_t) tsd_link_t;
     /* witness */		WITNESS_TSD_INITIALIZER			\
     /* test data */		MALLOC_TEST_TSD_INITIALIZER
 
-
-/*
- * TE_MIN_START_WAIT should not exceed the minimal allocation usize.
- */
-#define TE_MIN_START_WAIT ((uint64_t)1U)
-#define TE_MAX_START_WAIT UINT64_MAX
 
 #define TSD_INITIALIZER {						\
     				TSD_DATA_SLOW_INITIALIZER		\

--- a/src/prof.c
+++ b/src/prof.c
@@ -563,7 +563,15 @@ prof_sample_new_event_wait(tsd_t *tsd) {
 
 uint64_t
 prof_sample_postponed_event_wait(tsd_t *tsd) {
-	return TE_MIN_START_WAIT;
+	/*
+	 * The postponed wait time for prof sample event is computed as if we
+	 * want a new wait time (i.e. as if the event were triggered).  If we
+	 * instead postpone to the immediate next allocation, like how we're
+	 * handling the other events, then we can have sampling bias, if e.g.
+	 * the allocation immediately following a reentrancy always comes from
+	 * the same stack trace.
+	 */
+	return prof_sample_new_event_wait(tsd);
 }
 
 int

--- a/src/prof.c
+++ b/src/prof.c
@@ -561,6 +561,11 @@ prof_sample_new_event_wait(tsd_t *tsd) {
 #endif
 }
 
+uint64_t
+prof_sample_postponed_event_wait(tsd_t *tsd) {
+	return TE_MIN_START_WAIT;
+}
+
 int
 prof_getpid(void) {
 #ifdef _WIN32

--- a/src/prof.c
+++ b/src/prof.c
@@ -795,7 +795,7 @@ prof_thr_uid_alloc(tsdn_t *tsdn) {
 prof_tdata_t *
 prof_tdata_init(tsd_t *tsd) {
 	return prof_tdata_init_impl(tsd, prof_thr_uid_alloc(tsd_tsdn(tsd)), 0,
-	    NULL, prof_thread_active_init_get(tsd_tsdn(tsd)), false);
+	    NULL, prof_thread_active_init_get(tsd_tsdn(tsd)));
 }
 
 prof_tdata_t *
@@ -808,7 +808,7 @@ prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata) {
 
 	prof_tdata_detach(tsd, tdata);
 	return prof_tdata_init_impl(tsd, thr_uid, thr_discrim, thread_name,
-	    active, true);
+	    active);
 }
 
 void

--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -1245,7 +1245,7 @@ prof_bt_keycomp(const void *k1, const void *k2) {
 
 prof_tdata_t *
 prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid, uint64_t thr_discrim,
-    char *thread_name, bool active, bool reset_interval) {
+    char *thread_name, bool active) {
 	assert(tsd_reentrancy_level_get(tsd) == 0);
 
 	prof_tdata_t *tdata;
@@ -1272,10 +1272,6 @@ prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid, uint64_t thr_discrim,
 	    prof_bt_keycomp)) {
 		idalloctm(tsd_tsdn(tsd), tdata, NULL, NULL, true, true);
 		return NULL;
-	}
-
-	if (reset_interval) {
-		prof_sample_threshold_update(tsd);
 	}
 
 	tdata->enq = false;

--- a/src/stats.c
+++ b/src/stats.c
@@ -1494,11 +1494,6 @@ stats_print(void (*write_cb)(void *, const char *), void *cbopaque,
 	emitter_end(&emitter);
 }
 
-bool
-stats_interval_accum(tsd_t *tsd, uint64_t bytes) {
-	return counter_accum(tsd_tsdn(tsd), &stats_interval_accumulated, bytes);
-}
-
 uint64_t
 stats_interval_new_event_wait(tsd_t *tsd) {
 	return stats_interval_accum_batch;
@@ -1507,6 +1502,15 @@ stats_interval_new_event_wait(tsd_t *tsd) {
 uint64_t
 stats_interval_postponed_event_wait(tsd_t *tsd) {
 	return TE_MIN_START_WAIT;
+}
+
+void
+stats_interval_event_handler(tsd_t *tsd, uint64_t elapsed) {
+	assert(elapsed > 0 && elapsed != TE_INVALID_ELAPSED);
+	if (counter_accum(tsd_tsdn(tsd), &stats_interval_accumulated,
+	    elapsed)) {
+		je_malloc_stats_print(NULL, NULL, opt_stats_interval_opts);
+	}
 }
 
 bool

--- a/src/stats.c
+++ b/src/stats.c
@@ -1504,6 +1504,11 @@ stats_interval_new_event_wait(tsd_t *tsd) {
 	return stats_interval_accum_batch;
 }
 
+uint64_t
+stats_interval_postponed_event_wait(tsd_t *tsd) {
+	return TE_MIN_START_WAIT;
+}
+
 bool
 stats_boot(void) {
 	uint64_t stats_interval;

--- a/src/stats.c
+++ b/src/stats.c
@@ -1500,7 +1500,7 @@ stats_interval_accum(tsd_t *tsd, uint64_t bytes) {
 }
 
 uint64_t
-stats_interval_accum_batch_size(void) {
+stats_interval_new_event_wait(tsd_t *tsd) {
 	return stats_interval_accum_batch;
 }
 

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -40,6 +40,16 @@ tcache_salloc(tsdn_t *tsdn, const void *ptr) {
 	return arena_salloc(tsdn, ptr);
 }
 
+uint64_t
+tcache_gc_new_event_wait(tsd_t *tsd) {
+	return TCACHE_GC_INCR_BYTES;
+}
+
+uint64_t
+tcache_gc_dalloc_new_event_wait(tsd_t *tsd) {
+	return TCACHE_GC_INCR_BYTES;
+}
+
 void
 tcache_event_hard(tsd_t *tsd, tcache_slow_t *tcache_slow, tcache_t *tcache) {
 	szind_t binind = tcache_slow->next_gc_bin;

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -46,8 +46,18 @@ tcache_gc_new_event_wait(tsd_t *tsd) {
 }
 
 uint64_t
+tcache_gc_postponed_event_wait(tsd_t *tsd) {
+	return TE_MIN_START_WAIT;
+}
+
+uint64_t
 tcache_gc_dalloc_new_event_wait(tsd_t *tsd) {
 	return TCACHE_GC_INCR_BYTES;
+}
+
+uint64_t
+tcache_gc_dalloc_postponed_event_wait(tsd_t *tsd) {
+	return TE_MIN_START_WAIT;
 }
 
 void


### PR DESCRIPTION
On a logical level, the sample wait time belongs to the thread event module, and should not be determined according to the state of the prof `tdata`. It is a "prof -> thread event" dependency that we should remove. The `tdata` holds the temporary storage space for the backtracing result, so we have to have a valid `tdata` when we determine that we should sample. This is their only relationship, and it's an "allocation caller -> thread event lookahead" dependency followed by an "allocation caller -> `tdata`" dependency, and does not involve any "prof -> thread event" dependency.

However, this dependency was present before the refactoring of #1779, so it could either be truly unnecessary, or it tried to solve some edge cases I failed to consider. Let's see if any tests fail...