### PR TITLE
Add prof_dump_file_overwrite option

### DIFF
--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -24,6 +24,9 @@ extern bool opt_prof_unbias;
 /* For recording recent allocations */
 extern ssize_t opt_prof_recent_alloc_max;
 
+/* Whether to overwrite seq-less dump filenames */
+extern bool opt_prof_dump_overwrite;
+
 /* Whether to use thread name provided by the system or by mallctl. */
 extern bool opt_prof_sys_thread_name;
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -123,6 +123,7 @@ CTL_PROTO(opt_lg_extent_max_active_fit)
 CTL_PROTO(opt_prof)
 CTL_PROTO(opt_prof_prefix)
 CTL_PROTO(opt_prof_active)
+CTL_PROTO(opt_prof_dump_overwrite)
 CTL_PROTO(opt_prof_thread_active_init)
 CTL_PROTO(opt_lg_prof_sample)
 CTL_PROTO(opt_lg_prof_interval)
@@ -380,6 +381,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof"),		CTL(opt_prof)},
 	{NAME("prof_prefix"),	CTL(opt_prof_prefix)},
 	{NAME("prof_active"),	CTL(opt_prof_active)},
+	{NAME("prof_dump_overwrite"),	CTL(opt_prof_dump_overwrite)},
 	{NAME("prof_thread_active_init"), CTL(opt_prof_thread_active_init)},
 	{NAME("lg_prof_sample"), CTL(opt_lg_prof_sample)},
 	{NAME("lg_prof_interval"), CTL(opt_lg_prof_interval)},
@@ -1856,6 +1858,8 @@ CTL_RO_NL_GEN(opt_lg_extent_max_active_fit, opt_lg_extent_max_active_fit,
 CTL_RO_NL_CGEN(config_prof, opt_prof, opt_prof, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_prefix, opt_prof_prefix, const char *)
 CTL_RO_NL_CGEN(config_prof, opt_prof_active, opt_prof_active, bool)
+CTL_RO_NL_CGEN(config_prof, opt_prof_dump_overwrite,
+    opt_prof_dump_overwrite, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_thread_active_init,
     opt_prof_thread_active_init, bool)
 CTL_RO_NL_CGEN(config_prof, opt_lg_prof_sample, opt_lg_prof_sample, size_t)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1486,6 +1486,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 				CONF_HANDLE_CHAR_P(opt_prof_prefix,
 				    "prof_prefix", "jeprof")
 				CONF_HANDLE_BOOL(opt_prof_active, "prof_active")
+				CONF_HANDLE_BOOL(opt_prof_dump_overwrite,
+				    "prof_dump_overwrite")
 				CONF_HANDLE_BOOL(opt_prof_thread_active_init,
 				    "prof_thread_active_init")
 				CONF_HANDLE_SIZE_T(opt_lg_prof_sample,

--- a/src/prof.c
+++ b/src/prof.c
@@ -31,6 +31,7 @@ bool opt_prof_final = false;
 bool opt_prof_leak = false;
 bool opt_prof_accum = false;
 char opt_prof_prefix[PROF_DUMP_FILENAME_LEN];
+bool opt_prof_dump_overwrite = false;
 bool opt_prof_sys_thread_name = false;
 bool opt_prof_unbias = true;
 


### PR DESCRIPTION
Enabling this boolean option results in dumps _NOT_ including seq or
vseq in the filename. Dumps are always written to the same file for a
particular pid and dump type. If a previous dump file exists, it is
unlinked before a new dump is written.

My use-case is as follows:
 * I configure some processes to dump to a known directory via `prof_prefix`, `lg_prof_sample`, `lg_prof_interval` options
    * `prof_prefix` sends the dumps to a small `tmpfs` such that they're never written out to disk
 * Another process ('watcher') periodically checks this directory and does some processing with the _last_ (largest seq num) dump for each dump type
 * When the watcher chooses to process the _last_ files, it deletes the processed files and all earlier dumps

Since my watcher process only cares about the last dump file for each pid, and I have a small `tmpfs` that many processes use, I'd like to limit the number of extraneous files dumped. (Configuring `lg_prof_interval` to closely match the period of 'watcher' such that there aren't any extraneous files is impractical.)

Notes:
* I added an `unlink` before `creat` in `prof_dump_open_file_impl`. This is to deal with the scenario where the watcher is processing an extant dump for a pid while it concurrently decides to do another dump. With `prof_dump_file_overwrite:true` set, this would result in `creat` truncating the existing file. Happy to gate this behind `prof_dump_file_overwrite`.
* I don't know what I'm doing in terms of testing or anything, this is my first contribution. Will look at extant tests and see where I can add tests for this functionality.
