### PR TITLE
Rename geom_grow -> exp_grow.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -114,10 +114,10 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/ehooks.c \
 	$(srcroot)src/emap.c \
 	$(srcroot)src/eset.c \
+	$(srcroot)src/exp_grow.c \
 	$(srcroot)src/extent.c \
 	$(srcroot)src/extent_dss.c \
 	$(srcroot)src/extent_mmap.c \
-	$(srcroot)src/geom_grow.c \
 	$(srcroot)src/hook.c \
 	$(srcroot)src/hpa.c \
 	$(srcroot)src/hpa_central.c \

--- a/include/jemalloc/internal/exp_grow.h
+++ b/include/jemalloc/internal/exp_grow.h
@@ -1,8 +1,8 @@
-#ifndef JEMALLOC_INTERNAL_ECACHE_GROW_H
-#define JEMALLOC_INTERNAL_ECACHE_GROW_H
+#ifndef JEMALLOC_INTERNAL_EXP_GROW_H
+#define JEMALLOC_INTERNAL_EXP_GROW_H
 
-typedef struct geom_grow_s geom_grow_t;
-struct geom_grow_s {
+typedef struct exp_grow_s exp_grow_t;
+struct exp_grow_s {
 	/*
 	 * Next extent size class in a growing series to use when satisfying a
 	 * request via the extent hooks (only if opt_retain).  This limits the
@@ -19,32 +19,32 @@ struct geom_grow_s {
 };
 
 static inline bool
-geom_grow_size_prepare(geom_grow_t *geom_grow, size_t alloc_size_min,
+exp_grow_size_prepare(exp_grow_t *exp_grow, size_t alloc_size_min,
     size_t *r_alloc_size, pszind_t *r_skip) {
 	*r_skip = 0;
-	*r_alloc_size = sz_pind2sz(geom_grow->next + *r_skip);
+	*r_alloc_size = sz_pind2sz(exp_grow->next + *r_skip);
 	while (*r_alloc_size < alloc_size_min) {
 		(*r_skip)++;
-		if (geom_grow->next + *r_skip  >=
+		if (exp_grow->next + *r_skip  >=
 		    sz_psz2ind(SC_LARGE_MAXCLASS)) {
 			/* Outside legal range. */
 			return true;
 		}
-		*r_alloc_size = sz_pind2sz(geom_grow->next + *r_skip);
+		*r_alloc_size = sz_pind2sz(exp_grow->next + *r_skip);
 	}
 	return false;
 }
 
 static inline void
