### PR TITLE
Move opt.zero zeroing decisions earlier in the allocation life-cycle

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -289,6 +289,7 @@ CPP_SRCS :=
 TESTS_INTEGRATION_CPP :=
 endif
 TESTS_STRESS := $(srcroot)test/stress/microbench.c \
+	$(srcroot)test/stress/large_microbench.c \
 	$(srcroot)test/stress/hookbench.c
 
 

--- a/src/large.c
+++ b/src/large.c
@@ -32,9 +32,6 @@ large_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize, size_t alignment,
 		return NULL;
 	}
 
-	if (config_fill && unlikely(opt_zero)) {
-		zero = true;
-	}
 	if (likely(!tsdn_null(tsdn))) {
 		arena = arena_choose_maybe_huge(tsdn_tsd(tsdn), arena, usize);
 	}

--- a/test/include/test/bench.h
+++ b/test/include/test/bench.h
@@ -1,0 +1,39 @@
+static inline void
+time_func(timedelta_t *timer, uint64_t nwarmup, uint64_t niter,
+    void (*func)(void)) {
+	uint64_t i;
+
+	for (i = 0; i < nwarmup; i++) {
+		func();
+	}
+	timer_start(timer);
+	for (i = 0; i < niter; i++) {
+		func();
+	}
+	timer_stop(timer);
+}
+
+static inline void
+compare_funcs(uint64_t nwarmup, uint64_t niter, const char *name_a,
+    void (*func_a), const char *name_b, void (*func_b)) {
+	timedelta_t timer_a, timer_b;
+	char ratio_buf[6];
+	void *p;
+
+	p = mallocx(1, 0);
+	if (p == NULL) {
+		test_fail("Unexpected mallocx() failure");
+		return;
+	}
+
+	time_func(&timer_a, nwarmup, niter, func_a);
+	time_func(&timer_b, nwarmup, niter, func_b);
+
+	timer_ratio(&timer_a, &timer_b, ratio_buf, sizeof(ratio_buf));
+	malloc_printf("%"FMTu64" iterations, %s=%"FMTu64"us, "
+	    "%s=%"FMTu64"us, ratio=1:%s\n",
+	    niter, name_a, timer_usec(&timer_a), name_b, timer_usec(&timer_b),
+	    ratio_buf);
+
+	dallocx(p, 0);
+}

--- a/test/stress/large_microbench.c
+++ b/test/stress/large_microbench.c
@@ -1,0 +1,33 @@
+#include "test/jemalloc_test.h"
+#include "test/bench.h"
+
+static void
+large_mallocx_free(void) {
+	/*
+	 * We go a bit larger than the large minclass on its own to better
+	 * expose costs from things like zeroing.
+	 */
+	void *p = mallocx(SC_LARGE_MINCLASS, MALLOCX_TCACHE_NONE);
+	assert_ptr_not_null(p, "mallocx shouldn't fail");
+	free(p);
+}
+
+static void
+small_mallocx_free(void) {
+	void *p = mallocx(16, 0);
+	assert_ptr_not_null(p, "mallocx shouldn't fail");
+	free(p);
+}
+
+TEST_BEGIN(test_large_vs_small) {
+	compare_funcs(100*1000, 1*1000*1000, "large mallocx",
+	    large_mallocx_free, "small mallocx", small_mallocx_free);
+}
+TEST_END
+
+int
+main(void) {
+	return test_no_reentrancy(
+	    test_large_vs_small);
+}
+

--- a/test/stress/microbench.c
+++ b/test/stress/microbench.c
@@ -1,44 +1,5 @@
 #include "test/jemalloc_test.h"
-
-static inline void
-time_func(timedelta_t *timer, uint64_t nwarmup, uint64_t niter,
-    void (*func)(void)) {
-	uint64_t i;
-
-	for (i = 0; i < nwarmup; i++) {
-		func();
-	}
-	timer_start(timer);
-	for (i = 0; i < niter; i++) {
-		func();
-	}
-	timer_stop(timer);
-}
-
-void
-compare_funcs(uint64_t nwarmup, uint64_t niter, const char *name_a,
-    void (*func_a), const char *name_b, void (*func_b)) {
-	timedelta_t timer_a, timer_b;
-	char ratio_buf[6];
-	void *p;
-
-	p = mallocx(1, 0);
-	if (p == NULL) {
-		test_fail("Unexpected mallocx() failure");
-		return;
-	}
-
-	time_func(&timer_a, nwarmup, niter, func_a);
-	time_func(&timer_b, nwarmup, niter, func_b);
-
-	timer_ratio(&timer_a, &timer_b, ratio_buf, sizeof(ratio_buf));
-	malloc_printf("%"FMTu64" iterations, %s=%"FMTu64"us, "
-	    "%s=%"FMTu64"us, ratio=1:%s\n",
-	    niter, name_a, timer_usec(&timer_a), name_b, timer_usec(&timer_b),
-	    ratio_buf);
-
-	dallocx(p, 0);
-}
+#include "test/bench.h"
 
 static void
 malloc_free(void) {


### PR DESCRIPTION
This is both cleaner (it makes it so that the core internals don't know about opt.zero; they only know about the specific requests made of them), and makes the opt.zero case faster (since the extent-level allocator can madvise-zero the pages, avoiding having to memset them).

Tested the opt.zero improvement using the new benchmark with opt.zero on and off.

We take an extra branch now on realloc pathways, but it should mostly be correctly predicted (and those aren't hot paths to begin with).