### PR TITLE
Config: safety checks don't imply size checks.

### DIFF
--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -185,8 +185,7 @@ static const bool config_opt_safety_checks =
  * general safety checks.
  */
 static const bool config_opt_size_checks =
-#if defined(JEMALLOC_OPT_SIZE_CHECKS) || defined(JEMALLOC_OPT_SAFETY_CHECKS) \
-    || defined(JEMALLOC_DEBUG)
+#if defined(JEMALLOC_OPT_SIZE_CHECKS) || defined(JEMALLOC_DEBUG)
     true
 #else
     false


### PR DESCRIPTION
The commit introducing size checks accidentally enabled them whenever any safety
checks were on.  This ends up causing the regression that splitting up the
features was intended to avoid.  Fix the issue.