### PR TITLE
Stress tests: cleanups, and a mallctl test.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -293,14 +293,15 @@ else
 CPP_SRCS :=
 TESTS_INTEGRATION_CPP :=
 endif
-TESTS_ANALYZE := $(srcroot)test/analyze/rand.c \
-	$(srcroot)test/analyze/sizes.c \
-	$(srcroot)test/analyze/prof_bias.c
-TESTS_STRESS := $(srcroot)test/stress/microbench.c \
+TESTS_ANALYZE := $(srcroot)test/analyze/prof_bias.c \
+	$(srcroot)test/analyze/rand.c \
+	$(srcroot)test/analyze/sizes.c
+TESTS_STRESS := $(srcroot)test/stress/batch_alloc.c \
 	$(srcroot)test/stress/fill_flush.c \
-	$(srcroot)test/stress/large_microbench.c \
 	$(srcroot)test/stress/hookbench.c \
-	$(srcroot)test/stress/batch_alloc.c
+	$(srcroot)test/stress/large_microbench.c \
+	$(srcroot)test/stress/microbench.c
+	
 
 
 TESTS := $(TESTS_UNIT) $(TESTS_INTEGRATION) $(TESTS_INTEGRATION_CPP) \

--- a/Makefile.in
+++ b/Makefile.in
@@ -300,6 +300,7 @@ TESTS_STRESS := $(srcroot)test/stress/batch_alloc.c \
 	$(srcroot)test/stress/fill_flush.c \
 	$(srcroot)test/stress/hookbench.c \
 	$(srcroot)test/stress/large_microbench.c \
+	$(srcroot)test/stress/mallctl.c \
 	$(srcroot)test/stress/microbench.c
 	
 

--- a/test/include/test/bench.h
+++ b/test/include/test/bench.h
@@ -13,6 +13,20 @@ time_func(timedelta_t *timer, uint64_t nwarmup, uint64_t niter,
 	timer_stop(timer);
 }
 
