### PR TITLE
Fix broken CI builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,6 +256,8 @@ if test "x$GCC" = "xyes" ; then
   dnl has lots of nested structs).  See the discussion at.
   dnl https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
   JE_CFLAGS_ADD([-Wno-missing-braces])
+  dnl This one too.
+  JE_CFLAGS_ADD([-Wno-missing-field-initializers])
   JE_CFLAGS_ADD([-pipe])
   JE_CFLAGS_ADD([-g3])
 elif test "x$je_cv_msvc" = "xyes" ; then

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -142,7 +142,8 @@ tcache_gc_small(tsd_t *tsd, tcache_slow_t *tcache_slow, tcache_t *tcache,
 		    = tcache_gc_item_delay_compute(szind);
 	}
 
-	tcache_bin_flush_small(tsd, tcache, cache_bin, szind, ncached - nflush);
+	tcache_bin_flush_small(tsd, tcache, cache_bin, szind,
+	    (unsigned)(ncached - nflush));
 
 	/*
 	 * Reduce fill count by 2X.  Limit lg_fill_div such that
@@ -165,7 +166,7 @@ tcache_gc_large(tsd_t *tsd, tcache_slow_t *tcache_slow, tcache_t *tcache,
 	cache_bin_sz_t low_water = cache_bin_low_water_get(cache_bin,
 	    &tcache_bin_info[szind]);
 	tcache_bin_flush_large(tsd, tcache, cache_bin, szind,
-	    ncached - low_water + (low_water >> 2));
+	    (unsigned)(ncached - low_water + (low_water >> 2)));
 }
 
 static void


### PR DESCRIPTION
For some reason, travis runs stopped showing up in the CI pane for a week or two, and so the build looked green despite growing some build errors (none "real" -- integer conversion and initializer syntax ones). This fixes the issues.