### PR TITLE
Deduplicate entries in witness error message

### DIFF
--- a/src/witness.c
+++ b/src/witness.c
@@ -15,14 +15,41 @@ witness_init(witness_t *witness, const char *name, witness_rank_t rank,
 }
 
 static void
+witness_print_witness(witness_t *w, unsigned n) {
+	assert(n > 0);
+	if (n == 1) {
+		malloc_printf(" %s(%u)", w->name, w->rank);
+	} else {
+		malloc_printf(" %s(%u)X%u", w->name, w->rank, n);
+	}
+}
+
+static void
+witness_print_witnesses(const witness_list_t *witnesses) {
+	witness_t *w, *last = NULL;
+	unsigned n = 0;
+	ql_foreach(w, witnesses, link) {
+		if (last != NULL && w->rank > last->rank) {
+			assert(w->name != last->name);
+			witness_print_witness(last, n);
+			n = 0;
+		} else if (last != NULL) {
+			assert(w->rank == last->rank);
+			assert(w->name == last->name);
+		}
+		last = w;
+		++n;
+	}
+	if (last != NULL) {
+		witness_print_witness(last, n);
+	}
+}
+
+static void
 witness_lock_error_impl(const witness_list_t *witnesses,
     const witness_t *witness) {
-	witness_t *w;
-
 	malloc_printf("<jemalloc>: Lock rank order reversal:");
-	ql_foreach(w, witnesses, link) {
-		malloc_printf(" %s(%u)", w->name, w->rank);
-	}
+	witness_print_witnesses(witnesses);
 	malloc_printf(" %s(%u)\n", witness->name, witness->rank);
 	abort();
 }
@@ -49,13 +76,9 @@ witness_not_owner_error_t *JET_MUTABLE witness_not_owner_error =
 static void
 witness_depth_error_impl(const witness_list_t *witnesses,
     witness_rank_t rank_inclusive, unsigned depth) {
-	witness_t *w;
-
 	malloc_printf("<jemalloc>: Should own %u lock%s of rank >= %u:", depth,
 	    (depth != 1) ?  "s" : "", rank_inclusive);
-	ql_foreach(w, witnesses, link) {
-		malloc_printf(" %s(%u)", w->name, w->rank);
-	}
+	witness_print_witnesses(witnesses);
 	malloc_printf("\n");
 	abort();
 }


### PR DESCRIPTION
Before this change, I got the following error message while working on another project:
```
<jemalloc>: Lock rank order reversal: ctl(1) tcaches(2) arenas(3) background_thread_global(4) prof_dump(5) prof_bt2gctx(6) prof_tdatas(7) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_tdata(8) prof_log(9) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) prof_gctx(10) background_thread(11) background_thread(11) background_thread(11) background_thread(11) decay(12) decay(12) tcache_ql(13) extent_grow(14) extents(15) extents(15) extents(15) edata_cache(16) base(19) arena_large(20) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) bin(4294967295) prof_recent_dump(22)
```

Now, I get:
```
<jemalloc>: Lock rank order reversal: ctl(1) tcaches(2) arenas(3) background_thread_global(4) prof_dump(5) prof_bt2gctx(6) prof_tdatas(7) prof_tdata(8)X256 prof_log(9) prof_gctx(10)X1024 background_thread(11)X4 decay(12)X2 tcache_ql(13) extent_grow(14) extents(15)X3 edata_cache(16) base(19) arena_large(20) bin(4294967295)X36 prof_recent_dump(22)
```

Much better.

Also verifying while printing that locks of different orders have different names and locks of the same order have the same name. Not critically important but why not.