### PR TITLE
Remove --with-slab-maxregs options from INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -250,13 +250,6 @@ any of the following arguments (not a definitive list) to 'configure':
     configuration, jemalloc will provide additional size classes that are not
     16-byte-aligned (24, 40, and 56).
 
-* `--with-lg-slab-maxregs=<lg-slab-maxregs>`
-
-    Specify the maximum number of regions in a slab, which is
-    (<lg-page> - <lg-tiny-min>) by default. This increases the limit of slab
-    sizes specified by "slab_sizes" in malloc_conf. This should never be less
-    than the default value.
-
 * `--with-lg-vaddr=<lg-vaddr>`
 
     Specify the number of significant virtual address bits.  By default, the

--- a/configure.ac
+++ b/configure.ac
@@ -1589,10 +1589,10 @@ fi
 AC_ARG_WITH([lg_slab_maxregs],
   [AS_HELP_STRING([--with-lg-slab-maxregs=<lg-slab-maxregs>],
    [Base 2 log of maximum number of regions in a slab (used with malloc_conf slab_sizes)])],
-  [LG_SLAB_MAXREGS="with_lg_slab_maxregs"],
-  [LG_SLAB_MAXREGS=""])
+  [CONFIG_LG_SLAB_MAXREGS="with_lg_slab_maxregs"],
+  [CONFIG_LG_SLAB_MAXREGS=""])
 if test "x$with_lg_slab_maxregs" != "x" ; then
-  AC_DEFINE_UNQUOTED([LG_SLAB_MAXREGS], [$with_lg_slab_maxregs])
+  AC_DEFINE_UNQUOTED([CONFIG_LG_SLAB_MAXREGS], [$with_lg_slab_maxregs])
 fi
 
 AC_ARG_WITH([lg_page],

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -183,7 +183,7 @@
 #undef LG_PAGE
 
 /* Maximum number of regions in a slab. */
-#undef LG_SLAB_MAXREGS
+#undef CONFIG_LG_SLAB_MAXREGS
 
 /*
  * One huge page is 2^LG_HUGEPAGE bytes.  Note that this is defined even if the

--- a/include/jemalloc/internal/sc.h
+++ b/include/jemalloc/internal/sc.h
@@ -270,15 +270,17 @@
 #define SC_LARGE_MAXCLASS (SC_MAX_BASE + (SC_NGROUP - 1) * SC_MAX_DELTA)
 
 /* Maximum number of regions in one slab. */
-#ifndef LG_SLAB_MAXREGS
+#ifndef CONFIG_LG_SLAB_MAXREGS
 #  define SC_LG_SLAB_MAXREGS (LG_PAGE - SC_LG_TINY_MIN)
-#elif (LG_SLAB_MAXREGS < (LG_PAGE - SC_LG_TINY_MIN))
-#  error "Unsupported SC_LG_SLAB_MAXREGS"
 #else
-#  define SC_LG_SLAB_MAXREGS LG_SLAB_MAXREGS
+#  if CONFIG_LG_SLAB_MAXREGS < (LG_PAGE - SC_LG_TINY_MIN)
+#    error "Unsupported SC_LG_SLAB_MAXREGS"
+#  else
+#    define SC_LG_SLAB_MAXREGS CONFIG_LG_SLAB_MAXREGS
+#  endif
 #endif
-#define SC_SLAB_MAXREGS (1U << SC_LG_SLAB_MAXREGS)
 
+#define SC_SLAB_MAXREGS (1U << SC_LG_SLAB_MAXREGS)
 
 typedef struct sc_s sc_t;
 struct sc_s {


### PR DESCRIPTION
The variable slab sizes feature is still experimental; we don't want people to
start using it willy-nilly, or document its existence as a guarantee.

For some reason, the rebased version triggered some failures that the original PR didn't. Work around a triggered -Wundef issue.