### PR TITLE
Move the grow_retained helpers out of PAC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -117,6 +117,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/extent.c \
 	$(srcroot)src/extent_dss.c \
 	$(srcroot)src/extent_mmap.c \
+	$(srcroot)src/geom_grow.c \
 	$(srcroot)src/hook.c \
 	$(srcroot)src/inspect.c \
 	$(srcroot)src/large.c \

--- a/include/jemalloc/internal/ecache.h
+++ b/include/jemalloc/internal/ecache.h
@@ -19,26 +19,6 @@ struct ecache_s {
 	bool delay_coalesce;
 };
 
-typedef struct ecache_grow_s ecache_grow_t;
-struct ecache_grow_s {
-	/*
-	 * Next extent size class in a growing series to use when satisfying a
-	 * request via the extent hooks (only if opt_retain).  This limits the
-	 * number of disjoint virtual memory ranges so that extent merging can
-	 * be effective even if multiple arenas' extent allocation requests are
-	 * highly interleaved.
-	 *
-	 * retain_grow_limit is the max allowed size ind to expand (unless the
-	 * required size is greater).  Default is no limit, and controlled
-	 * through mallctl only.
-	 *
-	 * Synchronization: extent_grow_mtx
-	 */
-	pszind_t next;
-	pszind_t limit;
-	malloc_mutex_t mtx;
-};
-
 static inline size_t
 ecache_npages_get(ecache_t *ecache) {
 	return eset_npages_get(&ecache->eset);
@@ -64,10 +44,5 @@ bool ecache_init(tsdn_t *tsdn, ecache_t *ecache, extent_state_t state,
 void ecache_prefork(tsdn_t *tsdn, ecache_t *ecache);
 void ecache_postfork_parent(tsdn_t *tsdn, ecache_t *ecache);
 void ecache_postfork_child(tsdn_t *tsdn, ecache_t *ecache);
-
-bool ecache_grow_init(tsdn_t *tsdn, ecache_grow_t *ecache_grow);
-void ecache_grow_prefork(tsdn_t *tsdn, ecache_grow_t *ecache_grow);
-void ecache_grow_postfork_parent(tsdn_t *tsdn, ecache_grow_t *ecache_grow);
-void ecache_grow_postfork_child(tsdn_t *tsdn, ecache_grow_t *ecache_grow);
 
 #endif /* JEMALLOC_INTERNAL_ECACHE_H */

--- a/include/jemalloc/internal/geom_grow.h
+++ b/include/jemalloc/internal/geom_grow.h
@@ -13,12 +13,9 @@ struct geom_grow_s {
 	 * retain_grow_limit is the max allowed size ind to expand (unless the
 	 * required size is greater).  Default is no limit, and controlled
 	 * through mallctl only.
-	 *
-	 * Synchronization: mtx
 	 */
 	pszind_t next;
 	pszind_t limit;
-	malloc_mutex_t mtx;
 };
 
 static inline bool
@@ -48,9 +45,6 @@ geom_grow_size_commit(geom_grow_t *geom_grow, pszind_t skip) {
 
 }
 
-bool geom_grow_init(geom_grow_t *geom_grow);
-void geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow);
-void geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow);
-void geom_grow_postfork_child(tsdn_t *tsdn, geom_grow_t *geom_grow);
+void geom_grow_init(geom_grow_t *geom_grow);
 
 #endif /* JEMALLOC_INTERNAL_ECACHE_GROW_H */

--- a/include/jemalloc/internal/geom_grow.h
+++ b/include/jemalloc/internal/geom_grow.h
@@ -21,6 +21,33 @@ struct geom_grow_s {
 	malloc_mutex_t mtx;
 };
 
