### PR TITLE
Introduce a couple more PA-named modules.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -127,6 +127,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/nstime.c \
 	$(srcroot)src/pa.c \
 	$(srcroot)src/pa_extra.c \
+	$(srcroot)src/pac.c \
 	$(srcroot)src/pages.c \
 	$(srcroot)src/peak_event.c \
 	$(srcroot)src/prof.c \

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -27,7 +27,7 @@ void arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
     const char **dss, ssize_t *dirty_decay_ms, ssize_t *muzzy_decay_ms,
     size_t *nactive, size_t *ndirty, size_t *nmuzzy, arena_stats_t *astats,
     bin_stats_data_t *bstats, arena_stats_large_t *lstats,
-    pa_extent_stats_t *estats);
+    pac_estats_t *estats);
 void arena_handle_new_dirty_pages(tsdn_t *tsdn, arena_t *arena);
 #ifdef JEMALLOC_JET
 size_t arena_slab_regind(edata_t *slab, szind_t binind, const void *ptr);

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -40,10 +40,9 @@ void arena_extent_ralloc_large_shrink(tsdn_t *tsdn, arena_t *arena,
     edata_t *edata, size_t oldsize);
 void arena_extent_ralloc_large_expand(tsdn_t *tsdn, arena_t *arena,
     edata_t *edata, size_t oldsize);
-ssize_t arena_dirty_decay_ms_get(arena_t *arena);
-bool arena_dirty_decay_ms_set(tsdn_t *tsdn, arena_t *arena, ssize_t decay_ms);
-ssize_t arena_muzzy_decay_ms_get(arena_t *arena);
-bool arena_muzzy_decay_ms_set(tsdn_t *tsdn, arena_t *arena, ssize_t decay_ms);
+bool arena_decay_ms_set(tsdn_t *tsdn, arena_t *arena, extent_state_t state,
+    ssize_t decay_ms);
+ssize_t arena_decay_ms_get(arena_t *arena, extent_state_t state);
 void arena_decay(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
     bool all);
 void arena_reset(tsd_t *tsd, arena_t *arena);

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -131,9 +131,6 @@ arena_decay_ticks(tsdn_t *tsdn, arena_t *arena, unsigned nticks) {
 
 JEMALLOC_ALWAYS_INLINE void
 arena_decay_tick(tsdn_t *tsdn, arena_t *arena) {
-	malloc_mutex_assert_not_owner(tsdn, &arena->pa_shard.decay_dirty.mtx);
-	malloc_mutex_assert_not_owner(tsdn, &arena->pa_shard.decay_muzzy.mtx);
-
 	arena_decay_ticks(tsdn, arena, 1);
 }
 

--- a/include/jemalloc/internal/atomic.h
+++ b/include/jemalloc/internal/atomic.h
@@ -63,6 +63,13 @@
 	    type oldval = atomic_load_##short_type(a, ATOMIC_RELAXED);	\
 	    type newval = oldval + inc;					\
 	    atomic_store_##short_type(a, newval, ATOMIC_RELAXED);	\
+	}								\
+    ATOMIC_INLINE void							\
+    atomic_load_sub_store_##short_type(atomic_##short_type##_t *a,	\
+	type inc) {							\
+	    type oldval = atomic_load_##short_type(a, ATOMIC_RELAXED);	\
+	    type newval = oldval - inc;					\
+	    atomic_store_##short_type(a, newval, ATOMIC_RELAXED);	\
 	}
 
 /*

--- a/include/jemalloc/internal/background_thread_inlines.h
+++ b/include/jemalloc/internal/background_thread_inlines.h
@@ -55,7 +55,7 @@ arena_background_thread_inactivity_check(tsdn_t *tsdn, arena_t *arena,
 	    arena_background_thread_info_get(arena);
 	if (background_thread_indefinite_sleep(info)) {
 		background_thread_interval_check(tsdn, arena,
-		    &arena->pa_shard.decay_dirty, 0);
+		    &arena->pa_shard.pac.decay_dirty, 0);
 	}
 }
 

--- a/include/jemalloc/internal/ctl.h
+++ b/include/jemalloc/internal/ctl.h
@@ -44,7 +44,7 @@ typedef struct ctl_arena_stats_s {
 
 	bin_stats_data_t bstats[SC_NBINS];
 	arena_stats_large_t lstats[SC_NSIZES - SC_NBINS];
-	pa_extent_stats_t estats[SC_NPSIZES];
+	pac_estats_t estats[SC_NPSIZES];
 } ctl_arena_stats_t;
 
 typedef struct ctl_stats_s {

--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -48,7 +48,7 @@ edata_t *extent_split_wrapper(tsdn_t *tsdn, pa_shard_t *shard,
     ehooks_t *ehooks, edata_t *edata, size_t size_a, size_t size_b);
 bool extent_merge_wrapper(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
     edata_t *a, edata_t *b);
-
+size_t extent_sn_next(pac_t *pac);
 bool extent_boot(void);
 
 #endif /* JEMALLOC_INTERNAL_EXTENT_H */

--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -19,22 +19,22 @@
 #define LG_EXTENT_MAX_ACTIVE_FIT_DEFAULT 6
 extern size_t opt_lg_extent_max_active_fit;
 
