### PR TITLE
[RFC] Fix percpu arena by using all available CPUs (not only eligible)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -384,4 +384,7 @@ before_script:
 
 script:
   - make check
+  # trigger possible for incorrect detection of ncpus
+  # (assumes getconf if taskset exists)
+  - if command -v taskset >/dev/null; then echo "Running on last CPU" && taskset --cpu-list $(( $(getconf _NPROCESSORS_ONLN)-1 )) make check; fi
 

--- a/scripts/gen_travis.py
+++ b/scripts/gen_travis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from itertools import combinations
 

--- a/scripts/gen_travis.py
+++ b/scripts/gen_travis.py
@@ -22,6 +22,9 @@ before_script:
 
 script:
   - make check
+  # trigger possible for incorrect detection of ncpus
+  # (assumes getconf if taskset exists)
+  - if command -v taskset >/dev/null; then echo "Running on last CPU" && taskset --cpu-list $(( $(getconf _NPROCESSORS_ONLN)-1 )) make check; fi
 """
 
 # The 'default' configuration is gcc, on linux, with no compiler or configure

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -790,30 +790,6 @@ malloc_ncpus(void) {
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 	result = si.dwNumberOfProcessors;
-#elif defined(CPU_COUNT)
-	/*
-	 * glibc >= 2.6 has the CPU_COUNT macro.
-	 *
-	 * glibc's sysconf() uses isspace().  glibc allocates for the first time
-	 * *before* setting up the isspace tables.  Therefore we need a
-	 * different method to get the number of CPUs.
-	 *
-	 * The getaffinity approach is also preferred when only a subset of CPUs
-	 * is available, to avoid using more arenas than necessary.
-	 */
-	{
-#  if defined(__FreeBSD__)
-		cpuset_t set;
-#  else
-		cpu_set_t set;
-#  endif
-#  if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)
-		sched_getaffinity(0, sizeof(set), &set);
-#  else
-		pthread_getaffinity_np(pthread_self(), sizeof(set), &set);
-#  endif
-		result = CPU_COUNT(&set);
-	}
 #else
 	result = sysconf(_SC_NPROCESSORS_ONLN);
 #endif


### PR DESCRIPTION
Prefer `_SC_NPROCESSORS_ONLN` over `sched_getaffinity()` for number of
arenas for percpu_arena enabled, since `sched_getaffinity()` can be changed in runtime, or it can be
allowed to run only on, say, 8 CPU, but in this case:
- ncpus==1
- but malloc_getcpu() will return 7

And this will trigger the following assertion in debug build:
```
<jemalloc>: ../src/jemalloc.c:321: Failed assertion: "ind <= narenas_total_get()"
```

*Here is a reproducer [1].*

  [1]: https://gist.github.com/azat/9770f751c3e7d2da5422cc1ca26339c4

And AFAICS eligible number of CPUs cannot be used even for
[mutex detection](https://github.com/jemalloc/jemalloc/blob/259c5e3e8f4731f2e32ceac71c66f4bc7d078145/src/mutex.c#L50), since the affinity mask can be changed later.

Refs: #1676
Refs: #808