+static inline bool
+geom_grow_size_prepare(geom_grow_t *geom_grow, size_t alloc_size_min,
+    size_t *r_alloc_size, pszind_t *r_skip) {
+	*r_skip = 0;
+	*r_alloc_size = sz_pind2sz(geom_grow->next + *r_skip);
+	while (*r_alloc_size < alloc_size_min) {
+		(*r_skip)++;
+		if (geom_grow->next + *r_skip  >=
+		    sz_psz2ind(SC_LARGE_MAXCLASS)) {
+			/* Outside legal range. */
+			return true;
+		}
+		*r_alloc_size = sz_pind2sz(geom_grow->next + *r_skip);
+	}
+	return false;
+}
+
+static inline void
+geom_grow_size_commit(geom_grow_t *geom_grow, pszind_t skip) {
+	if (geom_grow->next + skip + 1 <= geom_grow->limit) {
+		geom_grow->next += skip + 1;
+	} else {
+		geom_grow->next = geom_grow->limit;
+	}
+
+}
+
 bool geom_grow_init(tsdn_t *tsdn, geom_grow_t *geom_grow);
 void geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow);
 void geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow);

--- a/include/jemalloc/internal/geom_grow.h
+++ b/include/jemalloc/internal/geom_grow.h
@@ -48,7 +48,7 @@ geom_grow_size_commit(geom_grow_t *geom_grow, pszind_t skip) {
 
 }
 
-bool geom_grow_init(tsdn_t *tsdn, geom_grow_t *geom_grow);
+bool geom_grow_init(geom_grow_t *geom_grow);
 void geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow);
 void geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow);
 void geom_grow_postfork_child(tsdn_t *tsdn, geom_grow_t *geom_grow);

--- a/include/jemalloc/internal/geom_grow.h
+++ b/include/jemalloc/internal/geom_grow.h
@@ -1,0 +1,29 @@
+#ifndef JEMALLOC_INTERNAL_ECACHE_GROW_H
+#define JEMALLOC_INTERNAL_ECACHE_GROW_H
+
+typedef struct geom_grow_s geom_grow_t;
+struct geom_grow_s {
+	/*
+	 * Next extent size class in a growing series to use when satisfying a
+	 * request via the extent hooks (only if opt_retain).  This limits the
+	 * number of disjoint virtual memory ranges so that extent merging can
+	 * be effective even if multiple arenas' extent allocation requests are
+	 * highly interleaved.
+	 *
+	 * retain_grow_limit is the max allowed size ind to expand (unless the
+	 * required size is greater).  Default is no limit, and controlled
+	 * through mallctl only.
+	 *
+	 * Synchronization: mtx
+	 */
+	pszind_t next;
+	pszind_t limit;
+	malloc_mutex_t mtx;
+};
+
+bool geom_grow_init(tsdn_t *tsdn, geom_grow_t *geom_grow);
+void geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow);
+void geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow);
+void geom_grow_postfork_child(tsdn_t *tsdn, geom_grow_t *geom_grow);
+
+#endif /* JEMALLOC_INTERNAL_ECACHE_GROW_H */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -1,7 +1,9 @@
 #ifndef JEMALLOC_INTERNAL_PAC_H
 #define JEMALLOC_INTERNAL_PAC_H
 
+#include "jemalloc/internal/geom_grow.h"
 #include "jemalloc/internal/pai.h"
+
 
 /*
  * Page allocator classic; an implementation of the PAI interface that:
@@ -93,7 +95,7 @@ struct pac_s {
 	edata_cache_t *edata_cache;
 
 	/* The grow info for the retained ecache. */
-	ecache_grow_t ecache_grow;
+	geom_grow_t geom_grow;
 
 	/*
 	 * Decay-based purging state, responsible for scheduling extent state

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -96,6 +96,7 @@ struct pac_s {
 
 	/* The grow info for the retained ecache. */
 	geom_grow_t geom_grow;
