### PR TITLE
Do not create size class tables for non-prof builds

### DIFF
--- a/include/jemalloc/internal/prof_data.h
+++ b/include/jemalloc/internal/prof_data.h
@@ -10,6 +10,9 @@ extern malloc_mutex_t prof_dump_mtx;
 extern malloc_mutex_t *gctx_locks;
 extern malloc_mutex_t *tdata_locks;
 
+extern size_t prof_unbiased_sz[SC_NSIZES];
+extern size_t prof_shifted_unbiased_cnt[SC_NSIZES];
+
 void prof_bt_hash(const void *key, size_t r_hash[2]);
 bool prof_bt_keycomp(const void *k1, const void *k2);
 
@@ -17,6 +20,7 @@ bool prof_data_init(tsd_t *tsd);
 prof_tctx_t *prof_lookup(tsd_t *tsd, prof_bt_t *bt);
 char *prof_thread_name_alloc(tsd_t *tsd, const char *thread_name);
 int prof_thread_name_set_impl(tsd_t *tsd, const char *thread_name);
+void prof_unbias_map_init();
 void prof_dump_impl(tsd_t *tsd, write_cb_t *prof_dump_write, void *cbopaque,
     prof_tdata_t *tdata, bool leakcheck);
 prof_tdata_t * prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid,

--- a/include/jemalloc/internal/prof_data.h
+++ b/include/jemalloc/internal/prof_data.h
@@ -10,8 +10,8 @@ extern malloc_mutex_t prof_dump_mtx;
 extern malloc_mutex_t *gctx_locks;
 extern malloc_mutex_t *tdata_locks;
 
-extern size_t prof_unbiased_sz[SC_NSIZES];
-extern size_t prof_shifted_unbiased_cnt[SC_NSIZES];
+extern size_t prof_unbiased_sz[PROF_SC_NSIZES];
+extern size_t prof_shifted_unbiased_cnt[PROF_SC_NSIZES];
 
 void prof_bt_hash(const void *key, size_t r_hash[2]);
 bool prof_bt_keycomp(const void *k1, const void *k2);

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -41,9 +41,6 @@ extern uint64_t prof_interval;
  * resets.
  */
 extern size_t lg_prof_sample;
-extern size_t prof_unbiased_sz[SC_NSIZES];
-extern size_t prof_shifted_unbiased_cnt[SC_NSIZES];
-void prof_unbias_map_init();
 
 extern bool prof_booted;
 

--- a/include/jemalloc/internal/prof_types.h
+++ b/include/jemalloc/internal/prof_types.h
@@ -39,6 +39,14 @@ typedef struct prof_recent_s prof_recent_t;
 #  define PROF_DUMP_BUFSIZE		65536
 #endif
 
+/* Size of size class related tables */
+#ifdef JEMALLOC_PROF
+#  define PROF_SC_NSIZES		SC_NSIZES
+#else
+/* Minimize memory bloat for non-prof builds. */
+#  define PROF_SC_NSIZES		1
+#endif
+
 /* Size of stack-allocated buffer used by prof_printf(). */
 #define PROF_PRINTF_BUFSIZE		128
 

--- a/src/prof.c
+++ b/src/prof.c
@@ -89,6 +89,8 @@ prof_alloc_rollback(tsd_t *tsd, prof_tctx_t *tctx) {
 void
 prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
     size_t usize, prof_tctx_t *tctx) {
+	cassert(config_prof);
+
 	if (opt_prof_sys_thread_name) {
 		prof_sys_thread_name_fetch(tsd);
 	}
@@ -133,6 +135,8 @@ prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 
 void
 prof_free_sampled_object(tsd_t *tsd, size_t usize, prof_info_t *prof_info) {
+	cassert(config_prof);
+
 	assert(prof_info != NULL);
 	prof_tctx_t *tctx = prof_info->alloc_tctx;
 	assert((uintptr_t)tctx > (uintptr_t)1U);

--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -59,8 +59,8 @@ static ckh_t bt2gctx;
  */
 static prof_tdata_tree_t tdatas;
 
-size_t prof_unbiased_sz[SC_NSIZES];
-size_t prof_shifted_unbiased_cnt[SC_NSIZES];
+size_t prof_unbiased_sz[PROF_SC_NSIZES];
+size_t prof_shifted_unbiased_cnt[PROF_SC_NSIZES];
 
 /******************************************************************************/
 /* Red-black trees. */


### PR DESCRIPTION
Save a few KB for non-prof builds. I'm planning to add some more size class related tables for internal fragmentation tracking, so the saving can be more.