### PR TITLE
Fix szind computation in profiling

### DIFF
--- a/src/prof.c
+++ b/src/prof.c
@@ -99,7 +99,7 @@ prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 	    ptr);
 	prof_info_set(tsd, edata, tctx);
 
-	szind_t szind = sz_size2index(size);
+	szind_t szind = sz_size2index(usize);
 
 	malloc_mutex_lock(tsd_tsdn(tsd), tctx->tdata->lock);
 	/*


### PR DESCRIPTION
The `szind` being computed earlier might have been smaller if the request was a small size plus a large alignment.