+	malloc_mutex_t grow_mtx;
 
 	/*
 	 * Decay-based purging state, responsible for scheduling extent state

--- a/src/ecache.c
+++ b/src/ecache.c
@@ -29,29 +29,3 @@ void
 ecache_postfork_child(tsdn_t *tsdn, ecache_t *ecache) {
 	malloc_mutex_postfork_child(tsdn, &ecache->mtx);
 }
-
-bool
-ecache_grow_init(tsdn_t *tsdn, ecache_grow_t *ecache_grow) {
-	ecache_grow->next = sz_psz2ind(HUGEPAGE);
-	ecache_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
-	if (malloc_mutex_init(&ecache_grow->mtx, "extent_grow",
-	    WITNESS_RANK_EXTENT_GROW, malloc_mutex_rank_exclusive)) {
-		return true;
-	}
-	return false;
-}
-
-void
-ecache_grow_prefork(tsdn_t *tsdn, ecache_grow_t *ecache_grow) {
-	malloc_mutex_prefork(tsdn, &ecache_grow->mtx);
-}
-
-void
-ecache_grow_postfork_parent(tsdn_t *tsdn, ecache_grow_t *ecache_grow) {
-	malloc_mutex_postfork_parent(tsdn, &ecache_grow->mtx);
-}
-
-void
-ecache_grow_postfork_child(tsdn_t *tsdn, ecache_grow_t *ecache_grow) {
-	malloc_mutex_postfork_child(tsdn, &ecache_grow->mtx);
-}

--- a/src/geom_grow.c
+++ b/src/geom_grow.c
@@ -2,7 +2,7 @@
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
 bool
-geom_grow_init(tsdn_t *tsdn, geom_grow_t *geom_grow) {
+geom_grow_init(geom_grow_t *geom_grow) {
 	geom_grow->next = sz_psz2ind(HUGEPAGE);
 	geom_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
 	if (malloc_mutex_init(&geom_grow->mtx, "extent_grow",

--- a/src/geom_grow.c
+++ b/src/geom_grow.c
@@ -1,29 +1,8 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
-bool
+void
 geom_grow_init(geom_grow_t *geom_grow) {
 	geom_grow->next = sz_psz2ind(HUGEPAGE);
 	geom_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
-	if (malloc_mutex_init(&geom_grow->mtx, "extent_grow",
-	    WITNESS_RANK_EXTENT_GROW, malloc_mutex_rank_exclusive)) {
-		return true;
-	}
-	return false;
 }
-
-void
-geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow) {
-	malloc_mutex_prefork(tsdn, &geom_grow->mtx);
-}
-
-void
-geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow) {
-	malloc_mutex_postfork_parent(tsdn, &geom_grow->mtx);
-}
-
-void
-geom_grow_postfork_child(tsdn_t *tsdn, geom_grow_t *geom_grow) {
-	malloc_mutex_postfork_child(tsdn, &geom_grow->mtx);
-}
-

--- a/src/geom_grow.c
+++ b/src/geom_grow.c
@@ -1,0 +1,29 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+bool
+geom_grow_init(tsdn_t *tsdn, geom_grow_t *geom_grow) {
+	geom_grow->next = sz_psz2ind(HUGEPAGE);
+	geom_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
+	if (malloc_mutex_init(&geom_grow->mtx, "extent_grow",
+	    WITNESS_RANK_EXTENT_GROW, malloc_mutex_rank_exclusive)) {
+		return true;
+	}
+	return false;
+}
+
+void
+geom_grow_prefork(tsdn_t *tsdn, geom_grow_t *geom_grow) {
+	malloc_mutex_prefork(tsdn, &geom_grow->mtx);
+}
+
+void
+geom_grow_postfork_parent(tsdn_t *tsdn, geom_grow_t *geom_grow) {
+	malloc_mutex_postfork_parent(tsdn, &geom_grow->mtx);
+}
+
+void
+geom_grow_postfork_child(tsdn_t *tsdn, geom_grow_t *geom_grow) {
+	malloc_mutex_postfork_child(tsdn, &geom_grow->mtx);
+}
+

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -16,7 +16,7 @@ pa_shard_prefork0(tsdn_t *tsdn, pa_shard_t *shard) {
 
 void
 pa_shard_prefork2(tsdn_t *tsdn, pa_shard_t *shard) {
-	ecache_grow_prefork(tsdn, &shard->pac.ecache_grow);
+	geom_grow_prefork(tsdn, &shard->pac.geom_grow);
 }
 
 void
@@ -37,7 +37,7 @@ pa_shard_postfork_parent(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_retained);
-	ecache_grow_postfork_parent(tsdn, &shard->pac.ecache_grow);
+	geom_grow_postfork_parent(tsdn, &shard->pac.geom_grow);
 	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_dirty.mtx);
 	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_muzzy.mtx);
 }
@@ -48,7 +48,7 @@ pa_shard_postfork_child(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_child(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_retained);
-	ecache_grow_postfork_child(tsdn, &shard->pac.ecache_grow);
+	geom_grow_postfork_child(tsdn, &shard->pac.geom_grow);
 	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_dirty.mtx);
 	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_muzzy.mtx);
 }

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -16,7 +16,7 @@ pa_shard_prefork0(tsdn_t *tsdn, pa_shard_t *shard) {
 
 void
 pa_shard_prefork2(tsdn_t *tsdn, pa_shard_t *shard) {
-	geom_grow_prefork(tsdn, &shard->pac.geom_grow);
+	malloc_mutex_prefork(tsdn, &shard->pac.grow_mtx);
 }
 
 void
@@ -37,7 +37,7 @@ pa_shard_postfork_parent(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_parent(tsdn, &shard->pac.ecache_retained);
-	geom_grow_postfork_parent(tsdn, &shard->pac.geom_grow);
+	malloc_mutex_postfork_parent(tsdn, &shard->pac.grow_mtx);
 	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_dirty.mtx);
 	malloc_mutex_postfork_parent(tsdn, &shard->pac.decay_muzzy.mtx);
 }
@@ -48,7 +48,7 @@ pa_shard_postfork_child(tsdn_t *tsdn, pa_shard_t *shard) {
 	ecache_postfork_child(tsdn, &shard->pac.ecache_dirty);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_muzzy);
 	ecache_postfork_child(tsdn, &shard->pac.ecache_retained);
-	geom_grow_postfork_child(tsdn, &shard->pac.geom_grow);
+	malloc_mutex_postfork_child(tsdn, &shard->pac.grow_mtx);
 	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_dirty.mtx);
 	malloc_mutex_postfork_child(tsdn, &shard->pac.decay_muzzy.mtx);
 }

--- a/src/pac.c
+++ b/src/pac.c
@@ -68,7 +68,7 @@ pac_init(tsdn_t *tsdn, pac_t *pac, base_t *base, emap_t *emap,
 	    ind, /* delay_coalesce */ false)) {
 		return true;
 	}
