### PR TITLE
Dependency generation commands to use compiler flags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -444,7 +444,7 @@ $(C_SYM_OBJS) $(C_OBJS) $(C_PIC_OBJS) $(C_JET_SYM_OBJS) $(C_JET_OBJS) $(C_TESTLI
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $(CPPFLAGS) $(CTARGET) $<
 ifdef CC_MM
-	@$(CC) -MM $(CPPFLAGS) -MT $@ -o $(@:%.$(O)=%.d) $<
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) -MT $@ -o $(@:%.$(O)=%.d) $<
 endif
 
 $(C_SYMS): %.sym:
@@ -468,7 +468,7 @@ $(CPP_OBJS) $(CPP_PIC_OBJS) $(TESTS_CPP_OBJS): %.$(O):
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -c $(CPPFLAGS) $(CTARGET) $<
 ifdef CC_MM
-	@$(CXX) -MM $(CPPFLAGS) -MT $@ -o $(@:%.$(O)=%.d) $<
+	@$(CXX) -MM $(CXXFLAGS) $(CPPFLAGS) -MT $@ -o $(@:%.$(O)=%.d) $<
 endif
 
 ifneq ($(SOREV),$(SO))


### PR DESCRIPTION
Compilers like Clang may require `--gcc-toolchain=` to find std headers. If jemalloc only uses preprocessor flags, dependency generation fails.