### PR TITLE
Fix compilation with TinyCC compiler

### DIFF
--- a/include/jemalloc/internal/bit_util.h
+++ b/include/jemalloc/internal/bit_util.h
@@ -75,7 +75,7 @@ fls_u_slow(unsigned x) {
 
 #undef DO_FLS_SLOW
 
-#ifdef JEMALLOC_HAVE_BUILTIN_CLZ
+#ifdef JEMALLOC_HAVE_BUILTIN_CLZ  && !defined(__TINYC__)
 static inline unsigned
 fls_llu(unsigned long long x) {
 	util_assume(x != 0);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203261/94360702-12072880-00e2-11eb-9340-be75dddb48d6.png)

As part of the [effort to make radare2 buildable with TinyCC](https://github.com/radareorg/radare2/pull/17295), which is the only option on some systems since easier to port rather than GCC or Clang.

Current [TinyCC compiler](https://bellard.org/tcc/) version is at https://repo.or.cz/tinycc.git/ - `mob` branch.