### PR TITLE
Add narenas_ratio.

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -127,6 +127,7 @@ bool	opt_utrace = false;
 bool	opt_xmalloc = false;
 bool	opt_zero = false;
 unsigned	opt_narenas = 0;
+unsigned	opt_narenas_ratio = 4;
 
 unsigned	ncpus;
 
@@ -1294,6 +1295,12 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 					    /* clip */ false)
 				}
 			}
+			if (CONF_MATCH("narenas_ratio")) {
+				CONF_HANDLE_UNSIGNED(opt_narenas_ratio,
+				    "narenas_ratio", 1, UINT_MAX,
+				    CONF_CHECK_MIN, CONF_DONT_CHECK_MAX,
+				    /* clip */ false)
+			}
 			if (CONF_MATCH("bin_shards")) {
 				const char *bin_shards_segment_cur = v;
 				size_t vlen_left = vlen;
@@ -1781,7 +1788,7 @@ malloc_narenas_default(void) {
 	 * default.
 	 */
 	if (ncpus > 1) {
-		return ncpus << 2;
+		return ncpus * opt_narenas_ratio;
 	} else {
 		return 1;
 	}


### PR DESCRIPTION
This allows setting arenas per cpu dynamically, rather than forcing the user to
know the number of CPUs in advance if they want a particular CPU/space tradeoff.

Practically, I want this mostly for running my own tuning experiments, rather than because I think end-users should be tweaking it on their own. Leaving it undocumented for now; we can always declare it to be supported later.

The way this sets things up, an explicit narenas setting (of a value other than "default") will still override an narenas_ratio setting (basically saying that the more specific attempt to set wins). This feels right to me; narenas_ratio is setting the default ratio. You can still get the equivalent behavior by setting "narenas:default" at the same time you set the ratio if you don't want this behavior.