### PR TITLE
RFC: allow to specify larger slab sizes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -250,6 +250,13 @@ any of the following arguments (not a definitive list) to 'configure':
     configuration, jemalloc will provide additional size classes that are not
     16-byte-aligned (24, 40, and 56).
 
+* `--with-lg-slab-maxregs=<lg-slab-maxregs>`
+
+    Specify the maximum number of regions in a slab, which is
+    (<lg-page> - <lg-tiny-min>) by default. This increases the limit of slab
+    sizes specified by "slab_sizes" in malloc_conf. This should never be less
+    than the default value.
+
 * `--with-lg-vaddr=<lg-vaddr>`
 
     Specify the number of significant virtual address bits.  By default, the

--- a/configure.ac
+++ b/configure.ac
@@ -1586,6 +1586,15 @@ if test "x$with_lg_quantum" != "x" ; then
   AC_DEFINE_UNQUOTED([LG_QUANTUM], [$with_lg_quantum])
 fi
 
+AC_ARG_WITH([lg_slab_maxregs],
+  [AS_HELP_STRING([--with-lg-slab-maxregs=<lg-slab-maxregs>],
+   [Base 2 log of maximum number of regions in a slab (used with malloc_conf slab_sizes)])],
+  [LG_SLAB_MAXREGS="with_lg_slab_maxregs"],
+  [LG_SLAB_MAXREGS=""])
+if test "x$with_lg_slab_maxregs" != "x" ; then
+  AC_DEFINE_UNQUOTED([LG_SLAB_MAXREGS], [$with_lg_slab_maxregs])
+fi
+
 AC_ARG_WITH([lg_page],
   [AS_HELP_STRING([--with-lg-page=<lg-page>], [Base 2 log of system page size])],
   [LG_PAGE="$with_lg_page"], [LG_PAGE="detect"])

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -182,6 +182,9 @@
 /* One page is 2^LG_PAGE bytes. */
 #undef LG_PAGE
 
+/* Maximum number of regions in a slab. */
+#undef LG_SLAB_MAXREGS
+
 /*
  * One huge page is 2^LG_HUGEPAGE bytes.  Note that this is defined even if the
  * system does not explicitly support huge pages; system calls that require

--- a/include/jemalloc/internal/sc.h
+++ b/include/jemalloc/internal/sc.h
@@ -270,8 +270,14 @@
 #define SC_LARGE_MAXCLASS (SC_MAX_BASE + (SC_NGROUP - 1) * SC_MAX_DELTA)
 
 /* Maximum number of regions in one slab. */
-#define SC_LG_SLAB_MAXREGS (LG_PAGE - SC_LG_TINY_MIN)
-#define SC_SLAB_MAXREGS (1U << LG_SLAB_MAXREGS)
+#ifndef LG_SLAB_MAXREGS
+#  define SC_LG_SLAB_MAXREGS (LG_PAGE - SC_LG_TINY_MIN)
+#elif (LG_SLAB_MAXREGS < (LG_PAGE - SC_LG_TINY_MIN))
+#  error "Unsupported SC_LG_SLAB_MAXREGS"
+#else
+#  define SC_LG_SLAB_MAXREGS LG_SLAB_MAXREGS
+#endif
+#define SC_SLAB_MAXREGS (1U << SC_LG_SLAB_MAXREGS)
 
 
 typedef struct sc_s sc_t;


### PR DESCRIPTION
We may get better performance from larger slab sizes. Currently, there is a malloc_conf `slab_sizes` to set the default slab sizes. But it is limited by `lg-slab-maxregs`, which means the maximum number of regions in a slab.

This patch adds a new configure `--with-lg-slab-maxregs`, which allows to override the default `lg-slab-maxregs`, which is `<lg-page> - <lg-tiny-min>`. The value should not be less than the default value. The max value of this option is related to `LG_BITMAP_MAXBITS` (see more in bitmap.h).

For example, on a 4k page size system, if we:
  1) configure jemalloc with with `--with-lg-slab-maxregs=12`.
  2) `export MALLOC_CONF="slab_sizes:9-16:4"`

The slab size of 16 bytes is set to 4 pages. Previously, the default lg-slab-maxregs is `9 (i.e. 12 - 3)`. The max slab size of 16 bytes is 2 pages (i.e. `(1<<9) * 16` bytes). By increasing the value from 9 to 12, the max slab size can be set by `MALLOC_CONF` is 16 pages (i.e. `(1<<12) * 16` bytes).

---
BTW. another way to increase slab size is by specifying larger `--with-lg-page`, but I think it is not flexible. For example:
1. it increases the slab size of all small size classes, and much more memory usage
2. it makes some previous large size classes to be treated as small size classes.
