### PR TITLE
Appveyor: don't update msys2 keyring.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,8 +30,6 @@ environment:
 install:
   - set PATH=c:\msys64\%MSYSTEM%\bin;c:\msys64\usr\bin;%PATH%
   - if defined MSVC call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC%
-  - curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
-  - pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz --nodeps
   - if defined MSVC pacman --noconfirm -Rsc mingw-w64-%CPU%-gcc gcc
   - pacman --noconfirm -S mingw-w64-%CPU%-make
 


### PR DESCRIPTION
This is no longer required, and the step now fails.