### PR TITLE
[Seeking early feedback] Do not rollback prof idump counter in arena_prof_promote()

### DIFF
--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -50,7 +50,6 @@ extern bool prof_booted;
 
 /* Functions only accessed in prof_inlines_a.h */
 bool prof_idump_accum_impl(tsdn_t *tsdn, uint64_t accumbytes);
-void prof_idump_rollback_impl(tsdn_t *tsdn, size_t usize);
 
 /* Functions only accessed in prof_inlines_b.h */
 prof_tdata_t *prof_tdata_init(tsd_t *tsd);

--- a/include/jemalloc/internal/prof_inlines_a.h
+++ b/include/jemalloc/internal/prof_inlines_a.h
@@ -36,15 +36,4 @@ prof_idump_accum(tsdn_t *tsdn, uint64_t accumbytes) {
 	return prof_idump_accum_impl(tsdn, accumbytes);
 }
 
-JEMALLOC_ALWAYS_INLINE void
-prof_idump_rollback(tsdn_t *tsdn, size_t usize) {
-	cassert(config_prof);
-
-	if (prof_interval == 0 || !prof_active_get_unlocked()) {
-		return;
-	}
-
-	prof_idump_rollback_impl(tsdn, usize);
-}
-
 #endif /* JEMALLOC_INTERNAL_PROF_INLINES_A_H */

--- a/src/arena.c
+++ b/src/arena.c
@@ -1061,8 +1061,6 @@ arena_prof_promote(tsdn_t *tsdn, void *ptr, size_t usize) {
 	edata_szind_set(edata, szind);
 	emap_remap(tsdn, &arena_emap_global, edata, szind, /* slab */ false);
 
-	prof_idump_rollback(tsdn, usize);
-
 	assert(isalloc(tsdn, ptr) == usize);
 }
 

--- a/src/prof.c
+++ b/src/prof.c
@@ -50,7 +50,7 @@ bool opt_prof_accum = false;
 char opt_prof_prefix[PROF_DUMP_FILENAME_LEN];
 bool opt_prof_experimental_use_sys_thread_name = false;
 
-/* Accessed via prof_idump_[accum/rollback](). */
+/* Accessed via prof_idump_accum(). */
 static counter_accum_t prof_idump_accumulated;
 
 /*
@@ -653,16 +653,6 @@ prof_idump_accum_impl(tsdn_t *tsdn, uint64_t accumbytes) {
 	cassert(config_prof);
 
 	return counter_accum(tsdn, &prof_idump_accumulated, accumbytes);
-}
-
-void
-prof_idump_rollback_impl(tsdn_t *tsdn, size_t usize) {
-	cassert(config_prof);
-
-	/* Rollback is only done on arena_prof_promote of small sizes. */
-	assert(SC_LARGE_MINCLASS > usize);
-	return counter_rollback(tsdn, &prof_idump_accumulated,
-	    SC_LARGE_MINCLASS - usize);
 }
 
 bool

--- a/test/unit/counter.c
+++ b/test/unit/counter.c
@@ -36,48 +36,6 @@ expect_counter_value(counter_accum_t *c, uint64_t v) {
 	expect_u64_eq(accum, v, "Counter value mismatch");
 }
 
-TEST_BEGIN(test_counter_rollback) {
-	uint64_t half_interval = interval / 2;
-
-	counter_accum_t c;
-	counter_accum_init(&c, interval);
-
-	tsd_t *tsd = tsd_fetch();
-	counter_rollback(tsd_tsdn(tsd), &c, half_interval);
-
-	bool trigger;
-	trigger = counter_accum(tsd_tsdn(tsd), &c, half_interval);
-	expect_b_eq(trigger, false, "Should not trigger");
-	counter_rollback(tsd_tsdn(tsd), &c, half_interval + 1);
-	expect_counter_value(&c,  0);
-
-	trigger = counter_accum(tsd_tsdn(tsd), &c, half_interval);
-	expect_b_eq(trigger, false, "Should not trigger");
-	counter_rollback(tsd_tsdn(tsd), &c, half_interval - 1);
-	expect_counter_value(&c,  1);
-
-	counter_rollback(tsd_tsdn(tsd), &c, 1);
-	expect_counter_value(&c,  0);
-
-	trigger = counter_accum(tsd_tsdn(tsd), &c, half_interval);
-	expect_b_eq(trigger, false, "Should not trigger");
-	counter_rollback(tsd_tsdn(tsd), &c, 1);
-	expect_counter_value(&c,  half_interval - 1);
-
-	trigger = counter_accum(tsd_tsdn(tsd), &c, half_interval);
-	expect_b_eq(trigger, false, "Should not trigger");
-	expect_counter_value(&c,  interval - 1);
-
-	trigger = counter_accum(tsd_tsdn(tsd), &c, 1);
-	expect_b_eq(trigger, true, "Should have triggered");
-	expect_counter_value(&c, 0);
-
-	trigger = counter_accum(tsd_tsdn(tsd), &c, interval + 1);
-	expect_b_eq(trigger, true, "Should have triggered");
-	expect_counter_value(&c, 1);
-}
-TEST_END
-
 #define N_THDS (16)
 #define N_ITER_THD (1 << 12)
 #define ITER_INCREMENT (interval >> 4)
@@ -123,6 +81,5 @@ int
 main(void) {
 	return test(
 	    test_counter_accum,
-	    test_counter_rollback,
 	    test_counter_mt);
 }


### PR DESCRIPTION
First, a question: when we bump a small allocation to a large allocation when it's sampled, do we count the original `usize` or the bumped one in the events?

I'm leaning towards that we should count the original `usize` - the bumped `usize` is jemalloc internal and should not affect user observable behaviors.

In any case, we don't need to rollback `usize` when we're bumping. If we only count `usize`, then we do nothing in bumping, and the final event counter update can take care of it, and this is what's currently the case in this PR; if we count the bumped `usize`, then we can count the difference between the two in bumping, and the final event counter update can complete it.

After we reach an agreement (which is the early feedback I'm seeking), I'll further do some simplifications.