### PR TITLE
Record alignment and usize explicitly in prof recent records

### DIFF
--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -49,7 +49,7 @@ prof_tdata_t *prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata);
 
 void prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx);
 void prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
-    size_t usize, prof_tctx_t *tctx);
+    size_t alignment, size_t usize, prof_tctx_t *tctx);
 void prof_free_sampled_object(tsd_t *tsd, size_t usize, prof_info_t *prof_info);
 prof_tctx_t *prof_tctx_create(tsd_t *tsd);
 void prof_idump(tsdn_t *tsdn);

--- a/include/jemalloc/internal/prof_inlines.h
+++ b/include/jemalloc/internal/prof_inlines.h
@@ -142,23 +142,24 @@ prof_alloc_prep(tsd_t *tsd, bool prof_active, bool sample_event) {
 }
 
 JEMALLOC_ALWAYS_INLINE void
-prof_malloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
-    emap_alloc_ctx_t *alloc_ctx, prof_tctx_t *tctx) {
+prof_malloc(tsd_t *tsd, const void *ptr, size_t size, size_t alignment,
+    size_t usize, emap_alloc_ctx_t *alloc_ctx, prof_tctx_t *tctx) {
 	cassert(config_prof);
 	assert(ptr != NULL);
 	assert(usize == isalloc(tsd_tsdn(tsd), ptr));
 
 	if (unlikely((uintptr_t)tctx > (uintptr_t)1U)) {
-		prof_malloc_sample_object(tsd, ptr, size, usize, tctx);
+		prof_malloc_sample_object(tsd, ptr, size, alignment, usize,
+		    tctx);
 	} else {
 		prof_tctx_reset(tsd, ptr, alloc_ctx);
 	}
 }
 
 JEMALLOC_ALWAYS_INLINE void
-prof_realloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
-    prof_tctx_t *tctx, bool prof_active, const void *old_ptr, size_t old_usize,
-    prof_info_t *old_prof_info, bool sample_event) {
+prof_realloc(tsd_t *tsd, const void *ptr, size_t size, size_t alignment,
+    size_t usize, prof_tctx_t *tctx, bool prof_active, const void *old_ptr,
+    size_t old_usize, prof_info_t *old_prof_info, bool sample_event) {
 	bool sampled, old_sampled, moved;
 
 	cassert(config_prof);
@@ -184,7 +185,8 @@ prof_realloc(tsd_t *tsd, const void *ptr, size_t size, size_t usize,
 	moved = (ptr != old_ptr);
 
 	if (unlikely(sampled)) {
-		prof_malloc_sample_object(tsd, ptr, size, usize, tctx);
+		prof_malloc_sample_object(tsd, ptr, size, alignment, usize,
+		    tctx);
 	} else if (moved) {
 		prof_tctx_reset(tsd, ptr, NULL);
 	} else if (unlikely(old_sampled)) {

--- a/include/jemalloc/internal/prof_recent.h
+++ b/include/jemalloc/internal/prof_recent.h
@@ -5,7 +5,8 @@ extern malloc_mutex_t prof_recent_alloc_mtx;
 extern malloc_mutex_t prof_recent_dump_mtx;
 
 bool prof_recent_alloc_prepare(tsd_t *tsd, prof_tctx_t *tctx);
-void prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size);
+void prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size,
+    size_t alignment, size_t usize);
 void prof_recent_alloc_reset(tsd_t *tsd, edata_t *edata);
 bool prof_recent_init();
 void edata_prof_recent_alloc_init(edata_t *edata);

--- a/include/jemalloc/internal/prof_structs.h
+++ b/include/jemalloc/internal/prof_structs.h
@@ -205,6 +205,8 @@ struct prof_recent_s {
 
 	ql_elm(prof_recent_t) link;
 	size_t size;
+	size_t alignment;
+	size_t usize;
 	atomic_p_t alloc_edata; /* NULL means allocation has been freed. */
 	prof_tctx_t *alloc_tctx;
 	prof_tctx_t *dalloc_tctx;

--- a/src/prof.c
+++ b/src/prof.c
@@ -87,7 +87,7 @@ prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx) {
 
 void
 prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
-    size_t usize, prof_tctx_t *tctx) {
+    size_t alignment, size_t usize, prof_tctx_t *tctx) {
 	if (opt_prof_sys_thread_name) {
 		prof_sys_thread_name_fetch(tsd);
 	}
@@ -108,7 +108,7 @@ prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 	malloc_mutex_unlock(tsd_tsdn(tsd), tctx->tdata->lock);
 	if (record_recent) {
 		assert(tctx == edata_prof_tctx_get(edata));
-		prof_recent_alloc(tsd, edata, size);
+		prof_recent_alloc(tsd, edata, size, alignment, usize);
 	}
 }
 

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -270,7 +270,8 @@ prof_recent_alloc_assert_count(tsd_t *tsd) {
 }
 
 void
-prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size) {
+prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size, size_t alignment,
+    size_t usize) {
 	assert(edata != NULL);
 	prof_tctx_t *tctx = edata_prof_tctx_get(edata);
 
@@ -356,6 +357,8 @@ prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size) {
 	prof_recent_t *tail = ql_last(&prof_recent_alloc_list, link);
 	assert(tail != NULL);
 	tail->size = size;
+	tail->alignment = alignment;
+	tail->usize = usize;
 	nstime_copy(&tail->alloc_time, edata_prof_alloc_time_get(edata));
 	tail->alloc_tctx = tctx;
 	nstime_init_zero(&tail->dalloc_time);
@@ -477,8 +480,9 @@ prof_recent_alloc_dump_node(emitter_t *emitter, prof_recent_t *node) {
 	emitter_json_object_begin(emitter);
 
 	emitter_json_kv(emitter, "size", emitter_type_size, &node->size);
-	size_t usize = sz_s2u(node->size);
-	emitter_json_kv(emitter, "usize", emitter_type_size, &usize);
+	emitter_json_kv(emitter, "alignment", emitter_type_size,
+	    &node->alignment);
+	emitter_json_kv(emitter, "usize", emitter_type_size, &node->usize);
 	bool released = prof_recent_alloc_edata_get_no_lock(node) == NULL;
 	emitter_json_kv(emitter, "released", emitter_type_bool, &released);
 


### PR DESCRIPTION
A few reasons behind this PR:
- Computing `usize` via `sz_s2u(size)` when dumping the prof recent records is simply wrong, if there was an alignment specified.
- To be complete, the record should contain all three of request size, alignment, and `usize`.
- Trying to compute the `usize` from the request size and alignment may be correct but not ideal. On the one hand, the formula might not be that simple, e.g. considering a `realloc()` with a lower alignment specified. On the other hand, the prof modules should not have knowledge about size class computations. So I end up passing all three values around.