### PR TITLE
Profiling: work around a biasing issue.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -291,7 +291,8 @@ CPP_SRCS :=
 TESTS_INTEGRATION_CPP :=
 endif
 TESTS_ANALYZE := $(srcroot)test/analyze/rand.c \
-	$(srcroot)test/analyze/sizes.c
+	$(srcroot)test/analyze/sizes.c \
+	$(srcroot)test/analyze/prof_bias.c
 TESTS_STRESS := $(srcroot)test/stress/microbench.c \
 	$(srcroot)test/stress/fill_flush.c \
 	$(srcroot)test/stress/large_microbench.c \

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -19,6 +19,7 @@ extern char opt_prof_prefix[
     PATH_MAX +
 #endif
     1];
+extern bool opt_prof_unbias;
 
 /* For recording recent allocations */
 extern ssize_t opt_prof_recent_alloc_max;
@@ -40,6 +41,9 @@ extern uint64_t prof_interval;
  * resets.
  */
 extern size_t lg_prof_sample;
+extern size_t prof_unbiased_sz[SC_NSIZES];
+extern size_t prof_shifted_unbiased_cnt[SC_NSIZES];
+void prof_unbias_map_init();
 
 extern bool prof_booted;
 

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -43,6 +43,13 @@ extern size_t lg_prof_sample;
 
 extern bool prof_booted;
 
+/*
+ * A hook to mock out backtrace functionality.  This can be handy, since it's
+ * otherwise difficult to guarantee that two allocations are reported as coming
+ * from the exact same stack trace in the presence of an optimizing compiler.
+ */
+extern void (* JET_MUTABLE prof_backtrace_hook)(prof_bt_t *bt);
+
 /* Functions only accessed in prof_inlines.h */
 prof_tdata_t *prof_tdata_init(tsd_t *tsd);
 prof_tdata_t *prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata);

--- a/include/jemalloc/internal/prof_structs.h
+++ b/include/jemalloc/internal/prof_structs.h
@@ -24,9 +24,13 @@ typedef struct {
 struct prof_cnt_s {
 	/* Profiling counters. */
 	uint64_t	curobjs;
+	uint64_t	curobjs_shifted_unbiased;
 	uint64_t	curbytes;
+	uint64_t	curbytes_unbiased;
 	uint64_t	accumobjs;
+	uint64_t	accumobjs_shifted_unbiased;
 	uint64_t	accumbytes;
+	uint64_t	accumbytes_unbiased;
 };
 
 typedef enum {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1517,6 +1517,16 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 					}
 					CONF_CONTINUE;
 				}
