### PR TITLE
Add NULL check when coalescing backwards.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -1641,8 +1641,11 @@ extent_try_coalesce_impl(tsdn_t *tsdn, arena_t *arena,
 		}
 
 		/* Try to coalesce backward. */
-		extent_t *prev = extent_lock_from_addr(tsdn, rtree_ctx,
-		    extent_before_get(extent), inactive_only);
+		extent_t *prev = NULL;
+		if (extent_before_get(extent) != NULL) {
+			prev = extent_lock_from_addr(tsdn, rtree_ctx,
+			    extent_before_get(extent), inactive_only);
+		}
 		if (prev != NULL) {
 			bool can_coalesce = extent_can_coalesce(arena, extents,
 			    extent, prev);


### PR DESCRIPTION
When testing ASLR implementation on FreeBSD we have noticed that every time we tried to build FreeBSD world with ASLR enabled on 32-bit target machines, the build failed with following message:
```
<jemalloc>: /usr/home/mindal/git/freebsd/contrib/jemalloc/include/jemalloc/internal/rtree.h:329: Failed assertion: "key != 0"
Abort trap (core dumped)
```
Looking at ktrace logs from multiple test runs, it seems that this assertion always fails when `mmap()` returns 0x1000. When trying to get previous extent, `extent_before_get()` subtracts page size from current address, which resolves to zero and this triggers the assertion in `rtree_leaf_elm_looup()`.

I looked at `dev` branch and the same fix should apply, however I had some problems when trying to import it into FreeBSD source tree and I wasn't able to test it further, so I'm leaving this as PR to master for now.