### PR TITLE
Add malloc_conf_2_conf_harder

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -209,6 +209,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/junk_free.c \
 	$(srcroot)test/unit/log.c \
 	$(srcroot)test/unit/mallctl.c \
+	$(srcroot)test/unit/malloc_conf_2.c \
 	$(srcroot)test/unit/malloc_io.c \
 	$(srcroot)test/unit/math.c \
 	$(srcroot)test/unit/mq.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1000,7 +1000,8 @@ AC_ARG_WITH([export],
 fi]
 )
 
-public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib mallctlnametomib malloc malloc_conf malloc_message malloc_stats_print malloc_usable_size mallocx smallocx_${jemalloc_version_gid} nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx"
+public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib
+mallctlnametomib malloc malloc_conf malloc_conf_2_conf_harder malloc_message malloc_stats_print malloc_usable_size mallocx smallocx_${jemalloc_version_gid} nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx"
 dnl Check for additional platform-specific public API functions.
 AC_CHECK_FUNC([memalign],
 	      [AC_DEFINE([JEMALLOC_OVERRIDE_MEMALIGN], [ ])

--- a/test/unit/malloc_conf_2.c
+++ b/test/unit/malloc_conf_2.c
@@ -1,0 +1,29 @@
+#include "test/jemalloc_test.h"
+
+const char *malloc_conf = "dirty_decay_ms:1000";
+const char *malloc_conf_2_conf_harder = "dirty_decay_ms:1234";
+
+TEST_BEGIN(test_malloc_conf_2) {
+#ifdef _WIN32
+	bool windows = true;
+#else
+	bool windows = false;
+#endif
+	/* Windows doesn't support weak symbol linker trickery. */
+	test_skip_if(windows);
+
+	ssize_t dirty_decay_ms;
+	size_t sz = sizeof(dirty_decay_ms);
+
+	int err = mallctl("opt.dirty_decay_ms", &dirty_decay_ms, &sz, NULL, 0);
+	assert_d_eq(err, 0, "Unexpected mallctl failure");
+	expect_zd_eq(dirty_decay_ms, 1234,
+	    "malloc_conf_2 setting didn't take effect");
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_malloc_conf_2);
+}

--- a/test/unit/malloc_conf_2.sh
+++ b/test/unit/malloc_conf_2.sh
@@ -1,0 +1,1 @@
+export MALLOC_CONF="dirty_decay_ms:500"


### PR DESCRIPTION
This comes in handy when you're just a user of a canary system who wants to change settings set by the configuration system itself (and so you control the binary but not the environment variables, which can override your settings).

The silly name is deliberate -- it's a hint that this shouldn't really be present in "serious" code.