### PR TITLE
Add thread name in prof last-N records

### DIFF
--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -484,6 +484,12 @@ prof_recent_alloc_dump_node(emitter_t *emitter, prof_recent_t *node) {
 
 	emitter_json_kv(emitter, "alloc_thread_uid", emitter_type_uint64,
 	    &node->alloc_tctx->thr_uid);
+	prof_tdata_t *alloc_tdata = node->alloc_tctx->tdata;
+	assert(alloc_tdata != NULL);
+	if (alloc_tdata->thread_name != NULL) {
+		emitter_json_kv(emitter, "alloc_thread_name",
+		    emitter_type_string, &alloc_tdata->thread_name);
+	}
 	uint64_t alloc_time_ns = nstime_ns(&node->alloc_time);
 	emitter_json_kv(emitter, "alloc_time", emitter_type_uint64,
 	    &alloc_time_ns);
@@ -494,6 +500,12 @@ prof_recent_alloc_dump_node(emitter_t *emitter, prof_recent_t *node) {
 	if (released && node->dalloc_tctx != NULL) {
 		emitter_json_kv(emitter, "dalloc_thread_uid",
 		    emitter_type_uint64, &node->dalloc_tctx->thr_uid);
+		prof_tdata_t *dalloc_tdata = node->dalloc_tctx->tdata;
+		assert(dalloc_tdata != NULL);
+		if (dalloc_tdata->thread_name != NULL) {
+			emitter_json_kv(emitter, "dalloc_thread_name",
+			    emitter_type_string, &dalloc_tdata->thread_name);
+		}
 		assert(!nstime_equals_zero(&node->dalloc_time));
 		uint64_t dalloc_time_ns = nstime_ns(&node->dalloc_time);
 		emitter_json_kv(emitter, "dalloc_time", emitter_type_uint64,


### PR DESCRIPTION
What I have for now may or may not work: it depends on the integrity of the `tdata` the `tctx` points to. I saw some cautioning comments:
https://github.com/jemalloc/jemalloc/blob/be9548f2bef30b75294fdd0eb6721d1bf6e6a56a/include/jemalloc/internal/prof_structs.h#L47-L52
I think the `tdata` should be living nicely as long as it has a positive number of associated `tctx`s? Does the "teardown" in that comment mean program exit, e.g. mainly for the `prof_final` case? Let me also see if any tests may fail...