### PR TITLE
Make prof_tctx_t pointer a true prof atomic fence

### DIFF
--- a/src/large.c
+++ b/src/large.c
@@ -360,9 +360,9 @@ large_prof_tctx_reset(edata_t *edata) {
 
 void
 large_prof_info_set(edata_t *edata, prof_tctx_t *tctx) {
-	large_prof_tctx_set(edata, tctx);
 	nstime_t t;
 	nstime_init_update(&t);
 	edata_prof_alloc_time_set(edata, &t);
 	edata_prof_recent_alloc_init(edata);
+	large_prof_tctx_set(edata, tctx);
 }


### PR DESCRIPTION
This is more of a question than a PR. I don't quite get the reason why we need the strong `ATOMIC_RELEASE` and `ATOMIC_ACQUIRE` for the `prof_tctx_t` pointer on `edata`. I might have missed something important, and I want to better understand it. Otherwise we shouldn't impose stronger than necessary requirements.