-geom_grow_size_commit(geom_grow_t *geom_grow, pszind_t skip) {
-	if (geom_grow->next + skip + 1 <= geom_grow->limit) {
-		geom_grow->next += skip + 1;
+exp_grow_size_commit(exp_grow_t *exp_grow, pszind_t skip) {
+	if (exp_grow->next + skip + 1 <= exp_grow->limit) {
+		exp_grow->next += skip + 1;
 	} else {
-		geom_grow->next = geom_grow->limit;
+		exp_grow->next = exp_grow->limit;
 	}
 
 }
 
-void geom_grow_init(geom_grow_t *geom_grow);
+void exp_grow_init(exp_grow_t *exp_grow);
 
-#endif /* JEMALLOC_INTERNAL_ECACHE_GROW_H */
+#endif /* JEMALLOC_INTERNAL_EXP_GROW_H */

--- a/include/jemalloc/internal/hpa.h
+++ b/include/jemalloc/internal/hpa.h
@@ -1,7 +1,7 @@
 #ifndef JEMALLOC_INTERNAL_HPA_H
 #define JEMALLOC_INTERNAL_HPA_H
 
-#include "jemalloc/internal/geom_grow.h"
+#include "jemalloc/internal/exp_grow.h"
 #include "jemalloc/internal/hpa_central.h"
 #include "jemalloc/internal/pai.h"
 #include "jemalloc/internal/psset.h"
@@ -29,7 +29,7 @@ struct hpa_s {
 	 * small finite number of allocations from it.
 	 */
 	edata_cache_t *edata_cache;
-	geom_grow_t geom_grow;
+	exp_grow_t exp_grow;
 };
 
 /* Used only by CTL; not actually stored here (i.e., all derived). */

--- a/include/jemalloc/internal/pac.h
+++ b/include/jemalloc/internal/pac.h
@@ -1,7 +1,7 @@
 #ifndef JEMALLOC_INTERNAL_PAC_H
 #define JEMALLOC_INTERNAL_PAC_H
 
-#include "jemalloc/internal/geom_grow.h"
+#include "jemalloc/internal/exp_grow.h"
 #include "jemalloc/internal/pai.h"
 
 
@@ -95,7 +95,7 @@ struct pac_s {
 	edata_cache_t *edata_cache;
 
 	/* The grow info for the retained ecache. */
-	geom_grow_t geom_grow;
+	exp_grow_t exp_grow;
 	malloc_mutex_t grow_mtx;
 
 	/*

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="..\..\..\..\src\ehooks.c" />
     <ClCompile Include="..\..\..\..\src\emap.c" />
     <ClCompile Include="..\..\..\..\src\eset.c" />
+    <ClCompile Include="..\..\..\..\src\exp_grow.c" />
     <ClCompile Include="..\..\..\..\src\extent.c" />
     <ClCompile Include="..\..\..\..\src\extent_dss.c" />
     <ClCompile Include="..\..\..\..\src\extent_mmap.c" />

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="..\..\..\..\src\emap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\exp_grow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\extent.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="..\..\..\..\src\ehooks.c" />
     <ClCompile Include="..\..\..\..\src\emap.c" />
     <ClCompile Include="..\..\..\..\src\eset.c" />
+    <ClCompile Include="..\..\..\..\src\exp_grow.c" />
     <ClCompile Include="..\..\..\..\src\extent.c" />
     <ClCompile Include="..\..\..\..\src\extent_dss.c" />
     <ClCompile Include="..\..\..\..\src\extent_mmap.c" />

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="..\..\..\..\src\emap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\exp_grow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\extent.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/exp_grow.c
+++ b/src/exp_grow.c
@@ -1,0 +1,8 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+void
+exp_grow_init(exp_grow_t *exp_grow) {
+	exp_grow->next = sz_psz2ind(HUGEPAGE);
+	exp_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
+}

--- a/src/extent.c
+++ b/src/extent.c
@@ -626,9 +626,9 @@ extent_grow_retained(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
 	 * satisfy this request.
 	 */
 	size_t alloc_size;
-	pszind_t geom_grow_skip;
-	bool err = geom_grow_size_prepare(&pac->geom_grow, alloc_size_min,
-	    &alloc_size, &geom_grow_skip);
+	pszind_t exp_grow_skip;
+	bool err = exp_grow_size_prepare(&pac->exp_grow, alloc_size_min,
+	    &alloc_size, &exp_grow_skip);
 	if (err) {
 		goto label_err;
 	}
@@ -724,7 +724,7 @@ extent_grow_retained(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
 	 * range.
 	 */
 	/* All opportunities for failure are past. */
-	geom_grow_size_commit(&pac->geom_grow, geom_grow_skip);
+	exp_grow_size_commit(&pac->exp_grow, exp_grow_skip);
 	malloc_mutex_unlock(tsdn, &pac->grow_mtx);
 
 	if (config_prof) {

--- a/src/geom_grow.c
+++ b/src/geom_grow.c
@@ -1,8 +1,0 @@
-#include "jemalloc/internal/jemalloc_preamble.h"
-#include "jemalloc/internal/jemalloc_internal_includes.h"
-
-void
-geom_grow_init(geom_grow_t *geom_grow) {
-	geom_grow->next = sz_psz2ind(HUGEPAGE);
-	geom_grow->limit = sz_psz2ind(SC_LARGE_MAXCLASS);
-}

--- a/src/hpa.c
+++ b/src/hpa.c
@@ -43,7 +43,7 @@ hpa_init(hpa_t *hpa, base_t *base, emap_t *emap, edata_cache_t *edata_cache) {
 	hpa->ind = base_ind_get(base);
 	hpa->edata_cache = edata_cache;
 
-	geom_grow_init(&hpa->geom_grow);
+	exp_grow_init(&hpa->exp_grow);
 
 	return false;
 }
@@ -132,7 +132,7 @@ hpa_alloc_central(tsdn_t *tsdn, hpa_shard_t *shard, size_t size_min,
 
 	size_t hugepage_goal_min = HUGEPAGE_CEILING(size_goal);
 
-	err = geom_grow_size_prepare(&hpa->geom_grow, hugepage_goal_min,
+	err = exp_grow_size_prepare(&hpa->exp_grow, hugepage_goal_min,
 	    &alloc_size, &skip);
 	if (err) {
 		malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
@@ -183,7 +183,7 @@ hpa_alloc_central(tsdn_t *tsdn, hpa_shard_t *shard, size_t size_min,
 	malloc_mutex_unlock(tsdn, &hpa->mtx);
 
 	if (!err) {
-		geom_grow_size_commit(&hpa->geom_grow, skip);
+		exp_grow_size_commit(&hpa->exp_grow, skip);
 	}
 	malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
 	edata_arena_ind_set(edata, shard->ind);

--- a/src/pac.c
+++ b/src/pac.c
@@ -68,7 +68,7 @@ pac_init(tsdn_t *tsdn, pac_t *pac, base_t *base, emap_t *emap,
 	    ind, /* delay_coalesce */ false)) {
 		return true;
 	}
-	geom_grow_init(&pac->geom_grow);
+	exp_grow_init(&pac->exp_grow);
 	if (malloc_mutex_init(&pac->grow_mtx, "extent_grow",
 	    WITNESS_RANK_EXTENT_GROW, malloc_mutex_rank_exclusive)) {
 		return true;
@@ -207,10 +207,10 @@ pac_retain_grow_limit_get_set(tsdn_t *tsdn, pac_t *pac, size_t *old_limit,
 
 	malloc_mutex_lock(tsdn, &pac->grow_mtx);
 	if (old_limit != NULL) {
-		*old_limit = sz_pind2sz(pac->geom_grow.limit);
+		*old_limit = sz_pind2sz(pac->exp_grow.limit);
 	}
 	if (new_limit != NULL) {
-		pac->geom_grow.limit = new_ind;
+		pac->exp_grow.limit = new_ind;
 	}
 	malloc_mutex_unlock(tsdn, &pac->grow_mtx);
 

--- a/test/unit/retained.c
+++ b/test/unit/retained.c
@@ -143,7 +143,7 @@ TEST_BEGIN(test_retained) {
 		size_t usable = 0;
 		size_t fragmented = 0;
 		for (pszind_t pind = sz_psz2ind(HUGEPAGE); pind <
-		    arena->pa_shard.pac.geom_grow.next; pind++) {
+		    arena->pa_shard.pac.exp_grow.next; pind++) {
 			size_t psz = sz_pind2sz(pind);
 			size_t psz_fragmented = psz % esz;
 			size_t psz_usable = psz - psz_fragmented;


### PR DESCRIPTION
This was promised in the review of the introduction of geom_grow, but would have
been painful to do there because of the series that introduced it.  Now that
those are comitted, renaming is easier.