-	if (geom_grow_init(tsdn, &pac->geom_grow)) {
+	if (geom_grow_init(&pac->geom_grow)) {
 		return true;
 	}
 	if (decay_init(&pac->decay_dirty, cur_time, dirty_decay_ms)) {

--- a/src/pac.c
+++ b/src/pac.c
@@ -68,7 +68,7 @@ pac_init(tsdn_t *tsdn, pac_t *pac, base_t *base, emap_t *emap,
 	    ind, /* delay_coalesce */ false)) {
 		return true;
 	}
-	if (ecache_grow_init(tsdn, &pac->ecache_grow)) {
+	if (geom_grow_init(tsdn, &pac->geom_grow)) {
 		return true;
 	}
 	if (decay_init(&pac->decay_dirty, cur_time, dirty_decay_ms)) {
@@ -203,14 +203,14 @@ pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
 		}
 	}
 
-	malloc_mutex_lock(tsdn, &pac->ecache_grow.mtx);
+	malloc_mutex_lock(tsdn, &pac->geom_grow.mtx);
 	if (old_limit != NULL) {
-		*old_limit = sz_pind2sz(pac->ecache_grow.limit);
+		*old_limit = sz_pind2sz(pac->geom_grow.limit);
 	}
 	if (new_limit != NULL) {
-		pac->ecache_grow.limit = new_ind;
+		pac->geom_grow.limit = new_ind;
 	}
-	malloc_mutex_unlock(tsdn, &pac->ecache_grow.mtx);
+	malloc_mutex_unlock(tsdn, &pac->geom_grow.mtx);
 
 	return false;
 }

--- a/test/unit/retained.c
+++ b/test/unit/retained.c
@@ -142,7 +142,7 @@ TEST_BEGIN(test_retained) {
 		size_t usable = 0;
 		size_t fragmented = 0;
 		for (pszind_t pind = sz_psz2ind(HUGEPAGE); pind <
-		    arena->pa_shard.pac.ecache_grow.next; pind++) {
+		    arena->pa_shard.pac.geom_grow.next; pind++) {
 			size_t psz = sz_pind2sz(pind);
 			size_t psz_fragmented = psz % esz;
 			size_t psz_usable = psz - psz_fragmented;


### PR DESCRIPTION
We'll need the same functionality soon for a hugepage allocator elsewhere.