### PR TITLE
Route batch allocation of small batch size to tcache

### DIFF
--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -317,6 +317,18 @@ cache_bin_alloc(cache_bin_t *bin, bool *success) {
 	return cache_bin_alloc_impl(bin, success, true);
 }
 
+JEMALLOC_ALWAYS_INLINE cache_bin_sz_t
+cache_bin_alloc_batch(cache_bin_t *bin, size_t num, void **out) {
+	size_t n = cache_bin_ncached_get_internal(bin);
+	if (n > num) {
+		n = num;
+	}
+	memcpy(out, bin->stack_head, n * sizeof(void *));
+	bin->stack_head += n;
+	cache_bin_low_water_adjust(bin);
+	return n;
+}
+
 /*
  * Free an object into the given bin.  Fails only if the bin is full.
  */

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -84,7 +84,7 @@ cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
 	assert(cache_bin_diff(bin, bin->low_bits_full,
 	    (uint16_t)(uintptr_t) bin->stack_head) == bin_stack_size);
 	assert(cache_bin_ncached_get(bin, info) == 0);
-	assert(cache_bin_empty_position_get(bin, info) == empty_position);
+	assert(cache_bin_empty_position_get(bin) == empty_position);
 
 	assert(bin_stack_size > 0 || empty_position == full_position);
 }

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -186,7 +186,7 @@ TEST_BEGIN(test_cache_bin) {
 	    ncached_max / 2);
 	/* Try to fill some, succeed partially. */
 	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max / 2,
-	    ncached_max / 2);
+	    ncached_max / 4);
 	/* Try to fill some, fail completely. */
 	do_fill_test(&bin, &info, ptrs, ncached_max, ncached_max / 2, 0);
 
@@ -196,6 +196,8 @@ TEST_BEGIN(test_cache_bin) {
 	do_flush_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 2);
 	do_flush_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 4);
 	do_flush_test(&bin, &info, ptrs, ncached_max / 2, 0);
+
+	free(ptrs);
 }
 TEST_END
 


### PR DESCRIPTION
For batch allocation requests of small sizes, instead of going to the page allocator for a fresh new slab, follow the ordinary hierarchy i.e. tcache -> arena -> page allocator, to improve performance. The downside is of course memory locality; however, locality was originally a best effort anyway.

A few remarks on the current version:
- I don't yet have a great way to determine the size threshold for deciding which route ("tcache route" / "page allocator route") the request should go through. Right now I just put an arbitrary number as a placeholder. I think there are a few aspects we need to consider here:
  - Improvement on performance. If we plot the difference in performance between the two routes against the batch size, then I imagine there are two big jumps: one is around the point at which the request cannot be fulfilled by the tcache without going to the arena, the other is around the point at which the request cannot be fulfilled by existing slabs in the arena without going to the page allocator. Both these two points can be a wider range instead of a single point (so the jump may be a steady one rather than a sudden one). Meanwhile, not sure about the magnitude of the two jumps: I suspect that the first jump should be quite significant, but how about the second one?
  - Cost on locality: locality is correlated with performance of later memory access by the caller, in particular sequential memory access, so locality also comes with a performance price tag, though a harder-to-measure one. Therefore, in theory, we can also plot the difference in memory access performance between the two routes against the batch size, and try to find a good spot to set the threshold. The order of memory locality, from worst to best, is tcache -> existing slabs in arena -> fresh new slabs; not sure how that'd translate to how the plot would look like.
  - It seems to me that many things I touched above have some dependencies on the caller. So, if we want to be lazy / flexible, we also have the option of asking the caller to choose, and to of course also bear the tuning effort. In such a case, we may have a default (of e.g. always going through one route). For the caller flag, we can use `MALLOCX_TCACHE_AUTO` / `MALLOCX_TCACHE_NONE` for the distinction.
- If we decide to have a size threshold ourselves rather than letting the caller specify, then we may want to allow the caller to specify the mallocx tcache flag. If the batch size is large, we can ignore the specified flag. However, if the batch size is small, then we need to decide what to do when the caller specifies `MALLOCX_TCACHE_NONE`. Obviously, we can ignore it. Meanwhile, it might also make some sense to treat that as "I don't care about performance", so we can go for the "page allocator route", to optimize for locality. If so, then the caller essentially has a "one way" overwrite privilege to our "route decision".
- Previously, I applied special care to the batch allocation API so that, whenever a manual arena is specified, we only serve memory strictly from that arena. Now, if tcache is allowed, then we can no longer guarantee that in the batch allocation API, just as the case for all other APIs we have. Therefore, I decide to simply save the effort and not try even when I can i.e. when the tcache is bypassed.
- When going through the tcache route, I make the tcache bin act as a middleman, and I never explicitly touch the arena level. This approach may not be optimal if the batch size is large enough to require more than one refill from the arena, when compared to the alternative approach where, whenever the tcache is depleted, I directly go to the arena and collect the remaining batch. My current approach is just easier to implement, since it roughly follows the original logic structure I had. Meanwhile, it might not be too bad, because we only decide to route through the tcache when the batch size is small, and it has the advantage of not leaving the tcache empty for the next allocation request. However, I'm also open to the alternative approach, and my guess is that I'd need to do some refactorings first for it.
- For unit tests, I currently short-circuit the locality and stats tests whenever the tcache route is chosen: the locality tests are irrelevant; there might be some opportunity for some stats tests, but it might be complicated to write. Please let me know your thoughts.
- I previously did not optimize for large sizes, but now it's sometimes possible, when (a) the size is not too large to be cached in tcache and (b) the batch size is small. Will do that after the core logic settles.