### PR TITLE
Mallctl stress test: fix a type.

### DIFF
--- a/test/stress/mallctl.c
+++ b/test/stress/mallctl.c
@@ -44,9 +44,9 @@ size_t mib_long[6];
 static void
 mallctlbymib_long(void) {
 	size_t miblen = sizeof(mib_long)/sizeof(mib_long[0]);
-	const char *version;
-	size_t sz = sizeof(version);
-	int err = mallctlbymib(mib_long, miblen, &version, &sz, NULL, 0);
+	uint64_t nmalloc;
+	size_t sz = sizeof(nmalloc);
+	int err = mallctlbymib(mib_long, miblen, &nmalloc, &sz, NULL, 0);
 	assert_d_eq(err, 0, "mallctlbymib failure");
 }
 


### PR DESCRIPTION
The mallctlbymib_long helper was copy-pasted from mallctlbymib_short, and
incorrectly used its output variable (a char *) rather than the output variable
of the mallctl call it was using (a uint64_t), causing breakages when
sizeof(char *) differed from sizeof(uint64_t).