### PR TITLE
Omit stats rows with no data

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -806,6 +806,9 @@ stats_arena_hpa_shard_print(emitter_t *emitter, unsigned i, uint64_t uptime) {
 	}
 	emitter_json_array_end(emitter); /* End "nonfull_slabs" */
 	emitter_json_object_end(emitter); /* End "hpa_shard" */
+	if (in_gap) {
+		emitter_table_printf(emitter, "                     ---\n");
+	}
 }
 
 static void

--- a/src/stats.c
+++ b/src/stats.c
@@ -379,6 +379,10 @@ stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i, uint64_t upti
 			    "                     ---\n");
 		}
 
+		if (in_gap && !emitter_outputs_json(emitter)) {
+			continue;
+		}
+
 		CTL_LEAF(arenas_bin_mib, 3, "size", &reg_size, size_t);
 		CTL_LEAF(arenas_bin_mib, 3, "nregs", &nregs, uint32_t);
 		CTL_LEAF(arenas_bin_mib, 3, "slab_size", &slab_size, size_t);


### PR DESCRIPTION
The output for bin stats does not have rows with no data any more; before this change, such rows exist in the output and there would be `---` lines after them whenever the next row was not empty. The output for large sizes stays the same; this change just serves to short-circuit early.