### PR TITLE
Add option to fetch system thread name on each prof sample

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -227,6 +227,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_reset.c \
 	$(srcroot)test/unit/prof_tctx.c \
 	$(srcroot)test/unit/prof_thread_name.c \
+	$(srcroot)test/unit/prof_use_sys_thread_name.c \
 	$(srcroot)test/unit/ql.c \
 	$(srcroot)test/unit/qr.c \
 	$(srcroot)test/unit/rb.c \

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -28,6 +28,9 @@ extern char opt_prof_prefix[
 extern ssize_t opt_prof_recent_alloc_max;
 extern malloc_mutex_t prof_recent_alloc_mtx;
 
+/* Whether to use thread name provided by the system or by mallctl. */
+extern bool opt_prof_experimental_use_sys_thread_name;
+
 /* Accessed via prof_active_[gs]et{_unlocked,}(). */
 extern bool prof_active;
 
@@ -59,6 +62,8 @@ void prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 void prof_free_sampled_object(tsd_t *tsd, size_t usize, prof_info_t *prof_info);
 prof_tctx_t *prof_tctx_create(tsd_t *tsd);
 #ifdef JEMALLOC_JET
+typedef int (prof_read_sys_thread_name_t)(char *buf, size_t limit);
+extern prof_read_sys_thread_name_t *JET_MUTABLE prof_read_sys_thread_name;
 size_t prof_tdata_count(void);
 size_t prof_bt_count(void);
 #endif

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -117,6 +117,7 @@ CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_accum)
 CTL_PROTO(opt_prof_recent_alloc_max)
+CTL_PROTO(opt_prof_experimental_use_sys_thread_name)
 CTL_PROTO(opt_zero_realloc)
 CTL_PROTO(tcache_create)
 CTL_PROTO(tcache_flush)
@@ -353,6 +354,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
 	{NAME("prof_accum"),	CTL(opt_prof_accum)},
 	{NAME("prof_recent_alloc_max"), CTL(opt_prof_recent_alloc_max)},
+	{NAME("prof_experimental_use_sys_thread_name"),
+	    CTL(opt_prof_experimental_use_sys_thread_name)},
 	{NAME("zero_realloc"),	CTL(opt_zero_realloc)}
 };
 
@@ -1829,6 +1832,8 @@ CTL_RO_NL_CGEN(config_prof, opt_prof_final, opt_prof_final, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_leak, opt_prof_leak, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_recent_alloc_max,
     opt_prof_recent_alloc_max, ssize_t)
+CTL_RO_NL_CGEN(config_prof, opt_prof_experimental_use_sys_thread_name,
+    opt_prof_experimental_use_sys_thread_name, bool)
 CTL_RO_NL_GEN(opt_zero_realloc,
     zero_realloc_mode_names[opt_zero_realloc_action], const char *)
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1426,6 +1426,9 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 				CONF_HANDLE_BOOL(opt_prof_log, "prof_log")
 				CONF_HANDLE_SSIZE_T(opt_prof_recent_alloc_max,
 				    "prof_recent_alloc_max", -1, SSIZE_MAX)
+				CONF_HANDLE_BOOL(
+				    opt_prof_experimental_use_sys_thread_name,
+				    "prof_experimental_use_sys_thread_name")
 			}
 			if (config_log) {
 				if (CONF_MATCH("log")) {

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -192,6 +192,7 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(bool, prof_final, prof);
 	TEST_MALLCTL_OPT(bool, prof_leak, prof);
 	TEST_MALLCTL_OPT(ssize_t, prof_recent_alloc_max, prof);
+	TEST_MALLCTL_OPT(bool, prof_experimental_use_sys_thread_name, prof);
 
 #undef TEST_MALLCTL_OPT
 }

--- a/test/unit/prof_use_sys_thread_name.c
+++ b/test/unit/prof_use_sys_thread_name.c
@@ -1,0 +1,75 @@
+#include "test/jemalloc_test.h"
+
+static const char *test_thread_name = "test_name";
+
+static int
+test_prof_read_sys_thread_name_error(char *buf, size_t limit) {
+	return ENOSYS;
+}
+
+static int
+test_prof_read_sys_thread_name(char *buf, size_t limit) {
+	assert(strlen(test_thread_name) < limit);
+	strncpy(buf, test_thread_name, limit);
+	return 0;
+}
+
+static int
+test_prof_read_sys_thread_name_clear(char *buf, size_t limit) {
+	assert(limit > 0);
+	buf[0] = '\0';
+	return 0;
+}
+
+TEST_BEGIN(test_prof_experimental_use_sys_thread_name) {
+	test_skip_if(!config_prof);
+
+	bool oldval;
+	size_t sz = sizeof(oldval);
+	assert_d_eq(mallctl("opt.prof_experimental_use_sys_thread_name",
+	    &oldval, &sz, NULL,	0), 0, "mallctl failed");
+	assert_true(oldval, "option was not set correctly");
+
+	const char *thread_name;
+	sz = sizeof(thread_name);
+	assert_d_eq(mallctl("thread.prof.name", &thread_name, &sz, NULL, 0), 0,
+	    "mallctl read for thread name should not fail");
+	expect_str_eq(thread_name, "", "Initial thread name should be empty");
+
+	thread_name = test_thread_name;
+	assert_d_eq(mallctl("thread.prof.name", NULL, NULL, &thread_name, sz),
+	    ENOENT, "mallctl write for thread name should fail");
+	assert_ptr_eq(thread_name, test_thread_name,
+	    "Thread name should not be touched");
+
+	prof_read_sys_thread_name = test_prof_read_sys_thread_name_error;
+	void *p = malloc(1);
+	free(p);
+	assert_d_eq(mallctl("thread.prof.name", &thread_name, &sz, NULL, 0), 0,
+	    "mallctl read for thread name should not fail");
+	assert_str_eq(thread_name, "",
+	    "Thread name should stay the same if the system call fails");
+
+	prof_read_sys_thread_name = test_prof_read_sys_thread_name;
+	p = malloc(1);
+	free(p);
+	assert_d_eq(mallctl("thread.prof.name", &thread_name, &sz, NULL, 0), 0,
+	    "mallctl read for thread name should not fail");
+	assert_str_eq(thread_name, test_thread_name,
+	    "Thread name should be changed if the system call succeeds");
+
+	prof_read_sys_thread_name = test_prof_read_sys_thread_name_clear;
+	p = malloc(1);
+	free(p);
+	assert_d_eq(mallctl("thread.prof.name", &thread_name, &sz, NULL, 0), 0,
+	    "mallctl read for thread name should not fail");
+	expect_str_eq(thread_name, "", "Thread name should be updated if the "
+	    "system call returns a different name");
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_prof_experimental_use_sys_thread_name);
+}

--- a/test/unit/prof_use_sys_thread_name.sh
+++ b/test/unit/prof_use_sys_thread_name.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_experimental_use_sys_thread_name:true"
+fi


### PR DESCRIPTION
This is solution to #1797.

The implementation is different from my comment on the issue: the system call is always invoked at sampling time. The purpose is to guarantee that we don't miss any thread name update set by the caller via system calls.

This would overwrite any thread name set via `mallctl`, so I'm explicitly disallowing the `mallctl` setter call when the new option is turned on. Logically the new option means: use the system thread name *instead of* the `mallctl` thread name.

Also added platform independent unit tests.