-edata_t *ecache_alloc(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+edata_t *ecache_alloc(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     ecache_t *ecache, void *new_addr, size_t size, size_t alignment, bool zero);
-edata_t *ecache_alloc_grow(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+edata_t *ecache_alloc_grow(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     ecache_t *ecache, void *new_addr, size_t size, size_t alignment, bool zero);
-void ecache_dalloc(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+void ecache_dalloc(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     ecache_t *ecache, edata_t *edata);
-edata_t *ecache_evict(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+edata_t *ecache_evict(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     ecache_t *ecache, size_t npages_min);
 
-edata_t *extent_alloc_wrapper(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+edata_t *extent_alloc_wrapper(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     void *new_addr, size_t size, size_t alignment, bool zero, bool *commit);
-void extent_dalloc_gap(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+void extent_dalloc_gap(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     edata_t *edata);
-void extent_dalloc_wrapper(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+void extent_dalloc_wrapper(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     edata_t *edata);
-void extent_destroy_wrapper(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+void extent_destroy_wrapper(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     edata_t *edata);
 bool extent_commit_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     size_t offset, size_t length);
@@ -44,9 +44,9 @@ bool extent_purge_lazy_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     size_t offset, size_t length);
 bool extent_purge_forced_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     size_t offset, size_t length);
-edata_t *extent_split_wrapper(tsdn_t *tsdn, pa_shard_t *shard,
+edata_t *extent_split_wrapper(tsdn_t *tsdn, pac_t *pac,
     ehooks_t *ehooks, edata_t *edata, size_t size_a, size_t size_b);
-bool extent_merge_wrapper(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
+bool extent_merge_wrapper(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
     edata_t *a, edata_t *b);
 size_t extent_sn_next(pac_t *pac);
 bool extent_boot(void);

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -100,12 +100,6 @@ pa_shard_dont_decay_muzzy(pa_shard_t *shard) {
 	    pac_muzzy_decay_ms_get(&shard->pac) <= 0;
 }
 
-static inline bool
-pa_shard_may_force_decay(pa_shard_t *shard) {
-	return !(pac_dirty_decay_ms_get(&shard->pac) == -1
-	    || pac_muzzy_decay_ms_get(&shard->pac) == -1);
-}
-
 static inline ehooks_t *
 pa_shard_ehooks_get(pa_shard_t *shard) {
 	return base_ehooks_get(shard->base);

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -126,8 +126,6 @@ struct pa_shard_s {
 	/* The source of edata_t objects. */
 	edata_cache_t edata_cache;
 
-	/* The grow info for the retained ecache. */
-	ecache_grow_t ecache_grow;
 
 	/* Extent serial number generator state. */
 	atomic_zu_t extent_sn_next;

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -66,12 +66,7 @@ struct pa_shard_s {
 	 */
 	atomic_zu_t nactive;
 
-	/*
-	 * An interface for page allocation from the ecache framework (i.e. a
-	 * cascade of ecache_dirty, ecache_muzzy, ecache_retained).  Right now
-	 * this is the *only* pai, but we'll soon grow another.
-	 */
-	pai_t ecache_pai;
+	/* Allocates from a PAC. */
 	pac_t pac;
 
 	/* The source of edata_t objects. */

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -7,6 +7,7 @@
 #include "jemalloc/internal/edata_cache.h"
 #include "jemalloc/internal/emap.h"
 #include "jemalloc/internal/lockedint.h"
+#include "jemalloc/internal/pai.h"
 
 enum pa_decay_purge_setting_e {
 	PA_DECAY_PURGE_ALWAYS,
@@ -109,6 +110,13 @@ struct pa_shard_s {
 	 * Synchronization: atomic.
 	 */
 	atomic_zu_t nactive;
+
+	/*
+	 * An interface for page allocation from the ecache framework (i.e. a
+	 * cascade of ecache_dirty, ecache_muzzy, ecache_retained).  Right now
+	 * this is the *only* pai, but we'll soon grow another.
+	 */
+	pai_t ecache_pai;
 
 	/*
 	 * Collections of extents that were previously allocated.  These are

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -84,9 +84,6 @@ struct pa_shard_s {
 	/* The source of edata_t objects. */
 	edata_cache_t edata_cache;
 
-	/* Extent serial number generator state. */
-	atomic_zu_t extent_sn_next;
-
 	malloc_mutex_t *stats_mtx;
 	pa_shard_stats_t *stats;
 
@@ -130,8 +127,6 @@ void pa_shard_reset(pa_shard_t *shard);
  * last step in destroying the shard.
  */
 void pa_shard_destroy_retained(tsdn_t *tsdn, pa_shard_t *shard);
-
-size_t pa_shard_extent_sn_next(pa_shard_t *shard);
 
 /* Gets an edata for the given allocation. */
 edata_t *pa_alloc(tsdn_t *tsdn, pa_shard_t *shard, size_t size,

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -113,7 +113,7 @@ void pa_shard_reset(pa_shard_t *shard);
  * decaying all active, dirty, and muzzy extents to the retained state, as the
  * last step in destroying the shard.
  */
-void pa_shard_destroy_retained(tsdn_t *tsdn, pa_shard_t *shard);
+void pa_shard_destroy(tsdn_t *tsdn, pa_shard_t *shard);
 
 /* Gets an edata for the given allocation. */
 edata_t *pa_alloc(tsdn_t *tsdn, pa_shard_t *shard, size_t size,

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -18,13 +18,6 @@
  * others will be coming soon.
  */
 
-enum pa_decay_purge_setting_e {
-	PA_DECAY_PURGE_ALWAYS,
-	PA_DECAY_PURGE_NEVER,
-	PA_DECAY_PURGE_ON_EPOCH_ADVANCE
-};
-typedef enum pa_decay_purge_setting_e pa_decay_purge_setting_t;
-
 /*
  * The stats for a particular pa_shard.  Because of the way the ctl module
  * handles stats epoch data collection (it has its own arena_stats, and merges
@@ -163,7 +156,7 @@ void pa_decay_all(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
  */
 bool pa_maybe_decay_purge(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
     pac_decay_stats_t *decay_stats, ecache_t *ecache,
-    pa_decay_purge_setting_t decay_purge_setting);
+    pac_decay_purge_setting_t decay_purge_setting);
 
 /*
  * Gets / sets the maximum amount that we'll grow an arena down the

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -137,39 +137,6 @@ bool pa_shrink(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
 void pa_dalloc(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata,
     bool *generated_dirty);
 
-/*
- * All purging functions require holding decay->mtx.  This is one of the few
- * places external modules are allowed to peek inside pa_shard_t internals.
- */
-
-/*
- * Decays the number of pages currently in the ecache.  This might not leave the
- * ecache empty if other threads are inserting dirty objects into it
- * concurrently with the call.
- */
-void pa_decay_all(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
-    pac_decay_stats_t *decay_stats, ecache_t *ecache, bool fully_decay);
-/*
- * Updates decay settings for the current time, and conditionally purges in
- * response (depending on decay_purge_setting).  Returns whether or not the
- * epoch advanced.
- */
-bool pa_maybe_decay_purge(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
-    pac_decay_stats_t *decay_stats, ecache_t *ecache,
-    pac_decay_purge_setting_t decay_purge_setting);
-
-/*
- * Gets / sets the maximum amount that we'll grow an arena down the
- * grow-retained pathways (unless forced to by an allocaction request).
- *
- * Set new_limit to NULL if it's just a query, or old_limit to NULL if you don't
- * care about the previous value.
- *
- * Returns true on error (if the new limit is not valid).
- */
-bool pa_shard_retain_grow_limit_get_set(tsdn_t *tsdn, pa_shard_t *shard,
-    size_t *old_limit, size_t *new_limit);
-
 /******************************************************************************/
 /*
  * Various bits of "boring" functionality that are still part of this module,

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -90,7 +90,7 @@ struct pa_shard_s {
 static inline bool
 pa_shard_dont_decay_muzzy(pa_shard_t *shard) {
 	return ecache_npages_get(&shard->pac.ecache_muzzy) == 0 &&
-	    pac_muzzy_decay_ms_get(&shard->pac) <= 0;
+	    pac_decay_ms_get(&shard->pac, extent_state_muzzy) <= 0;
 }
 
 static inline ehooks_t *
@@ -136,6 +136,10 @@ bool pa_shrink(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
  */
 void pa_dalloc(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata,
     bool *generated_dirty);
+
+bool pa_decay_ms_set(tsdn_t *tsdn, pa_shard_t *shard, extent_state_t state,
+    ssize_t decay_ms, pac_purge_eagerness_t eagerness);
+ssize_t pa_decay_ms_get(pa_shard_t *shard, extent_state_t state);
 
 /******************************************************************************/
 /*

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -23,9 +23,14 @@ struct pac_s {
 
 	emap_t *emap;
 	edata_cache_t *edata_cache;
+
+	/* The grow info for the retained ecache. */
+	ecache_grow_t ecache_grow;
 };
 
 bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
     edata_cache_t *edata_cache);
+bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
+    size_t *new_limit);
 
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -9,6 +9,58 @@
  * - Can use efficient OS-level zeroing primitives for demand-filled pages.
  */
 
+typedef struct pac_decay_stats_s pac_decay_stats_t;
+struct pac_decay_stats_s {
+	/* Total number of purge sweeps. */
+	locked_u64_t npurge;
+	/* Total number of madvise calls made. */
+	locked_u64_t nmadvise;
+	/* Total number of pages purged. */
+	locked_u64_t purged;
+};
+
+typedef struct pac_estats_s pac_estats_t;
+struct pac_estats_s {
+	/*
+	 * Stats for a given index in the range [0, SC_NPSIZES] in the various
+	 * ecache_ts.
+	 * We track both bytes and # of extents: two extents in the same bucket
+	 * may have different sizes if adjacent size classes differ by more than
+	 * a page, so bytes cannot always be derived from # of extents.
+	 */
+	size_t ndirty;
+	size_t dirty_bytes;
+	size_t nmuzzy;
+	size_t muzzy_bytes;
+	size_t nretained;
+	size_t retained_bytes;
+};
+
+typedef struct pac_stats_s pac_stats_t;
+struct pac_stats_s {
+	pac_decay_stats_t decay_dirty;
+	pac_decay_stats_t decay_muzzy;
+
+	/*
+	 * Number of unused virtual memory bytes currently retained.  Retained
+	 * bytes are technically mapped (though always decommitted or purged),
+	 * but they are excluded from the mapped statistic (above).
+	 */
+	size_t retained; /* Derived. */
+
+	/*
+	 * Number of bytes currently mapped, excluding retained memory (and any
+	 * base-allocated memory, which is tracked by the arena stats).
+	 *
+	 * We name this "pac_mapped" to avoid confusion with the arena_stats
+	 * "mapped".
+	 */
+	atomic_zu_t pac_mapped;
+
+	/* VM space had to be leaked (undocumented).  Normally 0. */
+	atomic_zu_t abandoned_vm;
+};
+
 typedef struct pac_s pac_t;
 struct pac_s {
 	/*
@@ -35,13 +87,18 @@ struct pac_s {
 	 */
 	decay_t decay_dirty; /* dirty --> muzzy */
 	decay_t decay_muzzy; /* muzzy --> retained */
+
+	malloc_mutex_t *stats_mtx;
+	pac_stats_t *stats;
 };
 
 bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
     edata_cache_t *edata_cache, nstime_t *cur_time, ssize_t dirty_decay_ms,
-    ssize_t muzzy_decay_ms);
+    ssize_t muzzy_decay_ms, pac_stats_t *pac_stats, malloc_mutex_t *stats_mtx);
 bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
     size_t *new_limit);
+void pac_stats_merge(tsdn_t *tsdn, pac_t *pac, pac_stats_t *pac_stats_out,
+    pac_estats_t *estats_out, size_t *resident);
 
 static inline ssize_t
 pac_dirty_decay_ms_get(pac_t *pac) {
@@ -51,6 +108,11 @@ pac_dirty_decay_ms_get(pac_t *pac) {
 static inline ssize_t
 pac_muzzy_decay_ms_get(pac_t *pac) {
 	return decay_ms_read(&pac->decay_muzzy);
+}
+
+static inline size_t
+pac_mapped(pac_t *pac) {
+	return atomic_load_zu(&pac->stats->pac_mapped, ATOMIC_RELAXED);
 }
 
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -1,6 +1,8 @@
 #ifndef JEMALLOC_INTERNAL_PAC_H
 #define JEMALLOC_INTERNAL_PAC_H
 
+#include "jemalloc/internal/pai.h"
+
 /*
  * Page allocator classic; an implementation of the PAI interface that:
  * - Can be used for arenas with custom extent hooks.
@@ -71,6 +73,11 @@ struct pac_stats_s {
 
 typedef struct pac_s pac_t;
 struct pac_s {
+	/*
+	 * Must be the first member (we convert it to a PAC given only a
+	 * pointer).  The handle to the allocation interface.
+	 */
+	pai_t pai;
 	/*
 	 * Collections of extents that were previously allocated.  These are
 	 * used when allocating extents, in an attempt to re-use address space.

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -1,0 +1,25 @@
+#ifndef JEMALLOC_INTERNAL_PAC_H
+#define JEMALLOC_INTERNAL_PAC_H
+
+/*
+ * Page allocator classic; an implementation of the PAI interface that:
+ * - Can be used for arenas with custom extent hooks.
+ * - Can always satisfy any allocation request (including highly-fragmentary
+ *   ones).
+ * - Can use efficient OS-level zeroing primitives for demand-filled pages.
+ */
+
+typedef struct pac_s pac_t;
+struct pac_s {
+	/*
+	 * Collections of extents that were previously allocated.  These are
+	 * used when allocating extents, in an attempt to re-use address space.
+	 *
+	 * Synchronization: internal.
+	 */
+	ecache_t ecache_dirty;
+	ecache_t ecache_muzzy;
+	ecache_t ecache_retained;
+};
+
+#endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -24,4 +24,7 @@ struct pac_s {
 	edata_cache_t *edata_cache;
 };
 
+bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind,
+    edata_cache_t *edata_cache);
+
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -10,12 +10,12 @@
  */
 
 /* How "eager" decay/purging should be. */
-enum pac_decay_purge_setting_e {
-	PAC_DECAY_PURGE_ALWAYS,
-	PAC_DECAY_PURGE_NEVER,
-	PAC_DECAY_PURGE_ON_EPOCH_ADVANCE
+enum pac_purge_eagerness_e {
+	PAC_PURGE_ALWAYS,
+	PAC_PURGE_NEVER,
+	PAC_PURGE_ON_EPOCH_ADVANCE
 };
-typedef enum pac_decay_purge_setting_e pac_decay_purge_setting_t;
+typedef enum pac_purge_eagerness_e pac_purge_eagerness_t;
 
 typedef struct pac_decay_stats_s pac_decay_stats_t;
 struct pac_decay_stats_s {
@@ -112,16 +112,6 @@ bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
 void pac_stats_merge(tsdn_t *tsdn, pac_t *pac, pac_stats_t *pac_stats_out,
     pac_estats_t *estats_out, size_t *resident);
 
-static inline ssize_t
-pac_dirty_decay_ms_get(pac_t *pac) {
-	return decay_ms_read(&pac->decay_dirty);
-}
-
-static inline ssize_t
-pac_muzzy_decay_ms_get(pac_t *pac) {
-	return decay_ms_read(&pac->decay_muzzy);
-}
-
 static inline size_t
 pac_mapped(pac_t *pac) {
 	return atomic_load_zu(&pac->stats->pac_mapped, ATOMIC_RELAXED);
@@ -146,7 +136,7 @@ void pac_decay_all(tsdn_t *tsdn, pac_t *pac, decay_t *decay,
  */
 bool pac_maybe_decay_purge(tsdn_t *tsdn, pac_t *pac, decay_t *decay,
     pac_decay_stats_t *decay_stats, ecache_t *ecache,
-    pac_decay_purge_setting_t decay_purge_setting);
+    pac_purge_eagerness_t eagerness);
 
 /*
  * Gets / sets the maximum amount that we'll grow an arena down the
@@ -160,4 +150,7 @@ bool pac_maybe_decay_purge(tsdn_t *tsdn, pac_t *pac, decay_t *decay,
 bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
     size_t *new_limit);
 
+bool pac_decay_ms_set(tsdn_t *tsdn, pac_t *pac, extent_state_t state,
+    ssize_t decay_ms, pac_purge_eagerness_t eagerness);
+ssize_t pac_decay_ms_get(pac_t *pac, extent_state_t state);
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -21,10 +21,11 @@ struct pac_s {
 	ecache_t ecache_muzzy;
 	ecache_t ecache_retained;
 
+	emap_t *emap;
 	edata_cache_t *edata_cache;
 };
 
-bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind,
+bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
     edata_cache_t *edata_cache);
 
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -153,4 +153,8 @@ bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
 bool pac_decay_ms_set(tsdn_t *tsdn, pac_t *pac, extent_state_t state,
     ssize_t decay_ms, pac_purge_eagerness_t eagerness);
 ssize_t pac_decay_ms_get(pac_t *pac, extent_state_t state);
+
+void pac_reset(tsdn_t *tsdn, pac_t *pac);
+void pac_destroy(tsdn_t *tsdn, pac_t *pac);
+
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -9,6 +9,14 @@
  * - Can use efficient OS-level zeroing primitives for demand-filled pages.
  */
 
+/* How "eager" decay/purging should be. */
+enum pac_decay_purge_setting_e {
+	PAC_DECAY_PURGE_ALWAYS,
+	PAC_DECAY_PURGE_NEVER,
+	PAC_DECAY_PURGE_ON_EPOCH_ADVANCE
+};
+typedef enum pac_decay_purge_setting_e pac_decay_purge_setting_t;
+
 typedef struct pac_decay_stats_s pac_decay_stats_t;
 struct pac_decay_stats_s {
 	/* Total number of purge sweeps. */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -90,6 +90,9 @@ struct pac_s {
 
 	malloc_mutex_t *stats_mtx;
 	pac_stats_t *stats;
+
+	/* Extent serial number generator state. */
+	atomic_zu_t extent_sn_next;
 };
 
 bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -26,11 +26,31 @@ struct pac_s {
 
 	/* The grow info for the retained ecache. */
 	ecache_grow_t ecache_grow;
+
+	/*
+	 * Decay-based purging state, responsible for scheduling extent state
+	 * transitions.
+	 *
+	 * Synchronization: via the internal mutex.
+	 */
+	decay_t decay_dirty; /* dirty --> muzzy */
+	decay_t decay_muzzy; /* muzzy --> retained */
 };
 
 bool pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
-    edata_cache_t *edata_cache);
+    edata_cache_t *edata_cache, nstime_t *cur_time, ssize_t dirty_decay_ms,
+    ssize_t muzzy_decay_ms);
 bool pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
     size_t *new_limit);
+
+static inline ssize_t
+pac_dirty_decay_ms_get(pac_t *pac) {
+	return decay_ms_read(&pac->decay_dirty);
+}
+
+static inline ssize_t
+pac_muzzy_decay_ms_get(pac_t *pac) {
+	return decay_ms_read(&pac->decay_muzzy);
+}
 
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -20,6 +20,8 @@ struct pac_s {
 	ecache_t ecache_dirty;
 	ecache_t ecache_muzzy;
 	ecache_t ecache_retained;
+
+	edata_cache_t *edata_cache;
 };
 
 #endif /* JEMALLOC_INTERNAL_PAC_H */

--- a/include/jemalloc/internal/pai.h
+++ b/include/jemalloc/internal/pai.h
@@ -1,0 +1,45 @@
+#ifndef JEMALLOC_INTERNAL_PAI_H
+#define JEMALLOC_INTERNAL_PAI_H
+
+/* An interface for page allocation. */
+
+typedef struct pai_s pai_t;
+struct pai_s {
+	/* Returns NULL on failure. */
+	edata_t *(*alloc)(tsdn_t *tsdn, pai_t *self, size_t size,
+	    size_t alignment, bool zero);
+	bool (*expand)(tsdn_t *tsdn, pai_t *self, edata_t *edata,
+	    size_t old_size, size_t new_size, bool zero);
+	bool (*shrink)(tsdn_t *tsdn, pai_t *self, edata_t *edata,
+	    size_t old_size, size_t new_size);
+	void (*dalloc)(tsdn_t *tsdn, pai_t *self, edata_t *edata);
+};
+
+/*
+ * These are just simple convenience functions to avoid having to reference the
+ * same pai_t twice on every invocation.
+ */
+
+static inline edata_t *
+pai_alloc(tsdn_t *tsdn, pai_t *self, size_t size, size_t alignment, bool zero) {
+	return self->alloc(tsdn, self, size, alignment, zero);
+}
+
+static inline bool
+pai_expand(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
+    size_t new_size, bool zero) {
+	return self->expand(tsdn, self, edata, old_size, new_size, zero);
+}
+
+static inline bool
+pai_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
+    size_t new_size) {
+	return self->shrink(tsdn, self, edata, old_size, new_size);
+}
+
+static inline void
+pai_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata) {
+	self->dalloc(tsdn, self, edata);
+}
+
+#endif /* JEMALLOC_INTERNAL_PAI_H */

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\..\..\src\nstime.c" />
     <ClCompile Include="..\..\..\..\src\pa.c" />
     <ClCompile Include="..\..\..\..\src\pa_extra.c" />
+    <ClCompile Include="..\..\..\..\src\pac.c" />
     <ClCompile Include="..\..\..\..\src\pages.c" />
     <ClCompile Include="..\..\..\..\src\peak_event.c" />
     <ClCompile Include="..\..\..\..\src\prof.c" />

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -88,6 +88,9 @@
     <ClCompile Include="..\..\..\..\src\pa_extra.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\pac.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\pages.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\..\..\src\nstime.c" />
     <ClCompile Include="..\..\..\..\src\pa.c" />
     <ClCompile Include="..\..\..\..\src\pa_extra.c" />
+    <ClCompile Include="..\..\..\..\src\pac.c" />
     <ClCompile Include="..\..\..\..\src\pages.c" />
     <ClCompile Include="..\..\..\..\src\peak_event.c" />
     <ClCompile Include="..\..\..\..\src\prof.c" />

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
@@ -88,6 +88,9 @@
     <ClCompile Include="..\..\..\..\src\pa_extra.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\pac.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\pages.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/arena.c
+++ b/src/arena.c
@@ -410,14 +410,14 @@ arena_muzzy_decay_ms_get(arena_t *arena) {
  * specifically requested it), should we purge ourselves, or wait for the
  * background thread to get to it.
  */
-static pa_decay_purge_setting_t
+static pac_decay_purge_setting_t
 arena_decide_unforced_decay_purge_setting(bool is_background_thread) {
 	if (is_background_thread) {
-		return PA_DECAY_PURGE_ALWAYS;
+		return PAC_DECAY_PURGE_ALWAYS;
 	} else if (!is_background_thread && background_thread_enabled()) {
-		return PA_DECAY_PURGE_NEVER;
+		return PAC_DECAY_PURGE_NEVER;
 	} else {
-		return PA_DECAY_PURGE_ON_EPOCH_ADVANCE;
+		return PAC_DECAY_PURGE_ON_EPOCH_ADVANCE;
 	}
 }
 
@@ -440,7 +440,7 @@ arena_decay_ms_set(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 	nstime_t cur_time;
 	nstime_init_update(&cur_time);
 	decay_reinit(decay, &cur_time, decay_ms);
-	pa_decay_purge_setting_t decay_purge =
+	pac_decay_purge_setting_t decay_purge =
 	    arena_decide_unforced_decay_purge_setting(
 		/* is_background_thread */ false);
 	pa_maybe_decay_purge(tsdn, &arena->pa_shard, decay, decay_stats, ecache,
@@ -497,7 +497,7 @@ arena_decay_impl(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 		/* No need to wait if another thread is in progress. */
 		return true;
 	}
-	pa_decay_purge_setting_t decay_purge =
+	pac_decay_purge_setting_t decay_purge =
 	    arena_decide_unforced_decay_purge_setting(is_background_thread);
 	bool epoch_advanced = pa_maybe_decay_purge(tsdn, &arena->pa_shard,
 	    decay, decay_stats, ecache, decay_purge);

--- a/src/arena.c
+++ b/src/arena.c
@@ -397,12 +397,12 @@ arena_extent_ralloc_large_expand(tsdn_t *tsdn, arena_t *arena, edata_t *edata,
 
 ssize_t
 arena_dirty_decay_ms_get(arena_t *arena) {
-	return pa_shard_dirty_decay_ms_get(&arena->pa_shard);
+	return pac_dirty_decay_ms_get(&arena->pa_shard.pac);
 }
 
 ssize_t
 arena_muzzy_decay_ms_get(arena_t *arena) {
-	return pa_shard_muzzy_decay_ms_get(&arena->pa_shard);
+	return pac_muzzy_decay_ms_get(&arena->pa_shard.pac);
 }
 
 /*
@@ -453,7 +453,7 @@ arena_decay_ms_set(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 bool
 arena_dirty_decay_ms_set(tsdn_t *tsdn, arena_t *arena,
     ssize_t decay_ms) {
-	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.decay_dirty,
+	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.pac.decay_dirty,
 	    &arena->pa_shard.stats->decay_dirty,
 	    &arena->pa_shard.pac.ecache_dirty, decay_ms);
 }
@@ -461,7 +461,7 @@ arena_dirty_decay_ms_set(tsdn_t *tsdn, arena_t *arena,
 bool
 arena_muzzy_decay_ms_set(tsdn_t *tsdn, arena_t *arena,
     ssize_t decay_ms) {
-	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.decay_muzzy,
+	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.pac.decay_muzzy,
 	    &arena->pa_shard.stats->decay_muzzy,
 	    &arena->pa_shard.pac.ecache_muzzy, decay_ms);
 }
@@ -520,7 +520,7 @@ arena_decay_impl(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 static bool
 arena_decay_dirty(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
     bool all) {
-	return arena_decay_impl(tsdn, arena, &arena->pa_shard.decay_dirty,
+	return arena_decay_impl(tsdn, arena, &arena->pa_shard.pac.decay_dirty,
 	    &arena->pa_shard.stats->decay_dirty,
 	    &arena->pa_shard.pac.ecache_dirty, is_background_thread, all);
 }
@@ -531,7 +531,7 @@ arena_decay_muzzy(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
 	if (pa_shard_dont_decay_muzzy(&arena->pa_shard)) {
 		return false;
 	}
-	return arena_decay_impl(tsdn, arena, &arena->pa_shard.decay_muzzy,
+	return arena_decay_impl(tsdn, arena, &arena->pa_shard.pac.decay_muzzy,
 	    &arena->pa_shard.stats->decay_muzzy,
 	    &arena->pa_shard.pac.ecache_muzzy, is_background_thread, all);
 }

--- a/src/arena.c
+++ b/src/arena.c
@@ -645,7 +645,7 @@ arena_destroy(tsd_t *tsd, arena_t *arena) {
 	 * extents, so only retained extents may remain and it's safe to call
 	 * pa_shard_destroy_retained.
 	 */
-	pa_shard_destroy_retained(tsd_tsdn(tsd), &arena->pa_shard);
+	pa_shard_destroy(tsd_tsdn(tsd), &arena->pa_shard);
 
 	/*
 	 * Remove the arena pointer from the arenas array.  We rely on the fact

--- a/src/arena.c
+++ b/src/arena.c
@@ -454,16 +454,16 @@ bool
 arena_dirty_decay_ms_set(tsdn_t *tsdn, arena_t *arena,
     ssize_t decay_ms) {
 	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.decay_dirty,
-	    &arena->pa_shard.stats->decay_dirty, &arena->pa_shard.ecache_dirty,
-	    decay_ms);
+	    &arena->pa_shard.stats->decay_dirty,
+	    &arena->pa_shard.pac.ecache_dirty, decay_ms);
 }
 
 bool
 arena_muzzy_decay_ms_set(tsdn_t *tsdn, arena_t *arena,
     ssize_t decay_ms) {
 	return arena_decay_ms_set(tsdn, arena, &arena->pa_shard.decay_muzzy,
-	    &arena->pa_shard.stats->decay_muzzy, &arena->pa_shard.ecache_muzzy,
-	    decay_ms);
+	    &arena->pa_shard.stats->decay_muzzy,
+	    &arena->pa_shard.pac.ecache_muzzy, decay_ms);
 }
 
 static bool
@@ -521,8 +521,8 @@ static bool
 arena_decay_dirty(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
     bool all) {
 	return arena_decay_impl(tsdn, arena, &arena->pa_shard.decay_dirty,
-	    &arena->pa_shard.stats->decay_dirty, &arena->pa_shard.ecache_dirty,
-	    is_background_thread, all);
+	    &arena->pa_shard.stats->decay_dirty,
+	    &arena->pa_shard.pac.ecache_dirty, is_background_thread, all);
 }
 
 static bool
@@ -532,8 +532,8 @@ arena_decay_muzzy(tsdn_t *tsdn, arena_t *arena, bool is_background_thread,
 		return false;
 	}
 	return arena_decay_impl(tsdn, arena, &arena->pa_shard.decay_muzzy,
-	    &arena->pa_shard.stats->decay_muzzy, &arena->pa_shard.ecache_muzzy,
-	    is_background_thread, all);
+	    &arena->pa_shard.stats->decay_muzzy,
+	    &arena->pa_shard.pac.ecache_muzzy, is_background_thread, all);
 }
 
 void

--- a/src/arena.c
+++ b/src/arena.c
@@ -443,8 +443,8 @@ arena_decay_ms_set(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 	pac_decay_purge_setting_t decay_purge =
 	    arena_decide_unforced_decay_purge_setting(
 		/* is_background_thread */ false);
-	pa_maybe_decay_purge(tsdn, &arena->pa_shard, decay, decay_stats, ecache,
-	    decay_purge);
+	pac_maybe_decay_purge(tsdn, &arena->pa_shard.pac, decay, decay_stats,
+	    ecache, decay_purge);
 	malloc_mutex_unlock(tsdn, &decay->mtx);
 
 	return false;
@@ -472,8 +472,8 @@ arena_decay_impl(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
     bool is_background_thread, bool all) {
 	if (all) {
 		malloc_mutex_lock(tsdn, &decay->mtx);
-		pa_decay_all(tsdn, &arena->pa_shard, decay, decay_stats, ecache,
-		    /* fully_decay */ all);
+		pac_decay_all(tsdn, &arena->pa_shard.pac, decay, decay_stats,
+		    ecache, /* fully_decay */ all);
 		malloc_mutex_unlock(tsdn, &decay->mtx);
 		/*
 		 * The previous pa_decay_all call may not have actually decayed
@@ -499,7 +499,7 @@ arena_decay_impl(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 	}
 	pac_decay_purge_setting_t decay_purge =
 	    arena_decide_unforced_decay_purge_setting(is_background_thread);
-	bool epoch_advanced = pa_maybe_decay_purge(tsdn, &arena->pa_shard,
+	bool epoch_advanced = pac_maybe_decay_purge(tsdn, &arena->pa_shard.pac,
 	    decay, decay_stats, ecache, decay_purge);
 	size_t npages_new;
 	if (epoch_advanced) {
@@ -1401,8 +1401,8 @@ bool
 arena_retain_grow_limit_get_set(tsd_t *tsd, arena_t *arena, size_t *old_limit,
     size_t *new_limit) {
 	assert(opt_retain);
-	return pa_shard_retain_grow_limit_get_set(tsd_tsdn(tsd),
-	    &arena->pa_shard, old_limit, new_limit);
+	return pac_retain_grow_limit_get_set(tsd_tsdn(tsd),
+	    &arena->pa_shard.pac, old_limit, new_limit);
 }
 
 unsigned

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -201,12 +201,12 @@ static uint64_t
 arena_decay_compute_purge_interval(tsdn_t *tsdn, arena_t *arena) {
 	uint64_t i1, i2;
 	i1 = arena_decay_compute_purge_interval_impl(tsdn,
-	    &arena->pa_shard.decay_dirty, &arena->pa_shard.ecache_dirty);
+	    &arena->pa_shard.decay_dirty, &arena->pa_shard.pac.ecache_dirty);
 	if (i1 == BACKGROUND_THREAD_MIN_INTERVAL_NS) {
 		return i1;
 	}
 	i2 = arena_decay_compute_purge_interval_impl(tsdn,
-	    &arena->pa_shard.decay_muzzy, &arena->pa_shard.ecache_muzzy);
+	    &arena->pa_shard.decay_muzzy, &arena->pa_shard.pac.ecache_muzzy);
 
 	return i1 < i2 ? i1 : i2;
 }
@@ -716,8 +716,8 @@ background_thread_interval_check(tsdn_t *tsdn, arena_t *arena, decay_t *decay,
 	if (info->npages_to_purge_new > BACKGROUND_THREAD_NPAGES_THRESHOLD) {
 		should_signal = true;
 	} else if (unlikely(background_thread_indefinite_sleep(info)) &&
-	    (ecache_npages_get(&arena->pa_shard.ecache_dirty) > 0 ||
-	    ecache_npages_get(&arena->pa_shard.ecache_muzzy) > 0 ||
+	    (ecache_npages_get(&arena->pa_shard.pac.ecache_dirty) > 0 ||
+	    ecache_npages_get(&arena->pa_shard.pac.ecache_muzzy) > 0 ||
 	    info->npages_to_purge_new > 0)) {
 		should_signal = true;
 	} else {

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -201,12 +201,12 @@ static uint64_t
 arena_decay_compute_purge_interval(tsdn_t *tsdn, arena_t *arena) {
 	uint64_t i1, i2;
 	i1 = arena_decay_compute_purge_interval_impl(tsdn,
-	    &arena->pa_shard.decay_dirty, &arena->pa_shard.pac.ecache_dirty);
+	    &arena->pa_shard.pac.decay_dirty, &arena->pa_shard.pac.ecache_dirty);
 	if (i1 == BACKGROUND_THREAD_MIN_INTERVAL_NS) {
 		return i1;
 	}
 	i2 = arena_decay_compute_purge_interval_impl(tsdn,
-	    &arena->pa_shard.decay_muzzy, &arena->pa_shard.pac.ecache_muzzy);
+	    &arena->pa_shard.pac.decay_muzzy, &arena->pa_shard.pac.ecache_muzzy);
 
 	return i1 < i2 ? i1 : i2;
 }

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2430,10 +2430,10 @@ arena_i_decay_ms_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
 		ret = EFAULT;
 		goto label_return;
 	}
+	extent_state_t state = dirty ? extent_state_dirty : extent_state_muzzy;
 
 	if (oldp != NULL && oldlenp != NULL) {
-		size_t oldval = dirty ? arena_dirty_decay_ms_get(arena) :
-		    arena_muzzy_decay_ms_get(arena);
+		size_t oldval = arena_decay_ms_get(arena, state);
 		READ(oldval, ssize_t);
 	}
 	if (newp != NULL) {
@@ -2452,9 +2452,9 @@ arena_i_decay_ms_ctl_impl(tsd_t *tsd, const size_t *mib, size_t miblen,
 				goto label_return;
 			}
 		}
-		if (dirty ? arena_dirty_decay_ms_set(tsd_tsdn(tsd), arena,
-		    *(ssize_t *)newp) : arena_muzzy_decay_ms_set(tsd_tsdn(tsd),
-		    arena, *(ssize_t *)newp)) {
+
+		if (arena_decay_ms_set(tsd_tsdn(tsd), arena, state,
+		    *(ssize_t *)newp)) {
 			ret = EFAULT;
 			goto label_return;
 		}

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3130,8 +3130,8 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib,
 		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_dirty.mtx);
 		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_muzzy.mtx);
 		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_retained.mtx);
-		MUTEX_PROF_RESET(arena->pa_shard.decay_dirty.mtx);
-		MUTEX_PROF_RESET(arena->pa_shard.decay_muzzy.mtx);
+		MUTEX_PROF_RESET(arena->pa_shard.pac.decay_dirty.mtx);
+		MUTEX_PROF_RESET(arena->pa_shard.pac.decay_muzzy.mtx);
 		MUTEX_PROF_RESET(arena->tcache_ql_mtx);
 		MUTEX_PROF_RESET(arena->base->mtx);
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3127,9 +3127,9 @@ stats_mutexes_reset_ctl(tsd_t *tsd, const size_t *mib,
 		}
 		MUTEX_PROF_RESET(arena->large_mtx);
 		MUTEX_PROF_RESET(arena->pa_shard.edata_cache.mtx);
-		MUTEX_PROF_RESET(arena->pa_shard.ecache_dirty.mtx);
-		MUTEX_PROF_RESET(arena->pa_shard.ecache_muzzy.mtx);
-		MUTEX_PROF_RESET(arena->pa_shard.ecache_retained.mtx);
+		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_dirty.mtx);
+		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_muzzy.mtx);
+		MUTEX_PROF_RESET(arena->pa_shard.pac.ecache_retained.mtx);
 		MUTEX_PROF_RESET(arena->pa_shard.decay_dirty.mtx);
 		MUTEX_PROF_RESET(arena->pa_shard.decay_muzzy.mtx);
 		MUTEX_PROF_RESET(arena->tcache_ql_mtx);

--- a/src/extent.c
+++ b/src/extent.c
@@ -55,8 +55,8 @@ extent_sn_next(pac_t *pac) {
 
 static inline bool
 extent_may_force_decay(pac_t *pac) {
-	return !(pac_dirty_decay_ms_get(pac) == -1
-	    || pac_muzzy_decay_ms_get(pac) == -1);
+	return !(pac_decay_ms_get(pac, extent_state_dirty) == -1
+	    || pac_decay_ms_get(pac, extent_state_muzzy) == -1);
 }
 
 static bool

--- a/src/extent.c
+++ b/src/extent.c
@@ -196,7 +196,7 @@ extents_abandon_vm(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
     ecache_t *ecache, edata_t *edata, bool growing_retained) {
 	size_t sz = edata_size_get(edata);
 	if (config_stats) {
-		atomic_fetch_add_zu(&shard->stats->abandoned_vm, sz,
+		atomic_fetch_add_zu(&shard->pac.stats->abandoned_vm, sz,
 		    ATOMIC_RELAXED);
 	}
 	/*
@@ -938,20 +938,19 @@ extent_maximally_purge(tsdn_t *tsdn, pa_shard_t *shard, ehooks_t *ehooks,
 	extent_dalloc_wrapper(tsdn, shard, ehooks, edata);
 	if (config_stats) {
 		/* Update stats accordingly. */
-		LOCKEDINT_MTX_LOCK(tsdn, *shard->stats_mtx);
+		LOCKEDINT_MTX_LOCK(tsdn, *shard->pac.stats_mtx);
 		locked_inc_u64(tsdn,
-		    LOCKEDINT_MTX(*shard->stats_mtx),
-		    &shard->stats->decay_dirty.nmadvise, 1);
+		    LOCKEDINT_MTX(*shard->pac.stats_mtx),
+		    &shard->pac.stats->decay_dirty.nmadvise, 1);
 		locked_inc_u64(tsdn,
-		    LOCKEDINT_MTX(*shard->stats_mtx),
-		    &shard->stats->decay_dirty.purged,
+		    LOCKEDINT_MTX(*shard->pac.stats_mtx),
+		    &shard->pac.stats->decay_dirty.purged,
 		    extent_size >> LG_PAGE);
-		LOCKEDINT_MTX_UNLOCK(tsdn, *shard->stats_mtx);
-		atomic_fetch_sub_zu(&shard->stats->pa_mapped, extent_size,
+		LOCKEDINT_MTX_UNLOCK(tsdn, *shard->pac.stats_mtx);
+		atomic_fetch_sub_zu(&shard->pac.stats->pac_mapped, extent_size,
 		    ATOMIC_RELAXED);
 	}
 }
-
 
 /*
  * Does the metadata management portions of putting an unused extent into the

--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -154,9 +154,10 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 			if (gap_size_page != 0) {
 				edata_init(gap, arena_ind_get(arena),
 				    gap_addr_page, gap_size_page, false,
-				    SC_NSIZES, pa_shard_extent_sn_next(
-					&arena->pa_shard), extent_state_active,
-				    false, true, false, EXTENT_NOT_HEAD);
+				    SC_NSIZES, extent_sn_next(
+					&arena->pa_shard.pac),
+				    extent_state_active, false, true, false,
+				    EXTENT_NOT_HEAD);
 			}
 			/*
 			 * Compute the address just past the end of the desired

--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -189,7 +189,7 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 					ehooks_t *ehooks = arena_get_ehooks(
 					    arena);
 					extent_dalloc_gap(tsdn,
-					    &arena->pa_shard, ehooks, gap);
+					    &arena->pa_shard.pac, ehooks, gap);
 				} else {
 					edata_cache_put(tsdn,
 					    &arena->pa_shard.edata_cache, gap);

--- a/src/pa.c
+++ b/src/pa.c
@@ -1,14 +1,6 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
-static edata_t *ecache_pai_alloc(tsdn_t *tsdn, pai_t *self, size_t size,
-    size_t alignment, bool zero);
-static bool ecache_pai_expand(tsdn_t *tsdn, pai_t *self, edata_t *edata,
-    size_t old_size, size_t new_size, bool zero);
-static bool ecache_pai_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata,
-    size_t old_size, size_t new_size);
-static void ecache_pai_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata);
-
 static void
 pa_nactive_add(pa_shard_t *shard, size_t add_pages) {
 	atomic_fetch_add_zu(&shard->nactive, add_pages, ATOMIC_RELAXED);
@@ -44,11 +36,6 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 	shard->emap = emap;
 	shard->base = base;
 
-	shard->ecache_pai.alloc = &ecache_pai_alloc;
-	shard->ecache_pai.expand = &ecache_pai_expand;
-	shard->ecache_pai.shrink = &ecache_pai_shrink;
-	shard->ecache_pai.dalloc = &ecache_pai_dalloc;
-
 	return false;
 }
 
@@ -62,43 +49,13 @@ pa_shard_destroy(tsdn_t *tsdn, pa_shard_t *shard) {
 	pac_destroy(tsdn, &shard->pac);
 }
 
-static inline bool
-pa_shard_may_have_muzzy(pa_shard_t *shard) {
-	return pac_decay_ms_get(&shard->pac, extent_state_muzzy) != 0;
-}
-
-static edata_t *
-ecache_pai_alloc(tsdn_t *tsdn, pai_t *self, size_t size, size_t alignment,
-    bool zero) {
-	pa_shard_t *shard =
-	    (pa_shard_t *)((uintptr_t)self - offsetof(pa_shard_t, ecache_pai));
-
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-	edata_t *edata = ecache_alloc(tsdn, &shard->pac, ehooks,
-	    &shard->pac.ecache_dirty, NULL, size, alignment, zero);
-
-	if (edata == NULL && pa_shard_may_have_muzzy(shard)) {
-		edata = ecache_alloc(tsdn, &shard->pac, ehooks,
-		    &shard->pac.ecache_muzzy, NULL, size, alignment, zero);
-	}
-	if (edata == NULL) {
-		edata = ecache_alloc_grow(tsdn, &shard->pac, ehooks,
-		    &shard->pac.ecache_retained, NULL, size, alignment, zero);
-		if (config_stats && edata != NULL) {
-			atomic_fetch_add_zu(&shard->pac.stats->pac_mapped, size,
-			    ATOMIC_RELAXED);
-		}
-	}
-	return edata;
-}
-
 edata_t *
 pa_alloc(tsdn_t *tsdn, pa_shard_t *shard, size_t size, size_t alignment,
     bool slab, szind_t szind, bool zero) {
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	edata_t *edata = pai_alloc(tsdn, &shard->ecache_pai, size, alignment,
+	edata_t *edata = pai_alloc(tsdn, &shard->pac.pai, size, alignment,
 	    zero);
 
 	if (edata != NULL) {
@@ -113,48 +70,6 @@ pa_alloc(tsdn_t *tsdn, pa_shard_t *shard, size_t size, size_t alignment,
 	return edata;
 }
 
-static bool
-ecache_pai_expand(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
-    size_t new_size, bool zero) {
-	pa_shard_t *shard =
-	    (pa_shard_t *)((uintptr_t)self - offsetof(pa_shard_t, ecache_pai));
-
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-	void *trail_begin = edata_past_get(edata);
-
-	size_t mapped_add = 0;
-	size_t expand_amount = new_size - old_size;
-
-	if (ehooks_merge_will_fail(ehooks)) {
-		return true;
-	}
-	edata_t *trail = ecache_alloc(tsdn, &shard->pac, ehooks,
-	    &shard->pac.ecache_dirty, trail_begin, expand_amount, PAGE, zero);
-	if (trail == NULL) {
-		trail = ecache_alloc(tsdn, &shard->pac, ehooks,
-		    &shard->pac.ecache_muzzy, trail_begin, expand_amount, PAGE,
-		    zero);
-	}
-	if (trail == NULL) {
-		trail = ecache_alloc_grow(tsdn, &shard->pac, ehooks,
-		    &shard->pac.ecache_retained, trail_begin, expand_amount,
-		    PAGE, zero);
-		mapped_add = expand_amount;
-	}
-	if (trail == NULL) {
-		return true;
-	}
-	if (extent_merge_wrapper(tsdn, &shard->pac, ehooks, edata, trail)) {
-		extent_dalloc_wrapper(tsdn, &shard->pac, ehooks, trail);
-		return true;
-	}
-	if (config_stats && mapped_add > 0) {
-		atomic_fetch_add_zu(&shard->pac.stats->pac_mapped, mapped_add,
-		    ATOMIC_RELAXED);
-	}
-	return false;
-}
-
 bool
 pa_expand(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
     size_t new_size, szind_t szind, bool zero) {
@@ -164,7 +79,7 @@ pa_expand(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
 
 	size_t expand_amount = new_size - old_size;
 
-	bool error = pai_expand(tsdn, &shard->ecache_pai, edata, old_size,
+	bool error = pai_expand(tsdn, &shard->pac.pai, edata, old_size,
 	    new_size, zero);
 	if (error) {
 		return true;
@@ -173,30 +88,6 @@ pa_expand(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
 	pa_nactive_add(shard, expand_amount >> LG_PAGE);
 	edata_szind_set(edata, szind);
 	emap_remap(tsdn, shard->emap, edata, szind, /* slab */ false);
-	return false;
-}
-
-static bool
-ecache_pai_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
-    size_t new_size) {
-	pa_shard_t *shard =
-	    (pa_shard_t *)((uintptr_t)self - offsetof(pa_shard_t, ecache_pai));
-
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-	size_t shrink_amount = old_size - new_size;
-
-
-	if (ehooks_split_will_fail(ehooks)) {
-		return true;
-	}
-
-	edata_t *trail = extent_split_wrapper(tsdn, &shard->pac, ehooks, edata,
-	    new_size, shrink_amount);
-	if (trail == NULL) {
-		return true;
-	}
-	ecache_dalloc(tsdn, &shard->pac, ehooks, &shard->pac.ecache_dirty,
-	    trail);
 	return false;
 }
 
@@ -209,7 +100,7 @@ pa_shrink(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
 	size_t shrink_amount = old_size - new_size;
 
 	*generated_dirty = false;
-	bool error = pai_shrink(tsdn, &shard->ecache_pai, edata, old_size,
+	bool error = pai_shrink(tsdn, &shard->pac.pai, edata, old_size,
 	    new_size);
 	if (error) {
 		return true;
@@ -222,15 +113,6 @@ pa_shrink(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata, size_t old_size,
 	return false;
 }
 
-static void
-ecache_pai_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata) {
-	pa_shard_t *shard =
-	    (pa_shard_t *)((uintptr_t)self - offsetof(pa_shard_t, ecache_pai));
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-	ecache_dalloc(tsdn, &shard->pac, ehooks, &shard->pac.ecache_dirty,
-	    edata);
-}
-
 void
 pa_dalloc(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata,
     bool *generated_dirty) {
@@ -241,136 +123,8 @@ pa_dalloc(tsdn_t *tsdn, pa_shard_t *shard, edata_t *edata,
 	}
 	edata_szind_set(edata, SC_NSIZES);
 	pa_nactive_sub(shard, edata_size_get(edata) >> LG_PAGE);
-	pai_dalloc(tsdn, &shard->ecache_pai, edata);
+	pai_dalloc(tsdn, &shard->pac.pai, edata);
 	*generated_dirty = true;
-}
-
-static size_t
-pa_stash_decayed(tsdn_t *tsdn, pa_shard_t *shard, ecache_t *ecache,
-    size_t npages_limit, size_t npages_decay_max,
-    edata_list_inactive_t *result) {
-	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
-	    WITNESS_RANK_CORE, 0);
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-
-	/* Stash extents according to npages_limit. */
-	size_t nstashed = 0;
-	while (nstashed < npages_decay_max) {
-		edata_t *edata = ecache_evict(tsdn, &shard->pac, ehooks, ecache,
-		    npages_limit);
-		if (edata == NULL) {
-			break;
-		}
-		edata_list_inactive_append(result, edata);
-		nstashed += edata_size_get(edata) >> LG_PAGE;
-	}
-	return nstashed;
-}
-
-static size_t
-pa_decay_stashed(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
-    pac_decay_stats_t *decay_stats, ecache_t *ecache, bool fully_decay,
-    edata_list_inactive_t *decay_extents) {
-	bool err;
-
-	size_t nmadvise = 0;
-	size_t nunmapped = 0;
-	size_t npurged = 0;
-
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-
-	bool try_muzzy = !fully_decay && pa_shard_may_have_muzzy(shard);
-
-	for (edata_t *edata = edata_list_inactive_first(decay_extents);
-	    edata != NULL; edata = edata_list_inactive_first(decay_extents)) {
-		edata_list_inactive_remove(decay_extents, edata);
-
-		size_t size = edata_size_get(edata);
-		size_t npages = size >> LG_PAGE;
-
-		nmadvise++;
-		npurged += npages;
-
-		switch (ecache->state) {
-		case extent_state_active:
-			not_reached();
-		case extent_state_dirty:
-			if (try_muzzy) {
-				err = extent_purge_lazy_wrapper(tsdn, ehooks,
-				    edata, /* offset */ 0, size);
-				if (!err) {
-					ecache_dalloc(tsdn, &shard->pac, ehooks,
-					    &shard->pac.ecache_muzzy, edata);
-					break;
-				}
-			}
-			JEMALLOC_FALLTHROUGH;
-		case extent_state_muzzy:
-			extent_dalloc_wrapper(tsdn, &shard->pac, ehooks, edata);
-			nunmapped += npages;
-			break;
-		case extent_state_retained:
-		default:
-			not_reached();
-		}
-	}
-
-	if (config_stats) {
-		LOCKEDINT_MTX_LOCK(tsdn, *shard->stats_mtx);
-		locked_inc_u64(tsdn, LOCKEDINT_MTX(*shard->stats_mtx),
-		    &decay_stats->npurge, 1);
-		locked_inc_u64(tsdn, LOCKEDINT_MTX(*shard->stats_mtx),
-		    &decay_stats->nmadvise, nmadvise);
-		locked_inc_u64(tsdn, LOCKEDINT_MTX(*shard->stats_mtx),
-		    &decay_stats->purged, npurged);
-		LOCKEDINT_MTX_UNLOCK(tsdn, *shard->stats_mtx);
-		atomic_fetch_sub_zu(&shard->pac.stats->pac_mapped,
-		    nunmapped << LG_PAGE, ATOMIC_RELAXED);
-	}
-
-	return npurged;
-}
-
-/*
- * npages_limit: Decay at most npages_decay_max pages without violating the
- * invariant: (ecache_npages_get(ecache) >= npages_limit).  We need an upper
- * bound on number of pages in order to prevent unbounded growth (namely in
- * stashed), otherwise unbounded new pages could be added to extents during the
- * current decay run, so that the purging thread never finishes.
- */
-static void
-pa_decay_to_limit(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
-    pac_decay_stats_t *decay_stats, ecache_t *ecache, bool fully_decay,
-    size_t npages_limit, size_t npages_decay_max) {
-	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
-	    WITNESS_RANK_CORE, 1);
-
-	if (decay->purging || npages_decay_max == 0) {
-		return;
-	}
-	decay->purging = true;
-	malloc_mutex_unlock(tsdn, &decay->mtx);
-
-	edata_list_inactive_t decay_extents;
-	edata_list_inactive_init(&decay_extents);
-	size_t npurge = pa_stash_decayed(tsdn, shard, ecache, npages_limit,
-	    npages_decay_max, &decay_extents);
-	if (npurge != 0) {
-		size_t npurged = pa_decay_stashed(tsdn, shard, decay,
-		    decay_stats, ecache, fully_decay, &decay_extents);
-		assert(npurged == npurge);
-	}
-
-	malloc_mutex_lock(tsdn, &decay->mtx);
-	decay->purging = false;
-}
-
-void
-pa_decay_all(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
-    pac_decay_stats_t *decay_stats, ecache_t *ecache, bool fully_decay) {
-	malloc_mutex_assert_owner(tsdn, &decay->mtx);
-	pa_decay_to_limit(tsdn, shard, decay, decay_stats, ecache, fully_decay,
-	    /* npages_limit */ 0, ecache_npages_get(ecache));
 }
 
 bool

--- a/src/pa.c
+++ b/src/pa.c
@@ -35,7 +35,6 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 		return true;
 	}
 
-	atomic_store_zu(&shard->extent_sn_next, 0, ATOMIC_RELAXED);
 	atomic_store_zu(&shard->nactive, 0, ATOMIC_RELAXED);
 
 	shard->stats_mtx = stats_mtx;
@@ -77,11 +76,6 @@ pa_shard_destroy_retained(tsdn_t *tsdn, pa_shard_t *shard) {
 	    &shard->pac.ecache_retained, 0)) != NULL) {
 		extent_destroy_wrapper(tsdn, shard, ehooks, edata);
 	}
-}
-
-size_t
-pa_shard_extent_sn_next(pa_shard_t *shard) {
-	return atomic_fetch_add_zu(&shard->extent_sn_next, 1, ATOMIC_RELAXED);
 }
 
 static bool

--- a/src/pa.c
+++ b/src/pa.c
@@ -29,14 +29,8 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 	if (edata_cache_init(&shard->edata_cache, base)) {
 		return true;
 	}
-	if (pac_init(tsdn, &shard->pac, ind, emap, &shard->edata_cache)) {
-		return true;
-	}
-
-	if (decay_init(&shard->decay_dirty, cur_time, dirty_decay_ms)) {
-		return true;
-	}
-	if (decay_init(&shard->decay_muzzy, cur_time, muzzy_decay_ms)) {
+	if (pac_init(tsdn, &shard->pac, ind, emap, &shard->edata_cache,
+	    cur_time, dirty_decay_ms, muzzy_decay_ms)) {
 		return true;
 	}
 
@@ -91,7 +85,7 @@ pa_shard_extent_sn_next(pa_shard_t *shard) {
 
 static bool
 pa_shard_may_have_muzzy(pa_shard_t *shard) {
-	return pa_shard_muzzy_decay_ms_get(shard) != 0;
+	return pac_muzzy_decay_ms_get(&shard->pac) != 0;
 }
 
 static edata_t *

--- a/src/pa.c
+++ b/src/pa.c
@@ -26,39 +26,12 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
     nstime_t *cur_time, ssize_t dirty_decay_ms, ssize_t muzzy_decay_ms) {
 	/* This will change eventually, but for now it should hold. */
 	assert(base_ind_get(base) == ind);
-	/*
-	 * Delay coalescing for dirty extents despite the disruptive effect on
-	 * memory layout for best-fit extent allocation, since cached extents
-	 * are likely to be reused soon after deallocation, and the cost of
-	 * merging/splitting extents is non-trivial.
-	 */
-	if (ecache_init(tsdn, &shard->pac.ecache_dirty, extent_state_dirty, ind,
-	    /* delay_coalesce */ true)) {
-		return true;
-	}
-	/*
-	 * Coalesce muzzy extents immediately, because operations on them are in
-	 * the critical path much less often than for dirty extents.
-	 */
-	if (ecache_init(tsdn, &shard->pac.ecache_muzzy, extent_state_muzzy, ind,
-	    /* delay_coalesce */ false)) {
-		return true;
-	}
-	/*
-	 * Coalesce retained extents immediately, in part because they will
-	 * never be evicted (and therefore there's no opportunity for delayed
-	 * coalescing), but also because operations on retained extents are not
-	 * in the critical path.
-	 */
-	if (ecache_init(tsdn, &shard->pac.ecache_retained, extent_state_retained,
-	    ind, /* delay_coalesce */ false)) {
-		return true;
-	}
 	if (edata_cache_init(&shard->edata_cache, base)) {
 		return true;
 	}
-	shard->pac.edata_cache = &shard->edata_cache;
-
+	if (pac_init(tsdn, &shard->pac, ind, &shard->edata_cache)) {
+		return true;
+	}
 	if (ecache_grow_init(tsdn, &shard->ecache_grow)) {
 		return true;
 	}

--- a/src/pa.c
+++ b/src/pa.c
@@ -57,6 +57,7 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 	if (edata_cache_init(&shard->edata_cache, base)) {
 		return true;
 	}
+	shard->pac.edata_cache = &shard->edata_cache;
 
 	if (ecache_grow_init(tsdn, &shard->ecache_grow)) {
 		return true;

--- a/src/pa.c
+++ b/src/pa.c
@@ -29,7 +29,7 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 	if (edata_cache_init(&shard->edata_cache, base)) {
 		return true;
 	}
-	if (pac_init(tsdn, &shard->pac, ind, emap, &shard->edata_cache,
+	if (pac_init(tsdn, &shard->pac, base, emap, &shard->edata_cache,
 	    cur_time, dirty_decay_ms, muzzy_decay_ms, &stats->pac_stats,
 	    stats_mtx)) {
 		return true;

--- a/src/pa.c
+++ b/src/pa.c
@@ -403,7 +403,7 @@ pa_decay_try_purge(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
 bool
 pa_maybe_decay_purge(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
     pac_decay_stats_t *decay_stats, ecache_t *ecache,
-    pa_decay_purge_setting_t decay_purge_setting) {
+    pac_decay_purge_setting_t decay_purge_setting) {
 	malloc_mutex_assert_owner(tsdn, &decay->mtx);
 
 	/* Purge all or nothing if the option is disabled. */
@@ -429,9 +429,9 @@ pa_maybe_decay_purge(tsdn_t *tsdn, pa_shard_t *shard, decay_t *decay,
 	size_t npages_current = ecache_npages_get(ecache);
 	bool epoch_advanced = decay_maybe_advance_epoch(decay, &time,
 	    npages_current);
-	if (decay_purge_setting == PA_DECAY_PURGE_ALWAYS
+	if (decay_purge_setting == PAC_DECAY_PURGE_ALWAYS
 	    || (epoch_advanced && decay_purge_setting
-	    == PA_DECAY_PURGE_ON_EPOCH_ADVANCE)) {
+	    == PAC_DECAY_PURGE_ON_EPOCH_ADVANCE)) {
 		size_t npages_limit = decay_npages_limit_get(decay);
 		pa_decay_try_purge(tsdn, shard, decay, decay_stats, ecache,
 		    npages_current, npages_limit);

--- a/src/pa.c
+++ b/src/pa.c
@@ -29,7 +29,7 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 	if (edata_cache_init(&shard->edata_cache, base)) {
 		return true;
 	}
-	if (pac_init(tsdn, &shard->pac, ind, &shard->edata_cache)) {
+	if (pac_init(tsdn, &shard->pac, ind, emap, &shard->edata_cache)) {
 		return true;
 	}
 	if (ecache_grow_init(tsdn, &shard->ecache_grow)) {

--- a/src/pa.c
+++ b/src/pa.c
@@ -58,24 +58,8 @@ pa_shard_reset(pa_shard_t *shard) {
 }
 
 void
-pa_shard_destroy_retained(tsdn_t *tsdn, pa_shard_t *shard) {
-	assert(ecache_npages_get(&shard->pac.ecache_dirty) == 0);
-	assert(ecache_npages_get(&shard->pac.ecache_muzzy) == 0);
-	/*
-	 * Iterate over the retained extents and destroy them.  This gives the
-	 * extent allocator underlying the extent hooks an opportunity to unmap
-	 * all retained memory without having to keep its own metadata
-	 * structures.  In practice, virtual memory for dss-allocated extents is
-	 * leaked here, so best practice is to avoid dss for arenas to be
-	 * destroyed, or provide custom extent hooks that track retained
-	 * dss-based extents for later reuse.
-	 */
-	ehooks_t *ehooks = pa_shard_ehooks_get(shard);
-	edata_t *edata;
-	while ((edata = ecache_evict(tsdn, &shard->pac, ehooks,
-	    &shard->pac.ecache_retained, 0)) != NULL) {
-		extent_destroy_wrapper(tsdn, &shard->pac, ehooks, edata);
-	}
+pa_shard_destroy(tsdn_t *tsdn, pa_shard_t *shard) {
+	pac_destroy(tsdn, &shard->pac);
 }
 
 static inline bool

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -26,7 +26,6 @@ pa_shard_prefork3(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_prefork(tsdn, &shard->pac.ecache_retained);
 }
 
-
 void
 pa_shard_prefork4(tsdn_t *tsdn, pa_shard_t *shard) {
 	edata_cache_prefork(tsdn, &shard->edata_cache);

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -10,8 +10,8 @@
 
 void
 pa_shard_prefork0(tsdn_t *tsdn, pa_shard_t *shard) {
-	malloc_mutex_prefork(tsdn, &shard->decay_dirty.mtx);
-	malloc_mutex_prefork(tsdn, &shard->decay_muzzy.mtx);
+	malloc_mutex_prefork(tsdn, &shard->pac.decay_dirty.mtx);
+	malloc_mutex_prefork(tsdn, &shard->pac.decay_muzzy.mtx);
 }
 
 void
@@ -38,8 +38,8 @@ pa_shard_postfork_parent(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_retained);
 	ecache_grow_postfork_parent(tsdn, &shard->pac.ecache_grow);
-	malloc_mutex_postfork_parent(tsdn, &shard->decay_dirty.mtx);
-	malloc_mutex_postfork_parent(tsdn, &shard->decay_muzzy.mtx);
+	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_dirty.mtx);
+	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_muzzy.mtx);
 }
 
 void
@@ -49,8 +49,8 @@ pa_shard_postfork_child(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_child(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_retained);
 	ecache_grow_postfork_child(tsdn, &shard->pac.ecache_grow);
-	malloc_mutex_postfork_child(tsdn, &shard->decay_dirty.mtx);
-	malloc_mutex_postfork_child(tsdn, &shard->decay_muzzy.mtx);
+	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_dirty.mtx);
+	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_muzzy.mtx);
 }
 
 void
@@ -148,7 +148,7 @@ pa_shard_mtx_stats_read(tsdn_t *tsdn, pa_shard_t *shard,
 	pa_shard_mtx_stats_read_single(tsdn, mutex_prof_data,
 	    &shard->pac.ecache_retained.mtx, arena_prof_mutex_extents_retained);
 	pa_shard_mtx_stats_read_single(tsdn, mutex_prof_data,
-	    &shard->decay_dirty.mtx, arena_prof_mutex_decay_dirty);
+	    &shard->pac.decay_dirty.mtx, arena_prof_mutex_decay_dirty);
 	pa_shard_mtx_stats_read_single(tsdn, mutex_prof_data,
-	    &shard->decay_muzzy.mtx, arena_prof_mutex_decay_muzzy);
+	    &shard->pac.decay_muzzy.mtx, arena_prof_mutex_decay_muzzy);
 }

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -16,7 +16,7 @@ pa_shard_prefork0(tsdn_t *tsdn, pa_shard_t *shard) {
 
 void
 pa_shard_prefork2(tsdn_t *tsdn, pa_shard_t *shard) {
-	ecache_grow_prefork(tsdn, &shard->ecache_grow);
+	ecache_grow_prefork(tsdn, &shard->pac.ecache_grow);
 }
 
 void
@@ -37,7 +37,7 @@ pa_shard_postfork_parent(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_retained);
-	ecache_grow_postfork_parent(tsdn, &shard->ecache_grow);
+	ecache_grow_postfork_parent(tsdn, &shard->pac.ecache_grow);
 	malloc_mutex_postfork_parent(tsdn, &shard->decay_dirty.mtx);
 	malloc_mutex_postfork_parent(tsdn, &shard->decay_muzzy.mtx);
 }
@@ -48,7 +48,7 @@ pa_shard_postfork_child(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_child(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_retained);
-	ecache_grow_postfork_child(tsdn, &shard->ecache_grow);
+	ecache_grow_postfork_child(tsdn, &shard->pac.ecache_grow);
 	malloc_mutex_postfork_child(tsdn, &shard->decay_dirty.mtx);
 	malloc_mutex_postfork_child(tsdn, &shard->decay_muzzy.mtx);
 }

--- a/src/pac.c
+++ b/src/pac.c
@@ -5,7 +5,8 @@
 
 bool
 pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
-    edata_cache_t *edata_cache) {
+    edata_cache_t *edata_cache, nstime_t *cur_time, ssize_t dirty_decay_ms,
+    ssize_t muzzy_decay_ms) {
 	/*
 	 * Delay coalescing for dirty extents despite the disruptive effect on
 	 * memory layout for best-fit extent allocation, since cached extents
@@ -35,6 +36,12 @@ pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
 		return true;
 	}
 	if (ecache_grow_init(tsdn, &pac->ecache_grow)) {
+		return true;
+	}
+	if (decay_init(&pac->decay_dirty, cur_time, dirty_decay_ms)) {
+		return true;
+	}
+	if (decay_init(&pac->decay_muzzy, cur_time, muzzy_decay_ms)) {
 		return true;
 	}
 

--- a/src/pac.c
+++ b/src/pac.c
@@ -49,6 +49,7 @@ pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
 	pac->edata_cache = edata_cache;
 	pac->stats = pac_stats;
 	pac->stats_mtx = stats_mtx;
+	atomic_store_zu(&pac->extent_sn_next, 0, ATOMIC_RELAXED);
 	return false;
 }
 

--- a/src/pac.c
+++ b/src/pac.c
@@ -6,7 +6,7 @@
 bool
 pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
     edata_cache_t *edata_cache, nstime_t *cur_time, ssize_t dirty_decay_ms,
-    ssize_t muzzy_decay_ms) {
+    ssize_t muzzy_decay_ms, pac_stats_t *pac_stats, malloc_mutex_t *stats_mtx) {
 	/*
 	 * Delay coalescing for dirty extents despite the disruptive effect on
 	 * memory layout for best-fit extent allocation, since cached extents
@@ -47,6 +47,8 @@ pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
 
 	pac->emap = emap;
 	pac->edata_cache = edata_cache;
+	pac->stats = pac_stats;
+	pac->stats_mtx = stats_mtx;
 	return false;
 }
 

--- a/src/pac.c
+++ b/src/pac.c
@@ -1,0 +1,39 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/pac.h"
+
+bool
+pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, edata_cache_t *edata_cache) {
+	/*
+	 * Delay coalescing for dirty extents despite the disruptive effect on
+	 * memory layout for best-fit extent allocation, since cached extents
+	 * are likely to be reused soon after deallocation, and the cost of
+	 * merging/splitting extents is non-trivial.
+	 */
+	if (ecache_init(tsdn, &pac->ecache_dirty, extent_state_dirty, ind,
+	    /* delay_coalesce */ true)) {
+		return true;
+	}
+	/*
+	 * Coalesce muzzy extents immediately, because operations on them are in
+	 * the critical path much less often than for dirty extents.
+	 */
+	if (ecache_init(tsdn, &pac->ecache_muzzy, extent_state_muzzy, ind,
+	    /* delay_coalesce */ false)) {
+		return true;
+	}
+	/*
+	 * Coalesce retained extents immediately, in part because they will
+	 * never be evicted (and therefore there's no opportunity for delayed
+	 * coalescing), but also because operations on retained extents are not
+	 * in the critical path.
+	 */
+	if (ecache_init(tsdn, &pac->ecache_retained, extent_state_retained,
+	    ind, /* delay_coalesce */ false)) {
+		return true;
+	}
+
+	pac->edata_cache = edata_cache;
+	return false;
+}

--- a/src/pac.c
+++ b/src/pac.c
@@ -4,7 +4,8 @@
 #include "jemalloc/internal/pac.h"
 
 bool
-pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, edata_cache_t *edata_cache) {
+pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, emap_t *emap,
+    edata_cache_t *edata_cache) {
 	/*
 	 * Delay coalescing for dirty extents despite the disruptive effect on
 	 * memory layout for best-fit extent allocation, since cached extents
@@ -34,6 +35,7 @@ pac_init(tsdn_t *tsdn, pac_t *pac, unsigned ind, edata_cache_t *edata_cache) {
 		return true;
 	}
 
+	pac->emap = emap;
 	pac->edata_cache = edata_cache;
 	return false;
 }

--- a/src/pac.c
+++ b/src/pac.c
@@ -76,4 +76,3 @@ pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
 
 	return false;
 }
-

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -107,7 +107,6 @@ TEST_BEGIN(test_alloc_free_purge_thds) {
 	for (int i = 0; i < 4; i++) {
 		thd_join(thds[i], NULL);
 	}
-
 }
 TEST_END
 

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -86,13 +86,14 @@ do_alloc_free_purge(void *arg) {
 		bool generated_dirty;
 		pa_dalloc(TSDN_NULL, &test_data->shard, edata,
 		    &generated_dirty);
-		malloc_mutex_lock(TSDN_NULL, &test_data->shard.decay_dirty.mtx);
+		malloc_mutex_lock(TSDN_NULL,
+		    &test_data->shard.pac.decay_dirty.mtx);
 		pa_decay_all(TSDN_NULL, &test_data->shard,
-		    &test_data->shard.decay_dirty,
+		    &test_data->shard.pac.decay_dirty,
 		    &test_data->stats.decay_dirty,
 		    &test_data->shard.pac.ecache_dirty, true);
 		malloc_mutex_unlock(TSDN_NULL,
-		    &test_data->shard.decay_dirty.mtx);
+		    &test_data->shard.pac.decay_dirty.mtx);
 	}
 	return NULL;
 }

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -90,7 +90,7 @@ do_alloc_free_purge(void *arg) {
 		    &test_data->shard.pac.decay_dirty.mtx);
 		pa_decay_all(TSDN_NULL, &test_data->shard,
 		    &test_data->shard.pac.decay_dirty,
-		    &test_data->stats.decay_dirty,
+		    &test_data->shard.pac.stats->decay_dirty,
 		    &test_data->shard.pac.ecache_dirty, true);
 		malloc_mutex_unlock(TSDN_NULL,
 		    &test_data->shard.pac.decay_dirty.mtx);

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -90,7 +90,7 @@ do_alloc_free_purge(void *arg) {
 		pa_decay_all(TSDN_NULL, &test_data->shard,
 		    &test_data->shard.decay_dirty,
 		    &test_data->stats.decay_dirty,
-		    &test_data->shard.ecache_dirty, true);
+		    &test_data->shard.pac.ecache_dirty, true);
 		malloc_mutex_unlock(TSDN_NULL,
 		    &test_data->shard.decay_dirty.mtx);
 	}

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -88,7 +88,7 @@ do_alloc_free_purge(void *arg) {
 		    &generated_dirty);
 		malloc_mutex_lock(TSDN_NULL,
 		    &test_data->shard.pac.decay_dirty.mtx);
-		pa_decay_all(TSDN_NULL, &test_data->shard,
+		pac_decay_all(TSDN_NULL, &test_data->shard.pac,
 		    &test_data->shard.pac.decay_dirty,
 		    &test_data->shard.pac.stats->decay_dirty,
 		    &test_data->shard.pac.ecache_dirty, true);

--- a/test/unit/retained.c
+++ b/test/unit/retained.c
@@ -142,7 +142,7 @@ TEST_BEGIN(test_retained) {
 		size_t usable = 0;
 		size_t fragmented = 0;
 		for (pszind_t pind = sz_psz2ind(HUGEPAGE); pind <
-		    arena->pa_shard.ecache_grow.next; pind++) {
+		    arena->pa_shard.pac.ecache_grow.next; pind++) {
 			size_t psz = sz_pind2sz(pind);
 			size_t psz_fragmented = psz % esz;
 			size_t psz_usable = psz - psz_fragmented;


### PR DESCRIPTION
This introduces, PAI "page allocator interface", which abstracts over the underlying page-level operations that interest us. It then pulls out the extent selection functionality in PA into PAC, "page allocator classic".

Right now neither of these is terribly well motivated; they're part of a larger-scale plan:

The PAI interface will allow adding a cache of small extents, that can be used to take pressure off the central extent allocator's lock; the interface allows testing the cache independently of all the underlying allocator functionality.

Pulling out the PA logic into PAC will make it easier to shim in a hugepage-allocator.