+				/*
+				 * Undocumented.  When set to false, don't
+				 * correct for an unbiasing bug in jeprof
+				 * attribution.  This can be handy if you want
+				 * to get consistent numbers from your binary
+				 * across different jemalloc versions, even if
+				 * those numbers are incorrect.  The default is
+				 * true.
+				 */
+				CONF_HANDLE_BOOL(opt_prof_unbias, "prof_unbias")
 			}
 			if (config_log) {
 				if (CONF_MATCH("log")) {

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -27,6 +27,8 @@
 
 malloc_mutex_t prof_dump_filename_mtx;
 
+bool prof_do_mock = false;
+
 static uint64_t prof_dump_seq;
 static uint64_t prof_dump_iseq;
 static uint64_t prof_dump_mseq;
@@ -267,11 +269,14 @@ prof_backtrace_impl(prof_bt_t *bt) {
 }
 #endif
 
+
+void (* JET_MUTABLE prof_backtrace_hook)(prof_bt_t *bt) = &prof_backtrace_impl;
+
 void
 prof_backtrace(tsd_t *tsd, prof_bt_t *bt) {
 	cassert(config_prof);
 	pre_reentrancy(tsd, NULL);
-	prof_backtrace_impl(bt);
+	prof_backtrace_hook(bt);
 	post_reentrancy(tsd);
 }
 

--- a/test/analyze/prof_bias.c
+++ b/test/analyze/prof_bias.c
@@ -1,0 +1,60 @@
+#include "test/jemalloc_test.h"
+
+/*
+ * This is a helper utility, only meant to be run manually (and, for example,
+ * doesn't check for failures, try to skip execution in non-prof modes, etc.).
+ * It runs, allocates objects of two different sizes from the same stack trace,
+ * and exits.
+ *
+ * The idea is that some human operator will run it like:
+ *     MALLOC_CONF="prof:true,prof_final:true" test/analyze/prof_bias
+ * and manually inspect the results.
+ *
+ * The results should be:
+ * jeprof --text test/analyze/prof_bias --inuse_space jeprof.<pid>.0.f.heap:
+ * 	around 1024 MB
+ * jeprof --text test/analyze/prof_bias --inuse_objects jeprof.<pid>.0.f.heap:
+ * 	around 33554448 = 16 + 32 * 1024 * 1024
+ *
+ * And, if prof_accum is on:
+ * jeprof --text test/analyze/prof_bias --alloc_space jeprof.<pid>.0.f.heap:
+ *     around 2048 MB
+ * jeprof --text test/analyze/prof_bias --alloc_objects jeprof.<pid>.0.f.heap:
+ * 	around 67108896 = 2 * (16 + 32 * 1024 * 1024)
+ */
+
+static void
+mock_backtrace(prof_bt_t *bt) {
+	bt->len = 4;
+	bt->vec[0] = (void *)0x111;
+	bt->vec[1] = (void *)0x222;
+	bt->vec[2] = (void *)0x333;
+	bt->vec[3] = (void *)0x444;
+}
+
+static void
+do_allocs(size_t sz, size_t cnt, bool do_frees) {
+	for (size_t i = 0; i < cnt; i++) {
+		void *ptr = mallocx(sz, 0);
+		assert_ptr_not_null(ptr, "Unexpected mallocx failure");
+		if (do_frees) {
+			dallocx(ptr, 0);
+		}
+	}
+}
+
+int
+main(void) {
+	size_t lg_prof_sample = 19;
+	int err = mallctl("prof.reset", NULL, NULL, (void *)&lg_prof_sample,
+	    sizeof(lg_prof_sample));
+	assert(err == 0);
+
+	prof_backtrace_hook = &mock_backtrace;
+	do_allocs(16, 32 * 1024 * 1024, /* do_frees */ true);
+	do_allocs(32 * 1024* 1024, 16, /* do_frees */ true);
+	do_allocs(16, 32 * 1024 * 1024, /* do_frees */ false);
+	do_allocs(32 * 1024* 1024, 16, /* do_frees */ false);
+
+	return 0;
+}


### PR DESCRIPTION
This fixes a longstanding issue: the combination of jemalloc and jeprof should be unbiasing-then-summing, but instead we were summing-then-unbiasing. This could lead to incorrect heap usage and object counts to stacks when those stacks are responsible for a wide range of allocation sizes. Included in this PR is a fairly primitive test program to demonstrate the issue.

When running the program on the first commit alone:
```
[~/jemalloc]$ MALLOC_CONF="prof:true,prof_final:true" test/analyze/prof_bias
[~/jemalloc]$ jeprof --text test/analyze/prof_bias --inuse_space jeprof.*
Using local file test/analyze/prof_bias.
Using local file jeprof.2343139.0.f.heap.
Total: 828.5 MB
   828.5 100.0% 100.0%    828.5 100.0% jet_tsd_tls

[~/jemalloc]$ jeprof --text test/analyze/prof_bias --inuse_objects jeprof.*
Using local file test/analyze/prof_bias.
Using local file jeprof.2343139.0.f.heap.
Total: 1721 objects
    1721 100.0% 100.0%     1721 100.0% jet_tsd_tls
```

When running it with the fix:
```
[~/jemalloc]$ jeprof --text test/analyze/prof_bias --inuse_space jeprof.*
Using local file test/analyze/prof_bias.
Using local file jeprof.2353690.0.f.heap.
Total: 1026.5 MB
  1026.5 100.0% 100.0%   1026.5 100.0% jet_tsd_tls

[~/jemalloc]$ jeprof --text test/analyze/prof_bias --inuse_objects jeprof.*
Using local file test/analyze/prof_bias.
Using local file jeprof.2353690.0.f.heap.
Total: 33720527 objects
33720527 100.0% 100.0% 33720527 100.0% jet_tsd_tls
```

The true number of bytes and objects is 1024 MB and 33554448 objects.

We include an opt-out facility that keeps the old behavior, so that there's at least *some* stable tracking metric across the split, even if can report incorrect values.