### PR TITLE
Fix size miscalculation bug in reallocation

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -1297,7 +1297,7 @@ void *
 arena_ralloc(tsdn_t *tsdn, arena_t *arena, void *ptr, size_t oldsize,
     size_t size, size_t alignment, bool zero, tcache_t *tcache,
     hook_ralloc_args_t *hook_args) {
-	size_t usize = sz_s2u(size);
+	size_t usize = alignment == 0 ? sz_s2u(size) : sz_sa2u(size, alignment);
 	if (unlikely(usize == 0 || size > SC_LARGE_MAXCLASS)) {
 		return NULL;
 	}

--- a/test/integration/rallocx.c
+++ b/test/integration/rallocx.c
@@ -171,6 +171,39 @@ TEST_BEGIN(test_align) {
 }
 TEST_END
 
+TEST_BEGIN(test_align_enum) {
+/* Span both small sizes and large sizes. */
+#define LG_MIN 12
+#define LG_MAX 15
+	for (size_t lg_align = LG_MIN; lg_align <= LG_MAX; ++lg_align) {
+		for (size_t lg_size = LG_MIN; lg_size <= LG_MAX; ++lg_size) {
+			size_t size = 1 << lg_size;
+			for (size_t lg_align_next = LG_MIN;
+			    lg_align_next <= LG_MAX; ++lg_align_next) {
+				int flags = MALLOCX_LG_ALIGN(lg_align);
+				void *p = mallocx(1, flags);
+				assert_ptr_not_null(p,
+				    "Unexpected mallocx() error");
+				assert_zu_eq(nallocx(1, flags),
+				    malloc_usable_size(p),
+				    "Wrong mallocx() usable size");
+				int flags_next =
+				    MALLOCX_LG_ALIGN(lg_align_next);
+				p = rallocx(p, size, flags_next);
+				assert_ptr_not_null(p,
+				    "Unexpected rallocx() error");
+				expect_zu_eq(nallocx(size, flags_next),
+				    malloc_usable_size(p),
+				    "Wrong rallocx() usable size");
+				free(p);
+			}
+		}
+	}
+#undef LG_MAX
+#undef LG_MIN
+}
+TEST_END
+
 TEST_BEGIN(test_lg_align_and_zero) {
 	void *p, *q;
 	unsigned lg_align;
@@ -253,6 +286,7 @@ main(void) {
 	    test_grow_and_shrink,
 	    test_zero,
 	    test_align,
+	    test_align_enum,
 	    test_lg_align_and_zero,
 	    test_overflow);
 }


### PR DESCRIPTION
Before this change, the snippet

```
tsdn_t *tsdn = tsdn_fetch();
void *p = mallocx(7, MALLOCX_ALIGN(64));
malloc_printf("isalloc(tsdn, p) = %zu\n", isalloc(tsdn, p));
p = rallocx(p, 57, MALLOCX_ALIGN(128));
malloc_printf("isalloc(tsdn, p) = %zu\n", isalloc(tsdn, p));
free(p);
```

yields

```
isalloc(tsdn, p) = 64
isalloc(tsdn, p) = 64
```

After this change, it yields

```
isalloc(tsdn, p) = 64
isalloc(tsdn, p) = 128
```
