### PR TITLE
Mitigate deadlock due to atexit(prof_log_stop_final)

### DIFF
--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -681,7 +681,7 @@ bool prof_log_init(tsd_t *tsd) {
 		prof_log_start(tsd_tsdn(tsd), NULL);
 	}
 
-	if (atexit(prof_log_stop_final) != 0) {
+	if (opt_prof_log && atexit(prof_log_stop_final) != 0) {
 		malloc_write("<jemalloc>: Error in atexit() "
 			     "for logging\n");
 		if (opt_abort) {


### PR DESCRIPTION
Calling `atexit()` can lead to deadlock in scenarios where there is another call to `atexit()` on the call stack.
Here is a similar note I found in the ChangeLog:
```
  - Disable "opt.prof_final" by default, in order to avoid atexit(3), which can
    internally deadlock on some platforms.
```

The call to `atexit(prof_log_stop_final)` is not necessary unless flag `opt_prof_log` is true.
As a result, we protect the call with the flag to mitigate the deadlock -- the default value of `opt_prof_log` is `false`.