### PR TITLE
[Seeking early feedback] Enable profiling for large internal fragmentation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -249,6 +249,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_mdump.c \
 	$(srcroot)test/unit/prof_recent.c \
 	$(srcroot)test/unit/prof_reset.c \
+	$(srcroot)test/unit/prof_select.c \
 	$(srcroot)test/unit/prof_stats.c \
 	$(srcroot)test/unit/prof_tctx.c \
 	$(srcroot)test/unit/prof_thread_name.c \

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -30,6 +30,15 @@ extern bool opt_prof_sys_thread_name;
 /* Whether to record per size class counts and request size totals. */
 extern bool opt_prof_stats;
 
+/* If not 0, profiling will only select allocations of the designated usize. */
+extern size_t opt_prof_select_usize;
+
+/*
+ * If opt_prof_select_usize is not 0, profiling will only select allocations
+ * wasting at least the designated amount of memory in internal fragmentation.
+ */
+extern size_t opt_prof_select_waste;
+
 /* Accessed via prof_active_[gs]et{_unlocked,}(). */
 extern bool prof_active;
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -138,6 +138,8 @@ CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_accum)
 CTL_PROTO(opt_prof_recent_alloc_max)
+CTL_PROTO(opt_prof_select_usize)
+CTL_PROTO(opt_prof_select_waste)
 CTL_PROTO(opt_prof_stats)
 CTL_PROTO(opt_prof_sys_thread_name)
 CTL_PROTO(opt_prof_time_res)
@@ -425,6 +427,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
 	{NAME("prof_accum"),	CTL(opt_prof_accum)},
 	{NAME("prof_recent_alloc_max"),	CTL(opt_prof_recent_alloc_max)},
+	{NAME("prof_select_usize"),	CTL(opt_prof_select_usize)},
+	{NAME("prof_select_waste"),	CTL(opt_prof_select_waste)},
 	{NAME("prof_stats"),	CTL(opt_prof_stats)},
 	{NAME("prof_sys_thread_name"),	CTL(opt_prof_sys_thread_name)},
 	{NAME("prof_time_resolution"),	CTL(opt_prof_time_res)},
@@ -2104,6 +2108,8 @@ CTL_RO_NL_CGEN(config_prof, opt_prof_final, opt_prof_final, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_leak, opt_prof_leak, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_recent_alloc_max,
     opt_prof_recent_alloc_max, ssize_t)
+CTL_RO_NL_CGEN(config_prof, opt_prof_select_usize, opt_prof_select_usize, size_t)
+CTL_RO_NL_CGEN(config_prof, opt_prof_select_waste, opt_prof_select_waste, size_t)
 CTL_RO_NL_CGEN(config_prof, opt_prof_stats, opt_prof_stats, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_sys_thread_name, opt_prof_sys_thread_name,
     bool)

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -318,6 +318,8 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(bool, prof_final, prof);
 	TEST_MALLCTL_OPT(bool, prof_leak, prof);
 	TEST_MALLCTL_OPT(ssize_t, prof_recent_alloc_max, prof);
+	TEST_MALLCTL_OPT(size_t, prof_select_usize, prof);
+	TEST_MALLCTL_OPT(size_t, prof_select_waste, prof);
 	TEST_MALLCTL_OPT(bool, prof_stats, prof);
 	TEST_MALLCTL_OPT(bool, prof_sys_thread_name, prof);
 

--- a/test/unit/prof_select.c
+++ b/test/unit/prof_select.c
@@ -1,0 +1,47 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/prof_data.h"
+
+static void
+check(size_t size, int flags, bool sample) {
+	tsd_t *tsd = tsd_fetch();
+	prof_cnt_t cnt_orig, cnt;
+
+	prof_cnt_all(&cnt_orig);
+
+	void *p = mallocx(size, flags);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+	prof_info_t prof_info;
+	prof_info_get(tsd, p, NULL, &prof_info);
+	expect_b_eq(prof_info.alloc_tctx != (prof_tctx_t *)(uintptr_t)1U,
+	    sample, "");
+	prof_cnt_all(&cnt);
+	expect_u64_eq(cnt_orig.curobjs + (sample ? 1 : 0), cnt.curobjs, "");
+
+	dallocx(p, flags);
+	prof_cnt_all(&cnt);
+	expect_u64_eq(cnt_orig.curobjs, cnt.curobjs, "");
+}
+
+TEST_BEGIN(test_prof_select) {
+	test_skip_if(!config_prof);
+
+	check(8, 0, false);
+	check(8, MALLOCX_ALIGN(32), true);
+	check(12, 0, false);
+	check(12, MALLOCX_ALIGN(32), true);
+	check(17, 0, true);
+	check(17, MALLOCX_ALIGN(64), false);
+	check(20, 0, true);
+	check(20, MALLOCX_ALIGN(64), false);
+	check(21, 0, false);
+	check(32, 0, false);
+	check(38, 0, false);
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_prof_select);
+}

--- a/test/unit/prof_select.sh
+++ b/test/unit/prof_select.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_select_usize:32,prof_select_waste:12"
+fi


### PR DESCRIPTION
This is not meant to be used widely. It's mainly for people who'd want to understand more about a particular type of allocation requests - those with a small request size plus a large alignment. This type of allocation requests results in serious internal fragmentation, given how jemalloc sizing currently works. I want to get some early feedback on where I'm going before adding unit tests.

The current implementation builds on top of profiling - only the "bad" requests get profiled. The "good" allocation requests still need to go through the medium path even though they won't be sampled, because we don't want to afford the "goodness" check on fast path. Profiling is sampled, and it might be beneficial to slightly tune up the profiling frequency when this new mode is turned on.

(I had to borrow #1923 because otherwise the logic would be very different for `rallocx()`.)