### PR TITLE
Sample every allocation by default in tests

### DIFF
--- a/include/jemalloc/internal/prof_types.h
+++ b/include/jemalloc/internal/prof_types.h
@@ -15,7 +15,13 @@ typedef struct prof_recent_s prof_recent_t;
 #else
 #  define PROF_PREFIX_DEFAULT		""
 #endif
-#define LG_PROF_SAMPLE_DEFAULT		19
+
+#ifdef JEMALLOC_JET
+#  define LG_PROF_SAMPLE_DEFAULT	0
+#else
+#  define LG_PROF_SAMPLE_DEFAULT	19
+#endif
+
 #define LG_PROF_INTERVAL_DEFAULT	-1
 
 /*

--- a/test/unit/arena_reset_prof.sh
+++ b/test/unit/arena_reset_prof.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="prof:true,lg_prof_sample:0"
+export MALLOC_CONF="prof:true"

--- a/test/unit/prof_accum.sh
+++ b/test/unit/prof_accum.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_accum:true,prof_active:false"
 fi

--- a/test/unit/prof_active.sh
+++ b/test/unit/prof_active.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,prof_thread_active_init:false,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_thread_active_init:false"
 fi

--- a/test/unit/prof_idump.sh
+++ b/test/unit/prof_idump.sh
@@ -2,7 +2,7 @@
 
 export MALLOC_CONF="tcache:false"
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="${MALLOC_CONF},prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0,lg_prof_interval:0"
+  export MALLOC_CONF="${MALLOC_CONF},prof:true,prof_accum:true,prof_active:false,lg_prof_interval:0"
 fi
 
 

--- a/test/unit/prof_log.sh
+++ b/test/unit/prof_log.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true"
 fi

--- a/test/unit/prof_recent.sh
+++ b/test/unit/prof_recent.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_recent_alloc_max:3"
+  export MALLOC_CONF="prof:true,prof_recent_alloc_max:3"
 fi

--- a/test/unit/prof_reset.sh
+++ b/test/unit/prof_reset.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,prof_active:false,lg_prof_sample:0,prof_recent_alloc_max:0"
+  export MALLOC_CONF="prof:true,prof_active:false,prof_recent_alloc_max:0"
 fi

--- a/test/unit/prof_sys_thread_name.sh
+++ b/test/unit/prof_sys_thread_name.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_sys_thread_name:true"
+  export MALLOC_CONF="prof:true,prof_sys_thread_name:true"
 fi

--- a/test/unit/prof_tctx.sh
+++ b/test/unit/prof_tctx.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true"
 fi

--- a/test/unit/safety_check.sh
+++ b/test/unit/safety_check.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true"
 fi

--- a/test/unit/thread_event.sh
+++ b/test/unit/thread_event.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true"
 fi


### PR DESCRIPTION
This is what we've been doing all the time, which makes sense because a non-zero `lg_prof_sample` brings randomness and is thus not good for tests. This PR serves to save some typing.