+#define FMT_NSECS_BUF_SIZE 100
+/* Print nanoseconds / iter into the buffer "buf". */
+static inline void
+fmt_nsecs(uint64_t usec, uint64_t iters, char *buf) {
+	uint64_t nsec = usec * 1000;
+	/* We'll display 3 digits after the decimal point. */
+	uint64_t nsec1000 = nsec * 1000;
+	uint64_t nsecs_per_iter1000 = nsec1000 / iters;
+	uint64_t intpart = nsecs_per_iter1000 / 1000;
+	uint64_t fracpart = nsecs_per_iter1000 % 1000;
+	malloc_snprintf(buf, FMT_NSECS_BUF_SIZE, "%"FMTu64".%03"FMTu64, intpart,
+	    fracpart);
+}
+
 static inline void
 compare_funcs(uint64_t nwarmup, uint64_t niter, const char *name_a,
     void (*func_a), const char *name_b, void (*func_b)) {
@@ -29,11 +43,18 @@ compare_funcs(uint64_t nwarmup, uint64_t niter, const char *name_a,
 	time_func(&timer_a, nwarmup, niter, func_a);
 	time_func(&timer_b, nwarmup, niter, func_b);
 
+	uint64_t usec_a = timer_usec(&timer_a);
+	char buf_a[FMT_NSECS_BUF_SIZE];
+	fmt_nsecs(usec_a, niter, buf_a);
+
+	uint64_t usec_b = timer_usec(&timer_b);
+	char buf_b[FMT_NSECS_BUF_SIZE];
+	fmt_nsecs(usec_b, niter, buf_b);
+
 	timer_ratio(&timer_a, &timer_b, ratio_buf, sizeof(ratio_buf));
-	malloc_printf("%"FMTu64" iterations, %s=%"FMTu64"us, "
-	    "%s=%"FMTu64"us, ratio=1:%s\n",
-	    niter, name_a, timer_usec(&timer_a), name_b, timer_usec(&timer_b),
-	    ratio_buf);
+	malloc_printf("%"FMTu64" iterations, %s=%"FMTu64"us (%s ns/iter), "
+	    "%s=%"FMTu64"us (%s ns/iter), ratio=1:%s\n",
+	    niter, name_a, usec_a, buf_a, name_b, usec_b, buf_b, ratio_buf);
 
 	dallocx(p, 0);
 }

--- a/test/stress/mallctl.c
+++ b/test/stress/mallctl.c
@@ -1,0 +1,74 @@
+#include "test/jemalloc_test.h"
+#include "test/bench.h"
+
+static void
+mallctl_short(void) {
+	const char *version;
+	size_t sz = sizeof(version);
+	int err = mallctl("version", &version, &sz, NULL, 0);
+	assert_d_eq(err, 0, "mallctl failure");
+}
+
+size_t mib_short[1];
+
+static void
+mallctlbymib_short(void) {
+	size_t miblen = sizeof(mib_short)/sizeof(mib_short[0]);
+	const char *version;
+	size_t sz = sizeof(version);
+	int err = mallctlbymib(mib_short, miblen, &version, &sz, NULL, 0);
+	assert_d_eq(err, 0, "mallctlbymib failure");
+}
+
+TEST_BEGIN(test_mallctl_vs_mallctlbymib_short) {
+	size_t miblen = sizeof(mib_short)/sizeof(mib_short[0]);
+
+	int err = mallctlnametomib("version", mib_short, &miblen);
+	assert_d_eq(err, 0, "mallctlnametomib failure");
+	compare_funcs(10*1000*1000, 10*1000*1000, "mallctl_short",
+	    mallctl_short, "mallctlbymib_short", mallctlbymib_short);
+}
+TEST_END
+
+static void
+mallctl_long(void) {
+	uint64_t nmalloc;
+	size_t sz = sizeof(nmalloc);
+	int err = mallctl("stats.arenas.0.bins.0.nmalloc", &nmalloc, &sz, NULL,
+	    0);
+	assert_d_eq(err, 0, "mallctl failure");
+}
+
+size_t mib_long[6];
+
+static void
+mallctlbymib_long(void) {
+	size_t miblen = sizeof(mib_long)/sizeof(mib_long[0]);
+	const char *version;
+	size_t sz = sizeof(version);
+	int err = mallctlbymib(mib_long, miblen, &version, &sz, NULL, 0);
+	assert_d_eq(err, 0, "mallctlbymib failure");
+}
+
+TEST_BEGIN(test_mallctl_vs_mallctlbymib_long) {
+	/*
+	 * We want to use the longest mallctl we have; that needs stats support
+	 * to be allowed.
+	 */
+	test_skip_if(!config_stats);
+
+	size_t miblen = sizeof(mib_long)/sizeof(mib_long[0]);
+	int err = mallctlnametomib("stats.arenas.0.bins.0.nmalloc", mib_long,
+	    &miblen);
+	assert_d_eq(err, 0, "mallctlnametomib failure");
+	compare_funcs(10*1000*1000, 10*1000*1000, "mallctl_long",
+	    mallctl_long, "mallctlbymib_long", mallctlbymib_long);
+}
+TEST_END
+
+int
+main(void) {
+	return test_no_reentrancy(
+	    test_mallctl_vs_mallctlbymib_short,
+	    test_mallctl_vs_mallctlbymib_long);
+}

--- a/test/unit/malloc_io.c
+++ b/test/unit/malloc_io.c
@@ -175,6 +175,7 @@ TEST_BEGIN(test_malloc_snprintf) {
 	TEST("_1234_", "_%o_", 01234);
 	TEST("_01234_", "_%#o_", 01234);
 	TEST("_1234_", "_%u_", 1234);
+	TEST("01234", "%05u", 1234);
 
 	TEST("_1234_", "_%d_", 1234);
 	TEST("_ 1234_", "_% d_", 1234);
@@ -182,6 +183,15 @@ TEST_BEGIN(test_malloc_snprintf) {
 	TEST("_-1234_", "_%d_", -1234);
 	TEST("_-1234_", "_% d_", -1234);
 	TEST("_-1234_", "_%+d_", -1234);
+
+	/*
+	 * Morally, we should test these too, but 0-padded signed types are not
+	 * yet supported.
+	 *
+	 * TEST("01234", "%05", 1234);
+	 * TEST("-1234", "%05d", -1234);
+	 * TEST("-01234", "%06d", -1234);
+	*/
 
 	TEST("_-1234_", "_%d_", -1234);
 	TEST("_1234_", "_%d_", 1234);


### PR DESCRIPTION
The backstory here is that I was curious of how fast mallctl interfaces were. I wrote a little stress test to determine how fast it was. Then I got frustrated that I couldn't easily read that speed, so I added the ns/iter functionality. Doing that requires the ability to 0-pad.