### PR TITLE
HPA: More directly assign hugepage ownership to arenas

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -121,6 +121,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/hook.c \
 	$(srcroot)src/hpa.c \
 	$(srcroot)src/hpa_central.c \
+	$(srcroot)src/hpdata.c \
 	$(srcroot)src/inspect.c \
 	$(srcroot)src/large.c \
 	$(srcroot)src/log.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -217,6 +217,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/hook.c \
 	$(srcroot)test/unit/hpa.c \
 	$(srcroot)test/unit/hpa_central.c \
+	$(srcroot)test/unit/hpdata.c \
 	$(srcroot)test/unit/huge.c \
 	$(srcroot)test/unit/inspect.c \
 	$(srcroot)test/unit/junk.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1594,6 +1594,7 @@ JE_COMPILABLE([a program using __builtin_popcountl], [
 if test "x${je_cv_gcc_builtin_popcountl}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_INTERNAL_POPCOUNT], [__builtin_popcount])
   AC_DEFINE([JEMALLOC_INTERNAL_POPCOUNTL], [__builtin_popcountl])
+  AC_DEFINE([JEMALLOC_INTERNAL_POPCOUNTLL], [__builtin_popcountll])
 fi
 
 AC_ARG_WITH([lg_quantum],

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -16,7 +16,6 @@ extern const char *percpu_arena_mode_names[];
 extern const uint64_t h_steps[SMOOTHSTEP_NSTEPS];
 extern malloc_mutex_t arenas_lock;
 extern emap_t arena_emap_global;
-extern hpa_t arena_hpa_global;
 
 extern size_t opt_oversize_threshold;
 extern size_t oversize_threshold;

--- a/include/jemalloc/internal/edata.h
+++ b/include/jemalloc/internal/edata.h
@@ -208,9 +208,9 @@ struct edata_s {
 		 */
 
 		/*
-		 * If this edata is from an HPA, it may be part of some larger
-		 * pageslab.  Track it if so.  Otherwise (either because it's
-		 * not part of a pageslab, or not from the HPA at all), NULL.
+		 * If this edata is a user allocation from an HPA, it comes out
+		 * of some pageslab (we don't yet support huegpage allocations
+		 * that don't fit into pageslabs).  This tracks it.
 		 */
 		edata_t *ps;
 		/*
@@ -225,6 +225,8 @@ struct edata_s {
 			 * between heaps.
 			 */
 			uint32_t longest_free_range;
+			/* Whether or not the slab is backed by a hugepage. */
+			bool hugeified;
 		};
 	};
 
@@ -326,6 +328,11 @@ static inline extent_pai_t
 edata_pai_get(const edata_t *edata) {
 	return (extent_pai_t)((edata->e_bits & EDATA_BITS_PAI_MASK) >>
 	    EDATA_BITS_PAI_SHIFT);
+}
+
+static inline bool
+edata_hugeified_get(const edata_t *edata) {
+	return edata->hugeified;
 }
 
 static inline bool
@@ -557,6 +564,11 @@ static inline void
 edata_pai_set(edata_t *edata, extent_pai_t pai) {
 	edata->e_bits = (edata->e_bits & ~EDATA_BITS_PAI_MASK) |
 	    ((uint64_t)pai << EDATA_BITS_PAI_SHIFT);
+}
+
+static inline void
+edata_hugeified_set(edata_t *edata, bool hugeified) {
+	edata->hugeified = hugeified;
 }
 
 static inline void

--- a/include/jemalloc/internal/hpa.h
+++ b/include/jemalloc/internal/hpa.h
@@ -35,8 +35,7 @@ struct hpa_s {
 /* Used only by CTL; not actually stored here (i.e., all derived). */
 typedef struct hpa_shard_stats_s hpa_shard_stats_t;
 struct hpa_shard_stats_s {
-	psset_bin_stats_t psset_full_slab_stats;
-	psset_bin_stats_t psset_slab_stats[PSSET_NPSIZES];
+	psset_stats_t psset_stats;
 };
 
 typedef struct hpa_shard_s hpa_shard_t;
@@ -89,6 +88,9 @@ bool hpa_init(hpa_t *hpa, base_t *base, emap_t *emap,
 bool hpa_shard_init(hpa_shard_t *shard, hpa_t *hpa,
     edata_cache_t *edata_cache, unsigned ind, size_t ps_goal,
     size_t ps_alloc_max, size_t small_max, size_t large_min);
+
+void hpa_stats_accum(hpa_shard_stats_t *dst, hpa_shard_stats_t *src);
+void hpa_stats_merge(tsdn_t *tsdn, hpa_shard_t *shard, hpa_shard_stats_t *dst);
 /*
  * Notify the shard that we won't use it for allocations much longer.  Due to
  * the possibility of races, we don't actually prevent allocations; just flush

--- a/include/jemalloc/internal/hpa.h
+++ b/include/jemalloc/internal/hpa.h
@@ -21,6 +21,8 @@ struct hpa_shard_s {
 	pai_t pai;
 	malloc_mutex_t grow_mtx;
 	malloc_mutex_t mtx;
+	/* The base metadata allocator. */
+	base_t *base;
 	/*
 	 * This edata cache is the one we use when allocating a small extent
 	 * from a pageslab.  The pageslab itself comes from the centralized
@@ -45,7 +47,14 @@ struct hpa_shard_s {
 	 *
 	 * Guarded by grow_mtx.
 	 */
-	edata_list_inactive_t unused_slabs;
+	hpdata_list_t unused_slabs;
+
+	/*
+	 * How many grow operations have occurred.
+	 *
+	 * Guarded by grow_mtx.
+	 */
+	uint64_t age_counter;
 
 	/*
 	 * Either NULL (if empty), or some integer multiple of a
@@ -54,7 +63,8 @@ struct hpa_shard_s {
 	 *
 	 * Guarded by grow_mtx.
 	 */
-	edata_t *eden;
+	void *eden;
+	size_t eden_len;
 
 	/* The arena ind we're associated with. */
 	unsigned ind;
@@ -67,7 +77,7 @@ struct hpa_shard_s {
  * just that it can function properly given the system it's running on.
  */
 bool hpa_supported();
-bool hpa_shard_init(hpa_shard_t *shard, emap_t *emap,
+bool hpa_shard_init(hpa_shard_t *shard, emap_t *emap, base_t *base,
     edata_cache_t *edata_cache, unsigned ind, size_t alloc_max);
 
 void hpa_shard_stats_accum(hpa_shard_stats_t *dst, hpa_shard_stats_t *src);

--- a/include/jemalloc/internal/hpa.h
+++ b/include/jemalloc/internal/hpa.h
@@ -6,10 +6,12 @@
 #include "jemalloc/internal/pai.h"
 #include "jemalloc/internal/psset.h"
 
-/* Used only by CTL; not actually stored here (i.e., all derived). */
+/* Completely derived; only used by CTL. */
 typedef struct hpa_shard_stats_s hpa_shard_stats_t;
 struct hpa_shard_stats_s {
 	psset_stats_t psset_stats;
+	/* The stat version of the nevictions counter. */
+	uint64_t nevictions;
 };
 
 typedef struct hpa_shard_s hpa_shard_t;
@@ -69,6 +71,14 @@ struct hpa_shard_s {
 	/* The arena ind we're associated with. */
 	unsigned ind;
 	emap_t *emap;
+
+	/*
+	 * The number of times we've purged a hugepage.  Each eviction purges a
+	 * single hugepage.
+	 *
+	 * Guarded by the grow mutex.
+	 */
+	uint64_t nevictions;
 };
 
 /*

--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -1,0 +1,124 @@
+#ifndef JEMALLOC_INTERNAL_HPDATA_H
+#define JEMALLOC_INTERNAL_HPDATA_H
+
+#include "jemalloc/internal/flat_bitmap.h"
+#include "jemalloc/internal/ph.h"
+#include "jemalloc/internal/ql.h"
+#include "jemalloc/internal/typed_list.h"
+
+/*
+ * The metadata representation we use for extents in hugepages.  While the PAC
+ * uses the edata_t to represent both active and inactive extents, the HP only
+ * uses the edata_t for active ones; instead, inactive extent state is tracked
+ * within hpdata associated with the enclosing hugepage-sized, hugepage-aligned
+ * region of virtual address space.
+ *
+ * An hpdata need not be "truly" backed by a hugepage (which is not necessarily
+ * an observable property of any given region of address space).  It's just
+ * hugepage-sized and hugepage-aligned; it's *potentially* huge.
+ */
+typedef struct hpdata_s hpdata_t;
+struct hpdata_s {
+	/*
+	 * We likewise follow the edata convention of mangling names and forcing
+	 * the use of accessors -- this lets us add some consistency checks on
+	 * access.
+	 */
+
+	/*
+	 * The address of the hugepage in question.  This can't be named h_addr,
+	 * since that conflicts with a macro defined in Windows headers.
+	 */
+	void *h_address;
+	/* Its age (measured in psset operations). */
+	uint64_t h_age;
+	/* Whether or not we think the hugepage is mapped that way by the OS. */
+	bool h_huge;
+	union {
+		/* When nonempty, used by the psset bins. */
+		phn(hpdata_t) ph_link;
+		/*
+		 * When empty (or not corresponding to any hugepage), list
+		 * linkage.
+		 */
+		ql_elm(hpdata_t) ql_link;
+	};
+
+	/* Number of currently free pages (regardless of contiguity). */
+	size_t h_nfree;
+	/* The length of the largest contiguous sequence of inactive pages. */
+	size_t h_longest_free_range;
+
+	/* A bitmap with bits set in the active pages. */
+	fb_group_t active_pages[FB_NGROUPS(HUGEPAGE_PAGES)];
+};
+
+static inline void *
+hpdata_addr_get(const hpdata_t *hpdata) {
+	return hpdata->h_address;
+}
+
+static inline void
+hpdata_addr_set(hpdata_t *hpdata, void *addr) {
+	assert(HUGEPAGE_ADDR2BASE(addr) == addr);
+	hpdata->h_address = addr;
+}
+
+static inline uint64_t
+hpdata_age_get(const hpdata_t *hpdata) {
+	return hpdata->h_age;
+}
+
+static inline void
+hpdata_age_set(hpdata_t *hpdata, uint64_t age) {
+	hpdata->h_age = age;
+}
+
+static inline bool
+hpdata_huge_get(const hpdata_t *hpdata) {
+	return hpdata->h_huge;
+}
+
+static inline void
+hpdata_huge_set(hpdata_t *hpdata, bool huge) {
+	hpdata->h_huge = huge;
+}
+
+static inline size_t
+hpdata_nfree_get(const hpdata_t *hpdata) {
+	return hpdata->h_nfree;
+}
+
+static inline void
+hpdata_nfree_set(hpdata_t *hpdata, size_t nfree) {
+	assert(nfree <= HUGEPAGE_PAGES);
+	hpdata->h_nfree = nfree;
+}
+
+static inline size_t
+hpdata_longest_free_range_get(const hpdata_t *hpdata) {
+	return hpdata->h_longest_free_range;
+}
+
+static inline void
+hpdata_longest_free_range_set(hpdata_t *hpdata, size_t longest_free_range) {
+	assert(longest_free_range <= HUGEPAGE_PAGES);
+	hpdata->h_longest_free_range = longest_free_range;
+}
+
+static inline void
+hpdata_init(hpdata_t *hpdata, void *addr, uint64_t age) {
+	hpdata_addr_set(hpdata, addr);
+	hpdata_age_set(hpdata, age);
+	hpdata_huge_set(hpdata, false);
+	hpdata_nfree_set(hpdata, HUGEPAGE_PAGES);
+	hpdata_longest_free_range_set(hpdata, HUGEPAGE_PAGES);
+	fb_init(hpdata->active_pages, HUGEPAGE_PAGES);
+}
+
+TYPED_LIST(hpdata_list, hpdata_t, ql_link)
+
+typedef ph(hpdata_t) hpdata_age_heap_t;
+ph_proto(, hpdata_age_heap_, hpdata_age_heap_t, hpdata_t);
+
+#endif /* JEMALLOC_INTERNAL_HPDATA_H */

--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -114,8 +114,15 @@ hpdata_assert_empty(hpdata_t *hpdata) {
 
 static inline bool
 hpdata_consistent(hpdata_t *hpdata) {
-	return fb_urange_longest(hpdata->active_pages, HUGEPAGE_PAGES)
-	    == hpdata_longest_free_range_get(hpdata);
+	if(fb_urange_longest(hpdata->active_pages, HUGEPAGE_PAGES)
+	    != hpdata_longest_free_range_get(hpdata)) {
+		return false;
+	}
+	if (fb_ucount(hpdata->active_pages, HUGEPAGE_PAGES, 0, HUGEPAGE_PAGES)
+	    != hpdata_nfree_get(hpdata)) {
+		return false;
+	}
+	return true;
 }
 
 static inline void

--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -133,7 +133,7 @@ void hpdata_init(hpdata_t *hpdata, void *addr, uint64_t age);
  * Given an hpdata which can serve an allocation request, pick and reserve an
  * offset within that allocation.
  */
-size_t hpdata_reserve_alloc(hpdata_t *hpdata, size_t npages);
-void hpdata_unreserve(hpdata_t *hpdata, size_t start, size_t npages);
+void *hpdata_reserve_alloc(hpdata_t *hpdata, size_t sz);
+void hpdata_unreserve(hpdata_t *hpdata, void *begin, size_t sz);
 
 #endif /* JEMALLOC_INTERNAL_HPDATA_H */

--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -112,10 +112,15 @@ hpdata_assert_empty(hpdata_t *hpdata) {
 	assert(hpdata_nfree_get(hpdata) == HUGEPAGE_PAGES);
 }
 
+static inline bool
+hpdata_consistent(hpdata_t *hpdata) {
+	return fb_urange_longest(hpdata->active_pages, HUGEPAGE_PAGES)
+	    == hpdata_longest_free_range_get(hpdata);
+}
+
 static inline void
 hpdata_assert_consistent(hpdata_t *hpdata) {
-	assert(fb_urange_longest(hpdata->active_pages, HUGEPAGE_PAGES)
-	    == hpdata_longest_free_range_get(hpdata));
+	assert(hpdata_consistent(hpdata));
 }
 
 TYPED_LIST(hpdata_list, hpdata_t, ql_link)

--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -123,6 +123,11 @@ TYPED_LIST(hpdata_list, hpdata_t, ql_link)
 typedef ph(hpdata_t) hpdata_age_heap_t;
 ph_proto(, hpdata_age_heap_, hpdata_age_heap_t, hpdata_t);
 
+static inline bool
+hpdata_empty(hpdata_t *hpdata) {
+	return hpdata_nfree_get(hpdata) == HUGEPAGE_PAGES;
+}
+
 void hpdata_init(hpdata_t *hpdata, void *addr, uint64_t age);
 /*
  * Given an hpdata which can serve an allocation request, pick and reserve an

--- a/include/jemalloc/internal/mutex_prof.h
+++ b/include/jemalloc/internal/mutex_prof.h
@@ -11,9 +11,7 @@
     OP(ctl)								\
     OP(prof)								\
     OP(prof_thds_data)							\
-    OP(prof_dump)							\
-    OP(hpa_central)							\
-    OP(hpa_central_grow)
+    OP(prof_dump)
 
 typedef enum {
 #define OP(mtx) global_prof_mutex_##mtx,

--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -130,9 +130,8 @@ bool pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
  * This isn't exposed to users; we allow late enablement of the HPA shard so
  * that we can boot without worrying about the HPA, then turn it on in a0.
  */
-bool pa_shard_enable_hpa(pa_shard_t *shard, hpa_t *hpa, size_t ps_goal,
-    size_t ps_alloc_max, size_t small_max, size_t large_min, size_t sec_nshards,
-    size_t sec_alloc_max, size_t sec_bytes_max);
+bool pa_shard_enable_hpa(pa_shard_t *shard, size_t alloc_max,
+    size_t sec_nshards, size_t sec_alloc_max, size_t sec_bytes_max);
 /*
  * We stop using the HPA when custom extent hooks are installed, but still
  * redirect deallocations to it.

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -58,6 +58,18 @@ static const bool pages_can_purge_forced =
 #endif
     ;
 
+#if defined(JEMALLOC_HAVE_MADVISE_HUGE) || defined(JEMALLOC_HAVE_MEMCNTL)
+#  define PAGES_CAN_HUGIFY
+#endif
+
+static const bool pages_can_hugify =
+#ifdef PAGES_CAN_HUGIFY
+    true
+#else
+    false
+#endif
+    ;
+
 typedef enum {
 	thp_mode_default       = 0, /* Do not change hugepage settings. */
 	thp_mode_always        = 1, /* Always set MADV_HUGEPAGE. */

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -17,6 +17,20 @@
 /* Huge page size.  LG_HUGEPAGE is determined by the configure script. */
 #define HUGEPAGE	((size_t)(1U << LG_HUGEPAGE))
 #define HUGEPAGE_MASK	((size_t)(HUGEPAGE - 1))
+
+#if LG_HUGEPAGE != 0
+#  define HUGEPAGE_PAGES (HUGEPAGE / PAGE)
+#else
+/*
+ * It's convenient to define arrays (or bitmaps) of HUGEPAGE_PAGES lengths.  If
+ * we can't autodetect the hugepage size, it gets treated as 0, in which case
+ * we'll trigger a compiler error in those arrays.  Avoid this case by ensuring
+ * that this value is at least 1.  (We won't ever run in this degraded state;
+ * hpa_supported() returns false in this case.
+ */
+#  define HUGEPAGE_PAGES 1
+#endif
+
 /* Return the huge page base address for the huge page containing address a. */
 #define HUGEPAGE_ADDR2BASE(a)						\
 	((void *)((uintptr_t)(a) & ~HUGEPAGE_MASK))

--- a/include/jemalloc/internal/psset.h
+++ b/include/jemalloc/internal/psset.h
@@ -64,13 +64,8 @@ void psset_stats_accum(psset_stats_t *dst, psset_stats_t *src);
 void psset_insert(psset_t *psset, hpdata_t *ps);
 void psset_remove(psset_t *psset, hpdata_t *ps);
 
-void psset_hugify(psset_t *psset, hpdata_t *ps);
-
-/*
- * Tries to obtain a chunk from an existing pageslab already in the set.
- * Returns true on failure.
- */
-bool psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size);
+/* Analogous to the eset_fit; pick a hpdata to serve the request. */
+hpdata_t *psset_fit(psset_t *psset, size_t size);
 
 /*
  * Given a newly created pageslab ps (not currently in the set), pass ownership
@@ -79,6 +74,7 @@ bool psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size);
  */
 void psset_alloc_new(psset_t *psset, hpdata_t *ps,
     edata_t *r_edata, size_t size);
+bool psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size);
 
 /*
  * Given an extent that comes from a pageslab in this pageslab set, returns it

--- a/include/jemalloc/internal/psset.h
+++ b/include/jemalloc/internal/psset.h
@@ -67,23 +67,4 @@ void psset_remove(psset_t *psset, hpdata_t *ps);
 /* Analogous to the eset_fit; pick a hpdata to serve the request. */
 hpdata_t *psset_fit(psset_t *psset, size_t size);
 
-/*
- * Given a newly created pageslab ps (not currently in the set), pass ownership
- * to the psset and allocate an extent from within it.  The passed-in pageslab
- * must be at least as big as size.
- */
-void psset_alloc_new(psset_t *psset, hpdata_t *ps,
-    edata_t *r_edata, size_t size);
-bool psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size);
-
-/*
- * Given an extent that comes from a pageslab in this pageslab set, returns it
- * to its slab.  Does not take ownership of the underlying edata_t.
- *
- * If some slab becomes empty as a result of the dalloc, it is retuend -- the
- * result must be checked and deallocated to the central HPA.  Otherwise returns
- * NULL.
- */
-hpdata_t *psset_dalloc(psset_t *psset, edata_t *edata);
-
 #endif /* JEMALLOC_INTERNAL_PSSET_H */

--- a/include/jemalloc/internal/psset.h
+++ b/include/jemalloc/internal/psset.h
@@ -24,11 +24,14 @@
 typedef struct psset_bin_stats_s psset_bin_stats_t;
 struct psset_bin_stats_s {
 	/* How many pageslabs are in this bin? */
-	size_t npageslabs;
+	size_t npageslabs_huge;
+	size_t npageslabs_nonhuge;
 	/* Of them, how many pages are active? */
-	size_t nactive;
+	size_t nactive_huge;
+	size_t nactive_nonhuge;
 	/* How many are inactive? */
-	size_t ninactive;
+	size_t ninactive_huge;
+	size_t ninactive_nonhuge;
 };
 
 /* Used only by CTL; not actually stored here (i.e., all derived). */
@@ -61,6 +64,8 @@ void psset_stats_accum(psset_stats_t *dst, psset_stats_t *src);
 
 void psset_insert(psset_t *psset, edata_t *ps);
 void psset_remove(psset_t *psset, edata_t *ps);
+
+void psset_hugify(psset_t *psset, edata_t *ps);
 
 /*
  * Tries to obtain a chunk from an existing pageslab already in the set.

--- a/include/jemalloc/internal/psset.h
+++ b/include/jemalloc/internal/psset.h
@@ -1,6 +1,8 @@
 #ifndef JEMALLOC_INTERNAL_PSSET_H
 #define JEMALLOC_INTERNAL_PSSET_H
 
+#include "jemalloc/internal/hpdata.h"
+
 /*
  * A page-slab set.  What the eset is to PAC, the psset is to HPA.  It maintains
  * a collection of page-slabs (the intent being that they are backed by
@@ -51,21 +53,18 @@ struct psset_s {
 	 * The pageslabs, quantized by the size class of the largest contiguous
 	 * free run of pages in a pageslab.
 	 */
-	edata_age_heap_t pageslabs[PSSET_NPSIZES];
+	hpdata_age_heap_t pageslabs[PSSET_NPSIZES];
 	bitmap_t bitmap[BITMAP_GROUPS(PSSET_NPSIZES)];
 	psset_stats_t stats;
-
-	/* How many alloc_new calls have happened? */
-	uint64_t age_counter;
 };
 
 void psset_init(psset_t *psset);
 void psset_stats_accum(psset_stats_t *dst, psset_stats_t *src);
 
-void psset_insert(psset_t *psset, edata_t *ps);
-void psset_remove(psset_t *psset, edata_t *ps);
+void psset_insert(psset_t *psset, hpdata_t *ps);
+void psset_remove(psset_t *psset, hpdata_t *ps);
 
-void psset_hugify(psset_t *psset, edata_t *ps);
+void psset_hugify(psset_t *psset, hpdata_t *ps);
 
 /*
  * Tries to obtain a chunk from an existing pageslab already in the set.
@@ -78,7 +77,7 @@ bool psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size);
  * to the psset and allocate an extent from within it.  The passed-in pageslab
  * must be at least as big as size.
  */
-void psset_alloc_new(psset_t *psset, edata_t *ps,
+void psset_alloc_new(psset_t *psset, hpdata_t *ps,
     edata_t *r_edata, size_t size);
 
 /*
@@ -89,6 +88,6 @@ void psset_alloc_new(psset_t *psset, edata_t *ps,
  * result must be checked and deallocated to the central HPA.  Otherwise returns
  * NULL.
  */
-edata_t *psset_dalloc(psset_t *psset, edata_t *edata);
+hpdata_t *psset_dalloc(psset_t *psset, edata_t *edata);
 
 #endif /* JEMALLOC_INTERNAL_PSSET_H */

--- a/include/jemalloc/internal/psset.h
+++ b/include/jemalloc/internal/psset.h
@@ -59,6 +59,9 @@ struct psset_s {
 
 void psset_init(psset_t *psset);
 
+void psset_insert(psset_t *psset, edata_t *ps);
+void psset_remove(psset_t *psset, edata_t *ps);
+
 /*
  * Tries to obtain a chunk from an existing pageslab already in the set.
  * Returns true on failure.

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="..\..\..\..\src\hook.c" />
     <ClCompile Include="..\..\..\..\src\hpa.c" />
     <ClCompile Include="..\..\..\..\src\hpa_central.c" />
+    <ClCompile Include="..\..\..\..\src\hpdata.c" />
     <ClCompile Include="..\..\..\..\src\inspect.c" />
     <ClCompile Include="..\..\..\..\src\jemalloc.c" />
     <ClCompile Include="..\..\..\..\src\large.c" />

--- a/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2015/jemalloc/jemalloc.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClCompile Include="..\..\..\..\src\hpa_central.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\hpdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\inspect.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="..\..\..\..\src\hook.c" />
     <ClCompile Include="..\..\..\..\src\hpa.c" />
     <ClCompile Include="..\..\..\..\src\hpa_central.c" />
+    <ClCompile Include="..\..\..\..\src\hpdata.c" />
     <ClCompile Include="..\..\..\..\src\inspect.c" />
     <ClCompile Include="..\..\..\..\src\jemalloc.c" />
     <ClCompile Include="..\..\..\..\src\large.c" />

--- a/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
+++ b/msvc/projects/vc2017/jemalloc/jemalloc.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClCompile Include="..\..\..\..\src\hpa_central.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\hpdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\inspect.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/arena.c
+++ b/src/arena.c
@@ -37,7 +37,6 @@ static atomic_zd_t dirty_decay_ms_default;
 static atomic_zd_t muzzy_decay_ms_default;
 
 emap_t arena_emap_global;
-hpa_t arena_hpa_global;
 
 const uint64_t h_steps[SMOOTHSTEP_NSTEPS] = {
 #define STEP(step, h, x, y)			\
@@ -1535,9 +1534,8 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	 *   so arena_hpa_global is not yet initialized.
 	 */
 	if (opt_hpa && ehooks_are_default(base_ehooks_get(base)) && ind != 0) {
-		if (pa_shard_enable_hpa(&arena->pa_shard, &arena_hpa_global,
-		    opt_hpa_slab_goal, opt_hpa_slab_max_alloc,
-		    opt_hpa_small_max, opt_hpa_large_min, opt_hpa_sec_nshards,
+		if (pa_shard_enable_hpa(&arena->pa_shard,
+		    opt_hpa_slab_max_alloc, opt_hpa_sec_nshards,
 		    opt_hpa_sec_max_alloc, opt_hpa_sec_max_bytes)) {
 			goto label_error;
 		}

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -220,6 +220,7 @@ CTL_PROTO(stats_arenas_i_extents_j_dirty_bytes)
 CTL_PROTO(stats_arenas_i_extents_j_muzzy_bytes)
 CTL_PROTO(stats_arenas_i_extents_j_retained_bytes)
 INDEX_PROTO(stats_arenas_i_extents_j)
+CTL_PROTO(stats_arenas_i_hpa_shard_nevictions)
 CTL_PROTO(stats_arenas_i_hpa_shard_full_slabs_npageslabs_huge)
 CTL_PROTO(stats_arenas_i_hpa_shard_full_slabs_nactive_huge)
 CTL_PROTO(stats_arenas_i_hpa_shard_full_slabs_ninactive_huge)
@@ -655,7 +656,8 @@ static const ctl_named_node_t stats_arenas_i_hpa_shard_node[] = {
 	{NAME("full_slabs"),	CHILD(named,
 	    stats_arenas_i_hpa_shard_full_slabs)},
 	{NAME("nonfull_slabs"),	CHILD(indexed,
-	    stats_arenas_i_hpa_shard_nonfull_slabs)}
+	    stats_arenas_i_hpa_shard_nonfull_slabs)},
+	{NAME("nevictions"),	CTL(stats_arenas_i_hpa_shard_nevictions)}
 };
 
 static const ctl_named_node_t stats_arenas_i_node[] = {
@@ -3371,6 +3373,9 @@ stats_arenas_i_extents_j_index(tsdn_t *tsdn, const size_t *mib,
 	}
 	return super_stats_arenas_i_extents_j_node;
 }
+
+CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_nevictions,
+    arenas_i(mib[2])->astats->hpastats.nevictions, uint64_t);
 
 /* Full, huge */
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_full_slabs_npageslabs_huge,

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1104,14 +1104,7 @@ MUTEX_PROF_ARENA_MUTEXES
 		}
 
 		/* Merge HPA stats. */
-		psset_bin_stats_accum(&sdstats->hpastats.psset_full_slab_stats,
-		    &astats->hpastats.psset_full_slab_stats);
-		for (pszind_t i = 0; i < PSSET_NPSIZES; i++) {
-			psset_bin_stats_accum(
-			    &sdstats->hpastats.psset_slab_stats[i],
-			    &astats->hpastats.psset_slab_stats[i]);
-		}
-
+		hpa_stats_accum(&sdstats->hpastats, &astats->hpastats);
 		sec_stats_accum(&sdstats->secstats, &astats->secstats);
 	}
 }
@@ -3375,21 +3368,21 @@ stats_arenas_i_extents_j_index(tsdn_t *tsdn, const size_t *mib,
 }
 
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_full_slabs_npageslabs,
-    arenas_i(mib[2])->astats->hpastats.psset_full_slab_stats.npageslabs,
+    arenas_i(mib[2])->astats->hpastats.psset_stats.full_slabs.npageslabs,
     size_t);
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_full_slabs_nactive,
-    arenas_i(mib[2])->astats->hpastats.psset_full_slab_stats.nactive, size_t);
+    arenas_i(mib[2])->astats->hpastats.psset_stats.full_slabs.nactive, size_t);
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_full_slabs_ninactive,
-    arenas_i(mib[2])->astats->hpastats.psset_full_slab_stats.ninactive, size_t);
+    arenas_i(mib[2])->astats->hpastats.psset_stats.full_slabs.ninactive, size_t);
 
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_nonfull_slabs_j_npageslabs,
-    arenas_i(mib[2])->astats->hpastats.psset_slab_stats[mib[5]].npageslabs,
+    arenas_i(mib[2])->astats->hpastats.psset_stats.nonfull_slabs[mib[5]].npageslabs,
     size_t);
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_nonfull_slabs_j_nactive,
-    arenas_i(mib[2])->astats->hpastats.psset_slab_stats[mib[5]].nactive,
+    arenas_i(mib[2])->astats->hpastats.psset_stats.nonfull_slabs[mib[5]].nactive,
     size_t);
 CTL_RO_CGEN(config_stats, stats_arenas_i_hpa_shard_nonfull_slabs_j_ninactive,
-    arenas_i(mib[2])->astats->hpastats.psset_slab_stats[mib[5]].ninactive,
+    arenas_i(mib[2])->astats->hpastats.psset_stats.nonfull_slabs[mib[5]].ninactive,
     size_t);
 
 static const ctl_named_node_t *

--- a/src/edata.c
+++ b/src/edata.c
@@ -4,4 +4,3 @@
 ph_gen(, edata_avail_, edata_avail_t, edata_t, ph_link,
     edata_esnead_comp)
 ph_gen(, edata_heap_, edata_heap_t, edata_t, ph_link, edata_snad_comp)
-ph_gen(, edata_age_heap_, edata_age_heap_t, edata_t, ph_link, edata_age_comp)

--- a/src/hpa.c
+++ b/src/hpa.c
@@ -6,6 +6,8 @@
 #include "jemalloc/internal/flat_bitmap.h"
 #include "jemalloc/internal/witness.h"
 
+#define HPA_EDEN_SIZE (128 * HUGEPAGE)
+
 static edata_t *hpa_alloc(tsdn_t *tsdn, pai_t *self, size_t size,
     size_t alignment, bool zero);
 static bool hpa_expand(tsdn_t *tsdn, pai_t *self, edata_t *edata,
@@ -15,43 +17,40 @@ static bool hpa_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata,
 static void hpa_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata);
 
 bool
-hpa_init(hpa_t *hpa, base_t *base, emap_t *emap, edata_cache_t *edata_cache) {
-	bool err;
-
+hpa_supported() {
+#ifdef _WIN32
+	/*
+	 * At least until the API and implementation is somewhat settled, we
+	 * don't want to try to debug the VM subsystem on the hardest-to-test
+	 * platform.
+	 */
+	return false;
+#endif
+	if (!pages_can_hugify) {
+		return false;
+	}
 	/*
 	 * We fundamentally rely on a address-space-hungry growth strategy for
-	 * hugepages.  This may change in the future, but for now we should have
-	 * refused to turn on any HPA at a higher level of the stack.
+	 * hugepages.
 	 */
-	assert(LG_SIZEOF_PTR == 3);
-
-	err = malloc_mutex_init(&hpa->grow_mtx, "hpa_grow", WITNESS_RANK_HPA_GROW,
-	    malloc_mutex_rank_exclusive);
-	if (err) {
-		return true;
+	if (LG_SIZEOF_PTR == 2) {
+		return false;
 	}
-	err = malloc_mutex_init(&hpa->mtx, "hpa", WITNESS_RANK_HPA,
-	    malloc_mutex_rank_exclusive);
-	if (err) {
-		return true;
+	/*
+	 * We use the edata bitmap; it needs to have at least as many bits as a
+	 * hugepage has pages.
+	 */
+	if (HUGEPAGE / PAGE > BITMAP_GROUPS_MAX * sizeof(bitmap_t) * 8) {
+		return false;
 	}
-
-	hpa_central_init(&hpa->central, edata_cache, emap);
-	if (err) {
-		return true;
-	}
-	hpa->ind = base_ind_get(base);
-	hpa->edata_cache = edata_cache;
-
-	exp_grow_init(&hpa->exp_grow);
-
-	return false;
+	return true;
 }
 
 bool
-hpa_shard_init(hpa_shard_t *shard, hpa_t *hpa, edata_cache_t *edata_cache,
-    unsigned ind, size_t ps_goal, size_t ps_alloc_max, size_t small_max,
-    size_t large_min) {
+hpa_shard_init(hpa_shard_t *shard, emap_t *emap, edata_cache_t *edata_cache,
+    unsigned ind, size_t alloc_max) {
+	/* malloc_conf processing should have filtered out these cases. */
+	assert(hpa_supported());
 	bool err;
 	err = malloc_mutex_init(&shard->grow_mtx, "hpa_shard_grow",
 	    WITNESS_RANK_HPA_SHARD_GROW, malloc_mutex_rank_exclusive);
@@ -66,12 +65,12 @@ hpa_shard_init(hpa_shard_t *shard, hpa_t *hpa, edata_cache_t *edata_cache,
 
 	assert(edata_cache != NULL);
 	edata_cache_small_init(&shard->ecs, edata_cache);
-	shard->hpa = hpa;
 	psset_init(&shard->psset);
-	shard->ps_goal = ps_goal;
-	shard->ps_alloc_max = ps_alloc_max;
-	shard->small_max = small_max;
-	shard->large_min = large_min;
+	shard->alloc_max = alloc_max;
+	edata_list_inactive_init(&shard->unused_slabs);
+	shard->eden = NULL;
+	shard->ind = ind;
+	shard->emap = emap;
 
 	/*
 	 * Fill these in last, so that if an hpa_shard gets used despite
@@ -83,9 +82,6 @@ hpa_shard_init(hpa_shard_t *shard, hpa_t *hpa, edata_cache_t *edata_cache,
 	shard->pai.shrink = &hpa_shrink;
 	shard->pai.dalloc = &hpa_dalloc;
 
-	shard->ind = ind;
-	assert(ind == base_ind_get(edata_cache->base));
-
 	return false;
 }
 
@@ -96,176 +92,333 @@ hpa_shard_init(hpa_shard_t *shard, hpa_t *hpa, edata_cache_t *edata_cache,
  * locking here.
  */
 void
-hpa_stats_accum(hpa_shard_stats_t *dst, hpa_shard_stats_t *src) {
+hpa_shard_stats_accum(hpa_shard_stats_t *dst, hpa_shard_stats_t *src) {
 	psset_stats_accum(&dst->psset_stats, &src->psset_stats);
 }
 
 void
-hpa_stats_merge(tsdn_t *tsdn, hpa_shard_t *shard, hpa_shard_stats_t *dst) {
+hpa_shard_stats_merge(tsdn_t *tsdn, hpa_shard_t *shard,
+    hpa_shard_stats_t *dst) {
 	malloc_mutex_lock(tsdn, &shard->mtx);
 	psset_stats_accum(&dst->psset_stats, &shard->psset.stats);
 	malloc_mutex_unlock(tsdn, &shard->mtx);
 }
 
-static edata_t *
-hpa_alloc_central(tsdn_t *tsdn, hpa_shard_t *shard, size_t size_min,
-    size_t size_goal) {
-	bool err;
-	edata_t *edata;
-
-	hpa_t *hpa = shard->hpa;
-
-	malloc_mutex_lock(tsdn, &hpa->mtx);
-	edata = hpa_central_alloc_reuse(tsdn, &hpa->central, size_min,
-	    size_goal);
-	malloc_mutex_unlock(tsdn, &hpa->mtx);
-	if (edata != NULL) {
-		edata_arena_ind_set(edata, shard->ind);
-		return edata;
-	}
-	/* No existing range can satisfy the request; try to grow. */
-	malloc_mutex_lock(tsdn, &hpa->grow_mtx);
-
+static bool
+hpa_should_hugify(hpa_shard_t *shard, edata_t *ps) {
 	/*
-	 * We could have raced with other grow attempts; re-check to see if we
-	 * did, and are now able to satisfy the request.
+	 * For now, just use a static check; hugify a page if it's <= 5%
+	 * inactive.  Eventually, this should be a malloc conf option.
 	 */
-	malloc_mutex_lock(tsdn, &hpa->mtx);
-	edata = hpa_central_alloc_reuse(tsdn, &hpa->central, size_min,
-	    size_goal);
-	malloc_mutex_unlock(tsdn, &hpa->mtx);
-	if (edata != NULL) {
-		malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
-		edata_arena_ind_set(edata, shard->ind);
-		return edata;
-	}
+	return !edata_hugeified_get(ps)
+	    && edata_nfree_get(ps) < (HUGEPAGE / PAGE) * 5 / 100;
+}
 
+/* Returns true on error. */
+static void
+hpa_hugify(edata_t *ps) {
+	assert(edata_size_get(ps) == HUGEPAGE);
+	assert(edata_hugeified_get(ps));
+	bool err = pages_huge(edata_base_get(ps), HUGEPAGE);
 	/*
-	 * No such luck. We've dropped mtx, so other allocations can proceed
-	 * while we allocate the new extent.  We know no one else will grow in
-	 * the meantime, though, since we still hold grow_mtx.
-	 */
-	size_t alloc_size;
-	pszind_t skip;
-
-	size_t hugepage_goal_min = HUGEPAGE_CEILING(size_goal);
-
-	err = exp_grow_size_prepare(&hpa->exp_grow, hugepage_goal_min,
-	    &alloc_size, &skip);
-	if (err) {
-		malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
-		return NULL;
-	}
-	alloc_size = HUGEPAGE_CEILING(alloc_size);
-
-	/*
-	 * Eventually, we need to think about this more systematically, and in
-	 * terms of extent hooks.  For now, though, we know we only care about
-	 * overcommitting systems, and we're not going to purge much.
-	 */
-	bool commit = true;
-	void *addr = pages_map(NULL, alloc_size, HUGEPAGE, &commit);
-	if (addr == NULL) {
-		malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
-		return NULL;
-	}
-	err = pages_huge(addr, alloc_size);
-	/*
-	 * Ignore this for now; even if the allocation fails, the address space
-	 * should still be usable.
+	 * Eat the error; even if the hugeification failed, it's still safe to
+	 * pretend it didn't (and would require extraordinary measures to
+	 * unhugify).
 	 */
 	(void)err;
+}
 
-	edata = edata_cache_get(tsdn, hpa->edata_cache);
-	if (edata == NULL) {
-		malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
-		pages_unmap(addr, alloc_size);
-		return NULL;
+static void
+hpa_dehugify(edata_t *ps) {
+	/* Purge, then dehugify while unbacked. */
+	pages_purge_forced(edata_addr_get(ps), HUGEPAGE);
+	pages_nohuge(edata_addr_get(ps), HUGEPAGE);
+	edata_hugeified_set(ps, false);
+}
+
+static edata_t *
+hpa_grow(tsdn_t *tsdn, hpa_shard_t *shard) {
+	malloc_mutex_assert_owner(tsdn, &shard->grow_mtx);
+	edata_t *ps = NULL;
+
+	/* Is there address space waiting for reuse? */
+	malloc_mutex_assert_owner(tsdn, &shard->grow_mtx);
+	ps = edata_list_inactive_first(&shard->unused_slabs);
+	if (ps != NULL) {
+		edata_list_inactive_remove(&shard->unused_slabs, ps);
+		return ps;
+	}
+
+	/* Is eden a perfect fit? */
+	if (shard->eden != NULL && edata_size_get(shard->eden) == HUGEPAGE) {
+		ps = shard->eden;
+		shard->eden = NULL;
+		return ps;
 	}
 
 	/*
-	 * The serial number here is just a placeholder; the hpa_central gets to
-	 * decide how it wants to fill it in.
-	 *
-	 * The grow edata is associated with the hpa_central_t arena ind; the
-	 * subsequent allocation we get (in the hpa_central_alloc_grow call
-	 * below) will be filled in with the shard ind.
+	 * We're about to try to allocate from eden by splitting.  If eden is
+	 * NULL, we have to allocate it too.  Otherwise, we just have to
+	 * allocate an edata_t for the new psset.
 	 */
-	edata_init(edata, hpa->ind, addr, alloc_size, /* slab */ false,
-	    SC_NSIZES, /* sn */ 0, extent_state_active, /* zeroed */ true,
-	    /* comitted */ true, EXTENT_PAI_HPA, /* is_head */ true);
+	if (shard->eden == NULL) {
+		/*
+		 * During development, we're primarily concerned with systems
+		 * with overcommit.  Eventually, we should be more careful here.
+		 */
+		bool commit = true;
+		/* Allocate address space, bailing if we fail. */
+		void *new_eden = pages_map(NULL, HPA_EDEN_SIZE, HUGEPAGE,
+		    &commit);
+		if (new_eden == NULL) {
+			return NULL;
+		}
+		malloc_mutex_lock(tsdn, &shard->mtx);
+		/* Allocate ps edata, bailing if we fail. */
+		ps = edata_cache_small_get(tsdn, &shard->ecs);
+		if (ps == NULL) {
+			malloc_mutex_unlock(tsdn, &shard->mtx);
+			pages_unmap(new_eden, HPA_EDEN_SIZE);
+			return NULL;
+		}
+		/* Allocate eden edata, bailing if we fail. */
+		shard->eden = edata_cache_small_get(tsdn, &shard->ecs);
+		if (shard->eden == NULL) {
+			edata_cache_small_put(tsdn, &shard->ecs, ps);
+			malloc_mutex_unlock(tsdn, &shard->mtx);
+			pages_unmap(new_eden, HPA_EDEN_SIZE);
+			return NULL;
+		}
+		/* Success. */
+		malloc_mutex_unlock(tsdn, &shard->mtx);
 
-	malloc_mutex_lock(tsdn, &hpa->mtx);
-	/* Note that this replace edata with the allocation to return. */
-	err = hpa_central_alloc_grow(tsdn, &hpa->central, size_goal, edata);
-	malloc_mutex_unlock(tsdn, &hpa->mtx);
-
-	if (!err) {
-		exp_grow_size_commit(&hpa->exp_grow, skip);
+		/*
+		 * Note that the values here don't really make sense (e.g. eden
+		 * is actually zeroed).  But we don't use the slab metadata in
+		 * determining subsequent allocation metadata (e.g. zero
+		 * tracking should be done at the per-page level, not at the
+		 * level of the hugepage).  It's just a convenient data
+		 * structure that contains much of the helpers we need (defined
+		 * lists, a bitmap, an address field, etc.).  Eventually, we'll
+		 * have a "real" representation of a hugepage that's unconnected
+		 * to the edata_ts it will serve allocations into.
+		 */
+		edata_init(shard->eden, shard->ind, new_eden, HPA_EDEN_SIZE,
+		    /* slab */ false, SC_NSIZES, /* sn */ 0, extent_state_dirty,
+		    /* zeroed */ false, /* comitted */ true, EXTENT_PAI_HPA,
+		    /* is_head */ true);
+		edata_hugeified_set(shard->eden, false);
+	} else {
+		/* Eden is already nonempty; only need an edata for ps. */
+		malloc_mutex_lock(tsdn, &shard->mtx);
+		ps = edata_cache_small_get(tsdn, &shard->ecs);
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		if (ps == NULL) {
+			return NULL;
+		}
 	}
-	malloc_mutex_unlock(tsdn, &hpa->grow_mtx);
-	edata_arena_ind_set(edata, shard->ind);
+	/*
+	 * We should have dropped mtx since we're not touching ecs any more, but
+	 * we should continue to hold the grow mutex, since we're about to touch
+	 * eden.
+	 */
+	malloc_mutex_assert_not_owner(tsdn, &shard->mtx);
+	malloc_mutex_assert_owner(tsdn, &shard->grow_mtx);
 
+	assert(shard->eden != NULL);
+	assert(edata_size_get(shard->eden) > HUGEPAGE);
+	assert(edata_size_get(shard->eden) % HUGEPAGE == 0);
+	assert(edata_addr_get(shard->eden)
+	    == HUGEPAGE_ADDR2BASE(edata_addr_get(shard->eden)));
+	malloc_mutex_lock(tsdn, &shard->mtx);
+	ps = edata_cache_small_get(tsdn, &shard->ecs);
+	malloc_mutex_unlock(tsdn, &shard->mtx);
+	if (ps == NULL) {
+		return NULL;
+	}
+	edata_init(ps, edata_arena_ind_get(shard->eden),
+	    edata_addr_get(shard->eden), HUGEPAGE, /* slab */ false,
+	    /* szind */ SC_NSIZES, /* sn */ 0, extent_state_dirty,
+	    /* zeroed */ false, /* comitted */ true, EXTENT_PAI_HPA,
+	    /* is_head */ true);
+	edata_hugeified_set(ps, false);
+	edata_addr_set(shard->eden, edata_past_get(ps));
+	edata_size_set(shard->eden,
+	    edata_size_get(shard->eden) - HUGEPAGE);
+
+	return ps;
+}
+
+/*
+ * The psset does not hold empty slabs.  Upon becoming empty, then, we need to
+ * put them somewhere.  We take this as an opportunity to purge, and retain
+ * their address space in a list outside the psset.
+ */
+static void
+hpa_handle_ps_eviction(tsdn_t *tsdn, hpa_shard_t *shard, edata_t *ps) {
+	/*
+	 * We do relatively expensive system calls.  The ps was evicted, so no
+	 * one should touch it while we're also touching it.
+	 */
+	malloc_mutex_assert_not_owner(tsdn, &shard->mtx);
+	malloc_mutex_assert_not_owner(tsdn, &shard->grow_mtx);
+
+	assert(edata_size_get(ps) == HUGEPAGE);
+	assert(HUGEPAGE_ADDR2BASE(edata_addr_get(ps)) == edata_addr_get(ps));
+
+	/*
+	 * We do this unconditionally, even for pages which were not originally
+	 * hugeified; it has the same effect.
+	 */
+	hpa_dehugify(ps);
+
+	malloc_mutex_lock(tsdn, &shard->grow_mtx);
+	edata_list_inactive_prepend(&shard->unused_slabs, ps);
+	malloc_mutex_unlock(tsdn, &shard->grow_mtx);
+}
+
+static edata_t *
+hpa_try_alloc_no_grow(tsdn_t *tsdn, hpa_shard_t *shard, size_t size, bool *oom) {
+	bool err;
+	malloc_mutex_lock(tsdn, &shard->mtx);
+	edata_t *edata = edata_cache_small_get(tsdn, &shard->ecs);
+	*oom = false;
+	if (edata == NULL) {
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		*oom = true;
+		return NULL;
+	}
+	assert(edata_arena_ind_get(edata) == shard->ind);
+
+	err = psset_alloc_reuse(&shard->psset, edata, size);
 	if (err) {
-		pages_unmap(addr, alloc_size);
-		edata_cache_put(tsdn, hpa->edata_cache, edata);
+		edata_cache_small_put(tsdn, &shard->ecs, edata);
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		return NULL;
+	}
+	/*
+	 * This could theoretically be moved outside of the critical section,
+	 * but that introduces the potential for a race.  Without the lock, the
+	 * (initially nonempty, since this is the reuse pathway) pageslab we
+	 * allocated out of could become otherwise empty while the lock is
+	 * dropped.  This would force us to deal with a pageslab eviction down
+	 * the error pathway, which is a pain.
+	 */
+	err = emap_register_boundary(tsdn, shard->emap, edata,
+	    SC_NSIZES, /* slab */ false);
+	if (err) {
+		edata_t *ps = psset_dalloc(&shard->psset, edata);
+		/*
+		 * The pageslab was nonempty before we started; it
+		 * should still be nonempty now, and so shouldn't get
+		 * evicted.
+		 */
+		assert(ps == NULL);
+		edata_cache_small_put(tsdn, &shard->ecs, edata);
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		*oom = true;
 		return NULL;
 	}
 
+	edata_t *ps = edata_ps_get(edata);
+	assert(ps != NULL);
+	bool hugify = hpa_should_hugify(shard, ps);
+	if (hugify) {
+		/*
+		 * Do the metadata modification while holding the lock; we'll
+		 * actually change state with the lock dropped.
+		 */
+		psset_hugify(&shard->psset, ps);
+	}
+	malloc_mutex_unlock(tsdn, &shard->mtx);
+	if (hugify) {
+		/*
+		 * Hugifying with the lock dropped is safe, even with
+		 * concurrent modifications to the ps.  This relies on
+		 * the fact that the current implementation will never
+		 * dehugify a non-empty pageslab, and ps will never
+		 * become empty before we return edata to the user to be
+		 * freed.
+		 *
+		 * Note that holding the lock would prevent not just operations
+		 * on this page slab, but also operations any other alloc/dalloc
+		 * operations in this hpa shard.
+		 */
+		hpa_hugify(ps);
+	}
 	return edata;
 }
 
 static edata_t *
 hpa_alloc_psset(tsdn_t *tsdn, hpa_shard_t *shard, size_t size) {
-	assert(size <= shard->ps_alloc_max);
-
+	assert(size <= shard->alloc_max);
 	bool err;
-	malloc_mutex_lock(tsdn, &shard->mtx);
-	edata_t *edata = edata_cache_small_get(tsdn, &shard->ecs);
-	if (edata == NULL) {
-		malloc_mutex_unlock(tsdn, &shard->mtx);
-		return NULL;
-	}
-	edata_arena_ind_set(edata, shard->ind);
+	bool oom;
+	edata_t *edata;
 
-	err = psset_alloc_reuse(&shard->psset, edata, size);
-	malloc_mutex_unlock(tsdn, &shard->mtx);
-	if (!err) {
+	edata = hpa_try_alloc_no_grow(tsdn, shard, size, &oom);
+	if (edata != NULL) {
 		return edata;
 	}
+
 	/* Nothing in the psset works; we have to grow it. */
 	malloc_mutex_lock(tsdn, &shard->grow_mtx);
-
-	/* As above; check for grow races. */
-	malloc_mutex_lock(tsdn, &shard->mtx);
-	err = psset_alloc_reuse(&shard->psset, edata, size);
-	malloc_mutex_unlock(tsdn, &shard->mtx);
-	if (!err) {
+	/*
+	 * Check for grow races; maybe some earlier thread expanded the psset
+	 * in between when we dropped the main mutex and grabbed the grow mutex.
+	 */
+	edata = hpa_try_alloc_no_grow(tsdn, shard, size, &oom);
+	if (edata != NULL || oom) {
 		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
 		return edata;
 	}
 
-	edata_t *grow_edata = hpa_alloc_central(tsdn, shard, size,
-	    shard->ps_goal);
+	/*
+	 * Note that we don't hold shard->mtx here (while growing);
+	 * deallocations (and allocations of smaller sizes) may still succeed
+	 * while we're doing this potentially expensive system call.
+	 */
+	edata_t *grow_edata = hpa_grow(tsdn, shard);
 	if (grow_edata == NULL) {
 		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
-
-		malloc_mutex_lock(tsdn, &shard->mtx);
-		edata_cache_small_put(tsdn, &shard->ecs, edata);
-		malloc_mutex_unlock(tsdn, &shard->mtx);
-
 		return NULL;
 	}
-	edata_arena_ind_set(grow_edata, shard->ind);
+	assert(edata_arena_ind_get(grow_edata) == shard->ind);
+
 	edata_slab_set(grow_edata, true);
 	fb_group_t *fb = edata_slab_data_get(grow_edata)->bitmap;
-	fb_init(fb, shard->ps_goal / PAGE);
+	fb_init(fb, HUGEPAGE / PAGE);
 
 	/* We got the new edata; allocate from it. */
 	malloc_mutex_lock(tsdn, &shard->mtx);
+	edata = edata_cache_small_get(tsdn, &shard->ecs);
+	if (edata == NULL) {
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
+		return NULL;
+	}
 	psset_alloc_new(&shard->psset, grow_edata, edata, size);
+	err = emap_register_boundary(tsdn, shard->emap, edata,
+	    SC_NSIZES, /* slab */ false);
+	if (err) {
+		edata_t *ps = psset_dalloc(&shard->psset, edata);
+		/*
+		 * The pageslab was empty except for the new allocation; it
+		 * should get evicted.
+		 */
+		assert(ps == grow_edata);
+		edata_cache_small_put(tsdn, &shard->ecs, edata);
+		/*
+		 * Technically the same as fallthrough at the time of this
+		 * writing, but consistent with the error handling in the rest
+		 * of the function.
+		 */
+		malloc_mutex_unlock(tsdn, &shard->mtx);
+		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
+		hpa_handle_ps_eviction(tsdn, shard, ps);
+		return NULL;
+	}
 	malloc_mutex_unlock(tsdn, &shard->mtx);
-
 	malloc_mutex_unlock(tsdn, &shard->grow_mtx);
 	return edata;
 }
@@ -283,33 +436,25 @@ static edata_t *
 hpa_alloc(tsdn_t *tsdn, pai_t *self, size_t size,
     size_t alignment, bool zero) {
 	assert((size & PAGE_MASK) == 0);
+	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
+	    WITNESS_RANK_CORE, 0);
+
 	hpa_shard_t *shard = hpa_from_pai(self);
 	/* We don't handle alignment or zeroing for now. */
 	if (alignment > PAGE || zero) {
 		return NULL;
 	}
-	if (size > shard->small_max && size < shard->large_min) {
+	if (size > shard->alloc_max) {
 		return NULL;
 	}
 
-	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
-	    WITNESS_RANK_CORE, 0);
-
-	edata_t *edata;
-	if (size <= shard->ps_alloc_max) {
-		edata = hpa_alloc_psset(tsdn, shard, size);
-		if (edata != NULL) {
-			emap_register_boundary(tsdn, shard->hpa->central.emap,
-			    edata, SC_NSIZES, /* slab */ false);
-		}
-	} else {
-		edata = hpa_alloc_central(tsdn, shard, size, size);
-	}
+	edata_t *edata = hpa_alloc_psset(tsdn, shard, size);
 
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
+
 	if (edata != NULL) {
-		emap_assert_mapped(tsdn, shard->hpa->central.emap, edata);
+		emap_assert_mapped(tsdn, shard->emap, edata);
 		assert(edata_pai_get(edata) == EXTENT_PAI_HPA);
 		assert(edata_state_get(edata) == extent_state_active);
 		assert(edata_arena_ind_get(edata) == shard->ind);
@@ -337,16 +482,6 @@ hpa_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata,
 }
 
 static void
-hpa_dalloc_central(tsdn_t *tsdn, hpa_shard_t *shard, edata_t *edata) {
-	hpa_t *hpa = shard->hpa;
-
-	edata_arena_ind_set(edata, hpa->ind);
-	malloc_mutex_lock(tsdn, &hpa->mtx);
-	hpa_central_dalloc(tsdn, &hpa->central, edata);
-	malloc_mutex_unlock(tsdn, &hpa->mtx);
-}
-
-static void
 hpa_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata) {
 	hpa_shard_t *shard = hpa_from_pai(self);
 
@@ -361,54 +496,27 @@ hpa_dalloc(tsdn_t *tsdn, pai_t *self, edata_t *edata) {
 	assert(edata_committed_get(edata));
 	assert(edata_base_get(edata) != NULL);
 
+	edata_t *ps = edata_ps_get(edata);
+	/* Currently, all edatas come from pageslabs. */
+	assert(ps != NULL);
+	emap_deregister_boundary(tsdn, shard->emap, edata);
+	malloc_mutex_lock(tsdn, &shard->mtx);
 	/*
-	 * There are two cases:
-	 * - The psset field is NULL.  In this case, the edata comes directly
-	 *   from the hpa_central_t and should be returned to it.
-	 * - THe psset field is not NULL, in which case we return the edata to
-	 *   the appropriate slab (which may in turn cause it to become empty,
-	 *   triggering an eviction of the whole slab, which should then be
-	 *   returned to the hpa_central_t).
+	 * Note that the shard mutex protects the edata hugeified field, too.
+	 * Page slabs can move between pssets (and have their hugeified status
+	 * change) in racy ways.
 	 */
-	if (edata_ps_get(edata) != NULL) {
-		emap_deregister_boundary(tsdn, shard->hpa->central.emap, edata);
-
-		malloc_mutex_lock(tsdn, &shard->mtx);
-		edata_t *evicted_ps = psset_dalloc(&shard->psset, edata);
-		edata_cache_small_put(tsdn, &shard->ecs, edata);
-		malloc_mutex_unlock(tsdn, &shard->mtx);
-
-
-		if (evicted_ps != NULL) {
-			/*
-			 * The deallocation caused a pageslab to become empty.
-			 * Free it back to the centralized allocator.
-			 */
-			bool err = emap_register_boundary(tsdn,
-			    shard->hpa->central.emap, evicted_ps, SC_NSIZES,
-			    /* slab */ false);
-			/*
-			 * Registration can only fail on OOM, but the boundary
-			 * mappings should have been initialized during
-			 * allocation.
-			 */
-			assert(!err);
-			edata_slab_set(evicted_ps, false);
-			edata_ps_set(evicted_ps, NULL);
-
-			assert(edata_arena_ind_get(evicted_ps) == shard->ind);
-			hpa_dalloc_central(tsdn, shard, evicted_ps);
-		}
-	} else {
-		hpa_dalloc_central(tsdn, shard, edata);
+	edata_t *evicted_ps = psset_dalloc(&shard->psset, edata);
+	/*
+	 * If a pageslab became empty because of the dalloc, it better have been
+	 * the one we expected.
+	 */
+	assert(evicted_ps == NULL || evicted_ps == ps);
+	edata_cache_small_put(tsdn, &shard->ecs, edata);
+	malloc_mutex_unlock(tsdn, &shard->mtx);
+	if (evicted_ps != NULL) {
+		hpa_handle_ps_eviction(tsdn, shard, evicted_ps);
 	}
-}
-
-static void
-hpa_shard_assert_stats_empty(psset_bin_stats_t *bin_stats) {
-	assert(bin_stats->npageslabs == 0);
-	assert(bin_stats->nactive == 0);
-	assert(bin_stats->ninactive == 0);
 }
 
 void
@@ -416,6 +524,29 @@ hpa_shard_disable(tsdn_t *tsdn, hpa_shard_t *shard) {
 	malloc_mutex_lock(tsdn, &shard->mtx);
 	edata_cache_small_disable(tsdn, &shard->ecs);
 	malloc_mutex_unlock(tsdn, &shard->mtx);
+}
+
+static void
+hpa_shard_assert_stats_empty(psset_bin_stats_t *bin_stats) {
+	assert(bin_stats->npageslabs_huge == 0);
+	assert(bin_stats->nactive_huge == 0);
+	assert(bin_stats->ninactive_huge == 0);
+	assert(bin_stats->npageslabs_nonhuge == 0);
+	assert(bin_stats->nactive_nonhuge == 0);
+	assert(bin_stats->ninactive_nonhuge == 0);
+}
+
+static void
+hpa_assert_empty(tsdn_t *tsdn, hpa_shard_t *shard, psset_t *psset) {
+	edata_t edata = {0};
+	malloc_mutex_assert_owner(tsdn, &shard->mtx);
+	bool psset_empty = psset_alloc_reuse(psset, &edata, PAGE);
+	assert(psset_empty);
+	hpa_shard_assert_stats_empty(&psset->stats.full_slabs);
+	for (pszind_t i = 0; i < PSSET_NPSIZES; i++) {
+		hpa_shard_assert_stats_empty(
+		    &psset->stats.nonfull_slabs[i]);
+	}
 }
 
 void
@@ -427,17 +558,15 @@ hpa_shard_destroy(tsdn_t *tsdn, hpa_shard_t *shard) {
 	 * 1-page allocation.
 	 */
 	if (config_debug) {
-		edata_t edata = {0};
 		malloc_mutex_lock(tsdn, &shard->mtx);
-		bool psset_empty = psset_alloc_reuse(&shard->psset, &edata,
-		    PAGE);
+		hpa_assert_empty(tsdn, shard, &shard->psset);
 		malloc_mutex_unlock(tsdn, &shard->mtx);
-		assert(psset_empty);
-		hpa_shard_assert_stats_empty(&shard->psset.stats.full_slabs);
-		for (pszind_t i = 0; i < PSSET_NPSIZES; i++) {
-			hpa_shard_assert_stats_empty(
-			    &shard->psset.stats.nonfull_slabs[i]);
-		}
+	}
+	edata_t *ps;
+	while ((ps = edata_list_inactive_first(&shard->unused_slabs)) != NULL) {
+		assert(edata_size_get(ps) == HUGEPAGE);
+		edata_list_inactive_remove(&shard->unused_slabs, ps);
+		pages_unmap(edata_base_get(ps), HUGEPAGE);
 	}
 }
 
@@ -461,22 +590,4 @@ void
 hpa_shard_postfork_child(tsdn_t *tsdn, hpa_shard_t *shard) {
 	malloc_mutex_postfork_child(tsdn, &shard->grow_mtx);
 	malloc_mutex_postfork_child(tsdn, &shard->mtx);
-}
-
-void
-hpa_prefork4(tsdn_t *tsdn, hpa_t *hpa) {
-	malloc_mutex_prefork(tsdn, &hpa->grow_mtx);
-	malloc_mutex_prefork(tsdn, &hpa->mtx);
-}
-
-void
-hpa_postfork_parent(tsdn_t *tsdn, hpa_t *hpa) {
-	malloc_mutex_postfork_parent(tsdn, &hpa->grow_mtx);
-	malloc_mutex_postfork_parent(tsdn, &hpa->mtx);
-}
-
-void
-hpa_postfork_child(tsdn_t *tsdn, hpa_t *hpa) {
-	malloc_mutex_postfork_child(tsdn, &hpa->grow_mtx);
-	malloc_mutex_postfork_child(tsdn, &hpa->mtx);
 }

--- a/src/hpdata.c
+++ b/src/hpdata.c
@@ -1,0 +1,18 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/hpdata.h"
+
+static int
+hpdata_age_comp(const hpdata_t *a, const hpdata_t *b) {
+	uint64_t a_age = hpdata_age_get(a);
+	uint64_t b_age = hpdata_age_get(b);
+	/*
+	 * hpdata ages are operation counts in the psset; no two should be the
+	 * same.
+	 */
+	assert(a_age != b_age);
+	return (a_age > b_age) - (a_age < b_age);
+}
+
+ph_gen(, hpdata_age_heap_, hpdata_age_heap_t, hpdata_t, ph_link, hpdata_age_comp)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -136,8 +136,8 @@ malloc_mutex_t arenas_lock;
 
 /* The global hpa, and whether it's on. */
 bool opt_hpa = false;
-size_t opt_hpa_slab_goal = 128 * 1024;
 size_t opt_hpa_slab_max_alloc = 256 * 1024;
+size_t opt_hpa_slab_goal = 128 * 1024;
 size_t opt_hpa_small_max = 32 * 1024;
 size_t opt_hpa_large_min = 4 * 1024 * 1024;
 
@@ -1490,20 +1490,9 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 					   CONF_CHECK_MIN, CONF_CHECK_MAX,
 					   true);
 			CONF_HANDLE_BOOL(opt_hpa, "hpa")
-			/*
-			 * If someone violates these mins and maxes, they're
-			 * confused.
-			 */
-			CONF_HANDLE_SIZE_T(opt_hpa_slab_goal, "hpa_slab_goal",
-			    PAGE, 512 * PAGE, CONF_CHECK_MIN, CONF_CHECK_MAX,
-			    true)
 			CONF_HANDLE_SIZE_T(opt_hpa_slab_max_alloc,
 			    "hpa_slab_max_alloc", PAGE, 512 * PAGE,
 			    CONF_CHECK_MIN, CONF_CHECK_MAX, true);
-			CONF_HANDLE_SIZE_T(opt_hpa_small_max, "hpa_small_max",
-			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
-			CONF_HANDLE_SIZE_T(opt_hpa_large_min, "hpa_large_min",
-			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
 
 			CONF_HANDLE_SIZE_T(opt_hpa_sec_max_alloc, "hpa_sec_max_alloc",
 			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
@@ -1511,6 +1500,21 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
 			CONF_HANDLE_SIZE_T(opt_hpa_sec_nshards, "hpa_sec_nshards",
 			    0, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
+
+			/*
+			 * These no longer have any effect, but various
+			 * non-public test configs set them as we iterate on HPA
+			 * development.  We parse and report them for now, but
+			 * they don't affect behavior.  Eventually they'll be
+			 * removed.
+			 */
+			CONF_HANDLE_SIZE_T(opt_hpa_slab_goal, "hpa_slab_goal",
+			    PAGE, 512 * PAGE, CONF_CHECK_MIN, CONF_CHECK_MAX,
+			    true)
+			CONF_HANDLE_SIZE_T(opt_hpa_small_max, "hpa_small_max",
+			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
+			CONF_HANDLE_SIZE_T(opt_hpa_large_min, "hpa_large_min",
+			    PAGE, 0, CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
 
 			if (CONF_MATCH("slab_sizes")) {
 				if (CONF_MATCH_VALUE("default")) {

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1797,31 +1797,19 @@ malloc_init_hard_a0_locked() {
 	}
 	a0 = arena_get(TSDN_NULL, 0, false);
 
-	if (opt_hpa && LG_SIZEOF_PTR == 2) {
+	if (opt_hpa && !hpa_supported()) {
+		malloc_printf("<jemalloc>: HPA not supported in the current "
+		    "configuration; %s.",
+		    opt_abort_conf ? "aborting" : "disabling");
 		if (opt_abort_conf) {
-			malloc_printf("<jemalloc>: Hugepages not currently "
-			    "supported on 32-bit architectures; aborting.");
+			malloc_abort_invalid_conf();
 		} else {
-			malloc_printf("<jemalloc>: Hugepages not currently "
-			    "supported on 32-bit architectures; disabling.");
 			opt_hpa = false;
 		}
 	} else if (opt_hpa) {
-		/*
-		 * The global HPA uses the edata cache from a0, and so needs to
-		 * be initialized specially, after a0 is.  The arena init code
-		 * handles this case specially, and does not turn on the HPA for
-		 * a0 when opt_hpa is true.  This lets us do global HPA
-		 * initialization against a valid a0.
-		 */
-		if (hpa_init(&arena_hpa_global, b0get(), &arena_emap_global,
-		    &a0->pa_shard.edata_cache)) {
-			return true;
-		}
-		if (pa_shard_enable_hpa(&a0->pa_shard, &arena_hpa_global,
-		    opt_hpa_slab_goal, opt_hpa_slab_max_alloc,
-		    opt_hpa_small_max, opt_hpa_large_min, opt_hpa_sec_nshards,
-		    opt_hpa_sec_max_alloc, opt_hpa_sec_max_bytes)) {
+		if (pa_shard_enable_hpa(&a0->pa_shard, opt_hpa_slab_max_alloc,
+		    opt_hpa_sec_nshards, opt_hpa_sec_max_alloc,
+		    opt_hpa_sec_max_bytes)) {
 			return true;
 		}
 	}
@@ -4335,9 +4323,6 @@ _malloc_prefork(void)
 				}
 			}
 		}
-		if (i == 4 && opt_hpa) {
-			hpa_prefork4(tsd_tsdn(tsd), &arena_hpa_global);
-		}
 
 	}
 	prof_prefork1(tsd_tsdn(tsd));
@@ -4377,9 +4362,6 @@ _malloc_postfork(void)
 			arena_postfork_parent(tsd_tsdn(tsd), arena);
 		}
 	}
-	if (opt_hpa) {
-		hpa_postfork_parent(tsd_tsdn(tsd), &arena_hpa_global);
-	}
 	prof_postfork_parent(tsd_tsdn(tsd));
 	if (have_background_thread) {
 		background_thread_postfork_parent(tsd_tsdn(tsd));
@@ -4409,9 +4391,6 @@ jemalloc_postfork_child(void) {
 		if ((arena = arena_get(tsd_tsdn(tsd), i, false)) != NULL) {
 			arena_postfork_child(tsd_tsdn(tsd), arena);
 		}
-	}
-	if (opt_hpa) {
-		hpa_postfork_child(tsd_tsdn(tsd), &arena_hpa_global);
 	}
 	prof_postfork_child(tsd_tsdn(tsd));
 	if (have_background_thread) {

--- a/src/pa.c
+++ b/src/pa.c
@@ -51,8 +51,8 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 bool
 pa_shard_enable_hpa(pa_shard_t *shard, size_t alloc_max, size_t sec_nshards,
     size_t sec_alloc_max, size_t sec_bytes_max) {
-	if (hpa_shard_init(&shard->hpa_shard, shard->emap, &shard->edata_cache,
-	    shard->ind, alloc_max)) {
+	if (hpa_shard_init(&shard->hpa_shard, shard->emap, shard->base,
+	    &shard->edata_cache, shard->ind, alloc_max)) {
 		return true;
 	}
 	if (sec_init(&shard->hpa_sec, &shard->hpa_shard.pai, sec_nshards,

--- a/src/pa.c
+++ b/src/pa.c
@@ -49,17 +49,10 @@ pa_shard_init(tsdn_t *tsdn, pa_shard_t *shard, emap_t *emap, base_t *base,
 }
 
 bool
-pa_shard_enable_hpa(pa_shard_t *shard, hpa_t *hpa, size_t ps_goal,
-    size_t ps_alloc_max, size_t small_max, size_t large_min,
-    size_t sec_nshards, size_t sec_alloc_max, size_t sec_bytes_max) {
-	ps_goal &= ~PAGE_MASK;
-	ps_alloc_max &= ~PAGE_MASK;
-
-	if (ps_alloc_max > ps_goal) {
-		ps_alloc_max = ps_goal;
-	}
-	if (hpa_shard_init(&shard->hpa_shard, hpa, &shard->edata_cache,
-	    shard->ind, ps_goal, ps_alloc_max, small_max, large_min)) {
+pa_shard_enable_hpa(pa_shard_t *shard, size_t alloc_max, size_t sec_nshards,
+    size_t sec_alloc_max, size_t sec_bytes_max) {
+	if (hpa_shard_init(&shard->hpa_shard, shard->emap, &shard->edata_cache,
+	    shard->ind, alloc_max)) {
 		return true;
 	}
 	if (sec_init(&shard->hpa_sec, &shard->hpa_shard.pai, sec_nshards,

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -150,15 +150,7 @@ pa_shard_stats_merge(tsdn_t *tsdn, pa_shard_t *shard,
 	}
 
 	if (shard->ever_used_hpa) {
-		malloc_mutex_lock(tsdn, &shard->hpa_shard.mtx);
-		psset_bin_stats_accum(&hpa_stats_out->psset_full_slab_stats,
-		    &shard->hpa_shard.psset.full_slab_stats);
-		for (pszind_t i = 0; i < PSSET_NPSIZES; i++) {
-			psset_bin_stats_accum(
-			    &hpa_stats_out->psset_slab_stats[i],
-			    &shard->hpa_shard.psset.slab_stats[i]);
-		}
-		malloc_mutex_unlock(tsdn, &shard->hpa_shard.mtx);
+		hpa_stats_merge(tsdn, &shard->hpa_shard, hpa_stats_out);
 		sec_stats_merge(tsdn, &shard->hpa_sec, sec_stats_out);
 	}
 }

--- a/src/pa_extra.c
+++ b/src/pa_extra.c
@@ -150,7 +150,7 @@ pa_shard_stats_merge(tsdn_t *tsdn, pa_shard_t *shard,
 	}
 
 	if (shard->ever_used_hpa) {
-		hpa_stats_merge(tsdn, &shard->hpa_shard, hpa_stats_out);
+		hpa_shard_stats_merge(tsdn, &shard->hpa_shard, hpa_stats_out);
 		sec_stats_merge(tsdn, &shard->hpa_sec, sec_stats_out);
 	}
 }

--- a/src/psset.c
+++ b/src/psset.c
@@ -11,11 +11,10 @@ static const bitmap_info_t psset_bitmap_info =
 void
 psset_init(psset_t *psset) {
 	for (unsigned i = 0; i < PSSET_NPSIZES; i++) {
-		edata_age_heap_new(&psset->pageslabs[i]);
+		hpdata_age_heap_new(&psset->pageslabs[i]);
 	}
 	bitmap_init(psset->bitmap, &psset_bitmap_info, /* fill */ true);
 	memset(&psset->stats, 0, sizeof(psset->stats));
-	psset->age_counter = 0;
 }
 
 static void
@@ -49,18 +48,17 @@ psset_stats_accum(psset_stats_t *dst, psset_stats_t *src) {
  * ensure we don't miss any heap modification operations.
  */
 JEMALLOC_ALWAYS_INLINE void
-psset_bin_stats_insert_remove(psset_bin_stats_t *binstats, edata_t *ps,
+psset_bin_stats_insert_remove(psset_bin_stats_t *binstats, hpdata_t *ps,
     bool insert) {
-	size_t *npageslabs_dst = edata_hugeified_get(ps)
+	size_t *npageslabs_dst = hpdata_huge_get(ps)
 	    ? &binstats->npageslabs_huge : &binstats->npageslabs_nonhuge;
-	size_t *nactive_dst = edata_hugeified_get(ps)
+	size_t *nactive_dst = hpdata_huge_get(ps)
 	    ? &binstats->nactive_huge : &binstats->nactive_nonhuge;
-	size_t *ninactive_dst = edata_hugeified_get(ps)
+	size_t *ninactive_dst = hpdata_huge_get(ps)
 	    ? &binstats->ninactive_huge : &binstats->ninactive_nonhuge;
 
-	size_t npages = edata_size_get(ps) >> LG_PAGE;
-	size_t ninactive = edata_nfree_get(ps);
-	size_t nactive = npages - ninactive;
+	size_t ninactive = hpdata_nfree_get(ps);
+	size_t nactive = HUGEPAGE_PAGES - ninactive;
 
 	size_t mul = insert ? (size_t)1 : (size_t)-1;
 	*npageslabs_dst += mul * 1;
@@ -69,12 +67,12 @@ psset_bin_stats_insert_remove(psset_bin_stats_t *binstats, edata_t *ps,
 }
 
 static void
-psset_bin_stats_insert(psset_bin_stats_t *binstats, edata_t *ps) {
+psset_bin_stats_insert(psset_bin_stats_t *binstats, hpdata_t *ps) {
 	psset_bin_stats_insert_remove(binstats, ps, /* insert */ true);
 }
 
 static void
-psset_bin_stats_remove(psset_bin_stats_t *binstats, edata_t *ps) {
+psset_bin_stats_remove(psset_bin_stats_t *binstats, hpdata_t *ps) {
 	psset_bin_stats_insert_remove(binstats, ps, /* insert */ false);
 }
 
@@ -96,27 +94,27 @@ psset_bin_stats_deactivate(psset_bin_stats_t *binstats, bool huge, size_t num) {
 }
 
 static void
-psset_edata_heap_remove(psset_t *psset, pszind_t pind, edata_t *ps) {
-	edata_age_heap_remove(&psset->pageslabs[pind], ps);
+psset_hpdata_heap_remove(psset_t *psset, pszind_t pind, hpdata_t *ps) {
+	hpdata_age_heap_remove(&psset->pageslabs[pind], ps);
 	psset_bin_stats_remove(&psset->stats.nonfull_slabs[pind], ps);
 }
 
 static void
-psset_edata_heap_insert(psset_t *psset, pszind_t pind, edata_t *ps) {
-	edata_age_heap_insert(&psset->pageslabs[pind], ps);
+psset_hpdata_heap_insert(psset_t *psset, pszind_t pind, hpdata_t *ps) {
+	hpdata_age_heap_insert(&psset->pageslabs[pind], ps);
 	psset_bin_stats_insert(&psset->stats.nonfull_slabs[pind], ps);
 }
 
 JEMALLOC_ALWAYS_INLINE void
-psset_assert_ps_consistent(edata_t *ps) {
-	assert(fb_urange_longest(edata_slab_data_get(ps)->bitmap,
-	    edata_size_get(ps) >> LG_PAGE) == edata_longest_free_range_get(ps));
+psset_assert_ps_consistent(hpdata_t *ps) {
+	assert(fb_urange_longest(ps->active_pages, HUGEPAGE_PAGES)
+	    == hpdata_longest_free_range_get(ps));
 }
 
 void
-psset_insert(psset_t *psset, edata_t *ps) {
+psset_insert(psset_t *psset, hpdata_t *ps) {
 	psset_assert_ps_consistent(ps);
-	size_t longest_free_range = edata_longest_free_range_get(ps);
+	size_t longest_free_range = hpdata_longest_free_range_get(ps);
 
 	if (longest_free_range == 0) {
 		/*
@@ -131,16 +129,16 @@ psset_insert(psset_t *psset, edata_t *ps) {
 	    longest_free_range << LG_PAGE));
 
 	assert(pind < PSSET_NPSIZES);
-	if (edata_age_heap_empty(&psset->pageslabs[pind])) {
+	if (hpdata_age_heap_empty(&psset->pageslabs[pind])) {
 		bitmap_unset(psset->bitmap, &psset_bitmap_info, (size_t)pind);
 	}
-	psset_edata_heap_insert(psset, pind, ps);
+	psset_hpdata_heap_insert(psset, pind, ps);
 }
 
 void
-psset_remove(psset_t *psset, edata_t *ps) {
+psset_remove(psset_t *psset, hpdata_t *ps) {
 	psset_assert_ps_consistent(ps);
-	size_t longest_free_range = edata_longest_free_range_get(ps);
+	size_t longest_free_range = hpdata_longest_free_range_get(ps);
 
 	if (longest_free_range == 0) {
 		psset_bin_stats_remove(&psset->stats.full_slabs, ps);
@@ -150,18 +148,18 @@ psset_remove(psset_t *psset, edata_t *ps) {
 	pszind_t pind = sz_psz2ind(sz_psz_quantize_floor(
 	    longest_free_range << LG_PAGE));
 	assert(pind < PSSET_NPSIZES);
-	psset_edata_heap_remove(psset, pind, ps);
-	if (edata_age_heap_empty(&psset->pageslabs[pind])) {
+	psset_hpdata_heap_remove(psset, pind, ps);
+	if (hpdata_age_heap_empty(&psset->pageslabs[pind])) {
 		bitmap_set(psset->bitmap, &psset_bitmap_info, (size_t)pind);
 	}
 }
 
 void
-psset_hugify(psset_t *psset, edata_t *ps) {
-	assert(!edata_hugeified_get(ps));
+psset_hugify(psset_t *psset, hpdata_t *ps) {
+	assert(!hpdata_huge_get(ps));
 	psset_assert_ps_consistent(ps);
 
-	size_t longest_free_range = edata_longest_free_range_get(ps);
+	size_t longest_free_range = hpdata_longest_free_range_get(ps);
 	psset_bin_stats_t *bin_stats;
 	if (longest_free_range == 0) {
 		bin_stats = &psset->stats.full_slabs;
@@ -172,7 +170,7 @@ psset_hugify(psset_t *psset, edata_t *ps) {
 		bin_stats = &psset->stats.nonfull_slabs[pind];
 	}
 	psset_bin_stats_remove(bin_stats, ps);
-	edata_hugeified_set(ps, true);
+	hpdata_huge_set(ps, true);
 	psset_bin_stats_insert(bin_stats, ps);
 }
 
@@ -180,7 +178,7 @@ psset_hugify(psset_t *psset, edata_t *ps) {
  * Similar to PAC's extent_recycle_extract.  Out of all the pageslabs in the
  * set, picks one that can satisfy the allocation and remove it from the set.
  */
-static edata_t *
+static hpdata_t *
 psset_recycle_extract(psset_t *psset, size_t size) {
 	pszind_t min_pind = sz_psz2ind(sz_psz_quantize_ceil(size));
 	pszind_t pind = (pszind_t)bitmap_ffu(psset->bitmap, &psset_bitmap_info,
@@ -188,13 +186,13 @@ psset_recycle_extract(psset_t *psset, size_t size) {
 	if (pind == PSSET_NPSIZES) {
 		return NULL;
 	}
-	edata_t *ps = edata_age_heap_first(&psset->pageslabs[pind]);
+	hpdata_t *ps = hpdata_age_heap_first(&psset->pageslabs[pind]);
 	if (ps == NULL) {
 		return NULL;
 	}
 
-	psset_edata_heap_remove(psset, pind, ps);
-	if (edata_age_heap_empty(&psset->pageslabs[pind])) {
+	psset_hpdata_heap_remove(psset, pind, ps);
+	if (hpdata_age_heap_empty(&psset->pageslabs[pind])) {
 		bitmap_set(psset->bitmap, &psset_bitmap_info, pind);
 	}
 
@@ -207,7 +205,7 @@ psset_recycle_extract(psset_t *psset, size_t size) {
  * edata with a range in the pageslab, and puts ps back in the set.
  */
 static void
-psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
+psset_ps_alloc_insert(psset_t *psset, hpdata_t *ps, edata_t *r_edata,
     size_t size) {
 	size_t start = 0;
 	/*
@@ -217,15 +215,14 @@ psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
 	size_t begin = 0;
 	size_t len = 0;
 
-	fb_group_t *ps_fb = edata_slab_data_get(ps)->bitmap;
+	fb_group_t *ps_fb = ps->active_pages;
 
 	size_t npages = size >> LG_PAGE;
-	size_t ps_npages = edata_size_get(ps) >> LG_PAGE;
 
 	size_t largest_unchosen_range = 0;
 	while (true) {
-		bool found = fb_urange_iter(ps_fb, ps_npages, start, &begin,
-		    &len);
+		bool found = fb_urange_iter(ps_fb, HUGEPAGE_PAGES, start,
+		    &begin, &len);
 		/*
 		 * A precondition to this function is that ps must be able to
 		 * serve the allocation.
@@ -245,14 +242,14 @@ psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
 		}
 		start = begin + len;
 	}
-	uintptr_t addr = (uintptr_t)edata_base_get(ps) + begin * PAGE;
+	uintptr_t addr = (uintptr_t)hpdata_addr_get(ps) + begin * PAGE;
 	edata_init(r_edata, edata_arena_ind_get(r_edata), (void *)addr, size,
 	    /* slab */ false, SC_NSIZES, /* sn */ 0, extent_state_active,
 	    /* zeroed */ false, /* committed */ true, EXTENT_PAI_HPA,
 	    EXTENT_NOT_HEAD);
 	edata_ps_set(r_edata, ps);
-	fb_set_range(ps_fb, ps_npages, begin, npages);
-	edata_nfree_set(ps, (uint32_t)(edata_nfree_get(ps) - npages));
+	fb_set_range(ps_fb, HUGEPAGE_PAGES, begin, npages);
+	hpdata_nfree_set(ps, (uint32_t)(hpdata_nfree_get(ps) - npages));
 	/* The pageslab isn't in a bin, so no bin stats need to change. */
 
 	/*
@@ -267,8 +264,8 @@ psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
 	 * this check in the case where we're allocating from some smaller run.
 	 */
 	start = begin + npages;
-	while (start < ps_npages) {
-		bool found = fb_urange_iter(ps_fb, ps_npages, start, &begin,
+	while (start < HUGEPAGE_PAGES) {
+		bool found = fb_urange_iter(ps_fb, HUGEPAGE_PAGES, start, &begin,
 		    &len);
 		if (!found) {
 			break;
@@ -278,7 +275,7 @@ psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
 		}
 		start = begin + len;
 	}
-	edata_longest_free_range_set(ps, (uint32_t)largest_unchosen_range);
+	hpdata_longest_free_range_set(ps, (uint32_t)largest_unchosen_range);
 	if (largest_unchosen_range == 0) {
 		psset_bin_stats_insert(&psset->stats.full_slabs, ps);
 	} else {
@@ -288,7 +285,7 @@ psset_ps_alloc_insert(psset_t *psset, edata_t *ps, edata_t *r_edata,
 
 bool
 psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size) {
-	edata_t *ps = psset_recycle_extract(psset, size);
+	hpdata_t *ps = psset_recycle_extract(psset, size);
 	if (ps == NULL) {
 		return true;
 	}
@@ -297,48 +294,43 @@ psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size) {
 }
 
 void
-psset_alloc_new(psset_t *psset, edata_t *ps, edata_t *r_edata, size_t size) {
-	fb_group_t *ps_fb = edata_slab_data_get(ps)->bitmap;
-	size_t ps_npages = edata_size_get(ps) >> LG_PAGE;
-	assert(fb_empty(ps_fb, ps_npages));
-	assert(ps_npages >= (size >> LG_PAGE));
-	edata_nfree_set(ps, (uint32_t)ps_npages);
-	edata_age_set(ps, psset->age_counter);
-	psset->age_counter++;
+psset_alloc_new(psset_t *psset, hpdata_t *ps, edata_t *r_edata, size_t size) {
+	fb_group_t *ps_fb = ps->active_pages;
+	assert(fb_empty(ps_fb, HUGEPAGE_PAGES));
+	assert(hpdata_nfree_get(ps) == HUGEPAGE_PAGES);
 	psset_ps_alloc_insert(psset, ps, r_edata, size);
 }
 
-edata_t *
+hpdata_t *
 psset_dalloc(psset_t *psset, edata_t *edata) {
 	assert(edata_pai_get(edata) == EXTENT_PAI_HPA);
 	assert(edata_ps_get(edata) != NULL);
-	edata_t *ps = edata_ps_get(edata);
+	hpdata_t *ps = edata_ps_get(edata);
 
-	fb_group_t *ps_fb = edata_slab_data_get(ps)->bitmap;
-	size_t ps_old_longest_free_range = edata_longest_free_range_get(ps);
+	fb_group_t *ps_fb = ps->active_pages;
+	size_t ps_old_longest_free_range = hpdata_longest_free_range_get(ps);
 	pszind_t old_pind = SC_NPSIZES;
 	if (ps_old_longest_free_range != 0) {
 		old_pind = sz_psz2ind(sz_psz_quantize_floor(
 		    ps_old_longest_free_range << LG_PAGE));
 	}
 
-	size_t ps_npages = edata_size_get(ps) >> LG_PAGE;
 	size_t begin =
-	    ((uintptr_t)edata_base_get(edata) - (uintptr_t)edata_base_get(ps))
+	    ((uintptr_t)edata_base_get(edata) - (uintptr_t)hpdata_addr_get(ps))
 	    >> LG_PAGE;
 	size_t len = edata_size_get(edata) >> LG_PAGE;
-	fb_unset_range(ps_fb, ps_npages, begin, len);
+	fb_unset_range(ps_fb, HUGEPAGE_PAGES, begin, len);
 
 	/* The pageslab is still in the bin; adjust its stats first. */
 	psset_bin_stats_t *bin_stats = (ps_old_longest_free_range == 0
 	    ? &psset->stats.full_slabs : &psset->stats.nonfull_slabs[old_pind]);
-	psset_bin_stats_deactivate(bin_stats, edata_hugeified_get(ps), len);
+	psset_bin_stats_deactivate(bin_stats, hpdata_huge_get(ps), len);
 
-	edata_nfree_set(ps, (uint32_t)(edata_nfree_get(ps) + len));
+	hpdata_nfree_set(ps, (uint32_t)(hpdata_nfree_get(ps) + len));
 
 	/* We might have just created a new, larger range. */
-	size_t new_begin = (size_t)(fb_fls(ps_fb, ps_npages, begin) + 1);
-	size_t new_end = fb_ffs(ps_fb, ps_npages, begin + len - 1);
+	size_t new_begin = (size_t)(fb_fls(ps_fb, HUGEPAGE_PAGES, begin) + 1);
+	size_t new_end = fb_ffs(ps_fb, HUGEPAGE_PAGES, begin + len - 1);
 	size_t new_range_len = new_end - new_begin;
 	/*
 	 * If the new free range is no longer than the previous longest one,
@@ -352,7 +344,7 @@ psset_dalloc(psset_t *psset, edata_t *edata) {
 	 * Otherwise, it might need to get evicted from the set, or change its
 	 * bin.
 	 */
-	edata_longest_free_range_set(ps, (uint32_t)new_range_len);
+	hpdata_longest_free_range_set(ps, (uint32_t)new_range_len);
 	/*
 	 * If it was previously non-full, then it's in some (possibly now
 	 * incorrect) bin already; remove it.
@@ -366,8 +358,8 @@ psset_dalloc(psset_t *psset, edata_t *edata) {
 	 * and the issue becomes moot).
 	 */
 	if (ps_old_longest_free_range > 0) {
-		psset_edata_heap_remove(psset, old_pind, ps);
-		if (edata_age_heap_empty(&psset->pageslabs[old_pind])) {
+		psset_hpdata_heap_remove(psset, old_pind, ps);
+		if (hpdata_age_heap_empty(&psset->pageslabs[old_pind])) {
 			bitmap_set(psset->bitmap, &psset_bitmap_info,
 			    (size_t)old_pind);
 		}
@@ -379,16 +371,16 @@ psset_dalloc(psset_t *psset, edata_t *edata) {
 		psset_bin_stats_remove(&psset->stats.full_slabs, ps);
 	}
 	/* If the pageslab is empty, it gets evicted from the set. */
-	if (new_range_len == ps_npages) {
+	if (new_range_len == HUGEPAGE_PAGES) {
 		return ps;
 	}
 	/* Otherwise, it gets reinserted. */
 	pszind_t new_pind = sz_psz2ind(sz_psz_quantize_floor(
 	    new_range_len << LG_PAGE));
-	if (edata_age_heap_empty(&psset->pageslabs[new_pind])) {
+	if (hpdata_age_heap_empty(&psset->pageslabs[new_pind])) {
 		bitmap_unset(psset->bitmap, &psset_bitmap_info,
 		    (size_t)new_pind);
 	}
-	psset_edata_heap_insert(psset, new_pind, ps);
+	psset_hpdata_heap_insert(psset, new_pind, ps);
 	return NULL;
 }

--- a/src/psset.c
+++ b/src/psset.c
@@ -76,23 +76,6 @@ psset_bin_stats_remove(psset_bin_stats_t *binstats, hpdata_t *ps) {
 	psset_bin_stats_insert_remove(binstats, ps, /* insert */ false);
 }
 
-/*
- * We don't currently need an "activate" equivalent to this, since down the
- * allocation pathways we don't do the optimization in which we change a slab
- * without first removing it from a bin.
- */
-static void
-psset_bin_stats_deactivate(psset_bin_stats_t *binstats, bool huge, size_t num) {
-	size_t *nactive_dst = huge
-	    ? &binstats->nactive_huge : &binstats->nactive_nonhuge;
-	size_t *ninactive_dst = huge
-	    ? &binstats->ninactive_huge : &binstats->ninactive_nonhuge;
-
-	assert(*nactive_dst >= num);
-	*nactive_dst -= num;
-	*ninactive_dst += num;
-}
-
 static void
 psset_hpdata_heap_remove(psset_t *psset, pszind_t pind, hpdata_t *ps) {
 	hpdata_age_heap_remove(&psset->pageslabs[pind], ps);
@@ -148,32 +131,8 @@ psset_remove(psset_t *psset, hpdata_t *ps) {
 	}
 }
 
-void
-psset_hugify(psset_t *psset, hpdata_t *ps) {
-	assert(!hpdata_huge_get(ps));
-	hpdata_assert_consistent(ps);
-
-	size_t longest_free_range = hpdata_longest_free_range_get(ps);
-	psset_bin_stats_t *bin_stats;
-	if (longest_free_range == 0) {
-		bin_stats = &psset->stats.full_slabs;
-	} else {
-		pszind_t pind = sz_psz2ind(sz_psz_quantize_floor(
-		    longest_free_range << LG_PAGE));
-		assert(pind < PSSET_NPSIZES);
-		bin_stats = &psset->stats.nonfull_slabs[pind];
-	}
-	psset_bin_stats_remove(bin_stats, ps);
-	hpdata_huge_set(ps, true);
-	psset_bin_stats_insert(bin_stats, ps);
-}
-
-/*
- * Similar to PAC's extent_recycle_extract.  Out of all the pageslabs in the
- * set, picks one that can satisfy the allocation and remove it from the set.
- */
-static hpdata_t *
-psset_recycle_extract(psset_t *psset, size_t size) {
+hpdata_t *
+psset_fit(psset_t *psset, size_t size) {
 	pszind_t min_pind = sz_psz2ind(sz_psz_quantize_ceil(size));
 	pszind_t pind = (pszind_t)bitmap_ffu(psset->bitmap, &psset_bitmap_info,
 	    (size_t)min_pind);
@@ -185,22 +144,14 @@ psset_recycle_extract(psset_t *psset, size_t size) {
 		return NULL;
 	}
 
-	psset_hpdata_heap_remove(psset, pind, ps);
-	if (hpdata_age_heap_empty(&psset->pageslabs[pind])) {
-		bitmap_set(psset->bitmap, &psset_bitmap_info, pind);
-	}
-
 	hpdata_assert_consistent(ps);
+
 	return ps;
 }
 
-/*
- * Given a pageslab ps and an edata to allocate size bytes from, initializes the
- * edata with a range in the pageslab, and puts ps back in the set.
- */
-static void
-psset_ps_alloc_insert(psset_t *psset, hpdata_t *ps, edata_t *r_edata,
-    size_t size) {
+void
+psset_alloc_new(psset_t *psset, hpdata_t *ps, edata_t *r_edata, size_t size) {
+	hpdata_assert_empty(ps);
 	size_t npages = size / PAGE;
 	size_t begin = hpdata_reserve_alloc(ps, npages);
 	uintptr_t addr = (uintptr_t)hpdata_addr_get(ps) + begin * PAGE;
@@ -209,30 +160,28 @@ psset_ps_alloc_insert(psset_t *psset, hpdata_t *ps, edata_t *r_edata,
 	    /* zeroed */ false, /* committed */ true, EXTENT_PAI_HPA,
 	    EXTENT_NOT_HEAD);
 	edata_ps_set(r_edata, ps);
-	/* The pageslab isn't in a bin, so no bin stats need to change. */
-
-	size_t longest_free_range = hpdata_longest_free_range_get(ps);
-	if (longest_free_range == 0) {
-		psset_bin_stats_insert(&psset->stats.full_slabs, ps);
-	} else {
-		psset_insert(psset, ps);
-	}
+	psset_insert(psset, ps);
 }
 
 bool
 psset_alloc_reuse(psset_t *psset, edata_t *r_edata, size_t size) {
-	hpdata_t *ps = psset_recycle_extract(psset, size);
-	if (ps == NULL) {
-		return true;
-	}
-	psset_ps_alloc_insert(psset, ps, r_edata, size);
-	return false;
-}
+       hpdata_t *ps = psset_fit(psset, size);
+       if (ps == NULL) {
+               return true;
+       }
+       psset_remove(psset, ps);
 
-void
-psset_alloc_new(psset_t *psset, hpdata_t *ps, edata_t *r_edata, size_t size) {
-	hpdata_assert_empty(ps);
-	psset_ps_alloc_insert(psset, ps, r_edata, size);
+       size_t npages = size / PAGE;
+       size_t begin = hpdata_reserve_alloc(ps, npages);
+       uintptr_t addr = (uintptr_t)hpdata_addr_get(ps) + begin * PAGE;
+       edata_init(r_edata, edata_arena_ind_get(r_edata), (void *)addr, size,
+	   /* slab */ false, SC_NSIZES, /* sn */ 0, extent_state_active,
+	   /* zeroed */ false, /* committed */ true, EXTENT_PAI_HPA,
+	   EXTENT_NOT_HEAD);
+       edata_ps_set(r_edata, ps);
+       psset_insert(psset, ps);
+
+       return false;
 }
 
 hpdata_t *
@@ -241,70 +190,17 @@ psset_dalloc(psset_t *psset, edata_t *edata) {
 	assert(edata_ps_get(edata) != NULL);
 	hpdata_t *ps = edata_ps_get(edata);
 
-	size_t ps_old_longest_free_range = hpdata_longest_free_range_get(ps);
-	pszind_t old_pind = SC_NPSIZES;
-	if (ps_old_longest_free_range != 0) {
-		old_pind = sz_psz2ind(sz_psz_quantize_floor(
-		    ps_old_longest_free_range << LG_PAGE));
-	}
-
 	size_t begin =
 	    ((uintptr_t)edata_base_get(edata) - (uintptr_t)hpdata_addr_get(ps))
 	    >> LG_PAGE;
 	size_t len = edata_size_get(edata) >> LG_PAGE;
 
-	/* The pageslab is still in the bin; adjust its stats first. */
-	psset_bin_stats_t *bin_stats = (ps_old_longest_free_range == 0
-	    ? &psset->stats.full_slabs : &psset->stats.nonfull_slabs[old_pind]);
-	psset_bin_stats_deactivate(bin_stats, hpdata_huge_get(ps), len);
-
+	psset_remove(psset, ps);
 	hpdata_unreserve(ps, begin, len);
-	size_t ps_new_longest_free_range = hpdata_longest_free_range_get(ps);
-
-	/*
-	 * If the new free range is no longer than the previous longest one,
-	 * then the pageslab is non-empty and doesn't need to change bins.
-	 * We're done, and don't need to return a pageslab to evict.
-	 */
-	if (ps_new_longest_free_range <= ps_old_longest_free_range) {
+	if (hpdata_empty(ps)) {
+		return ps;
+	} else {
+		psset_insert(psset, ps);
 		return NULL;
 	}
-	/*
-	 * If it was previously non-full, then it's in some (possibly now
-	 * incorrect) bin already; remove it.
-	 *
-	 * TODO: We bailed out early above if we didn't expand the longest free
-	 * range, which should avoid a lot of redundant remove/reinserts in the
-	 * same bin.  But it doesn't eliminate all of them; it's possible that
-	 * we decreased the longest free range length, but only slightly, and
-	 * not enough to change our pszind.  We could check that more precisely.
-	 * (Or, ideally, size class dequantization will happen at some point,
-	 * and the issue becomes moot).
-	 */
-	if (ps_old_longest_free_range > 0) {
-		psset_hpdata_heap_remove(psset, old_pind, ps);
-		if (hpdata_age_heap_empty(&psset->pageslabs[old_pind])) {
-			bitmap_set(psset->bitmap, &psset_bitmap_info,
-			    (size_t)old_pind);
-		}
-	} else {
-		/*
-		 * Otherwise, the bin was full, and we need to adjust the full
-		 * bin stats.
-		 */
-		psset_bin_stats_remove(&psset->stats.full_slabs, ps);
-	}
-	/* If the pageslab is empty, it gets evicted from the set. */
-	if (ps_new_longest_free_range == HUGEPAGE_PAGES) {
-		return ps;
-	}
-	/* Otherwise, it gets reinserted. */
-	pszind_t new_pind = sz_psz2ind(sz_psz_quantize_floor(
-	    ps_new_longest_free_range << LG_PAGE));
-	if (hpdata_age_heap_empty(&psset->pageslabs[new_pind])) {
-		bitmap_unset(psset->bitmap, &psset_bitmap_info,
-		    (size_t)new_pind);
-	}
-	psset_hpdata_heap_insert(psset, new_pind, ps);
-	return NULL;
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -667,16 +667,27 @@ stats_arena_hpa_shard_print(emitter_t *emitter, unsigned i) {
 	emitter_row_t row;
 	emitter_row_init(&row);
 
-	size_t npageslabs;
-	size_t nactive;
-	size_t ninactive;
+	size_t npageslabs_huge;
+	size_t nactive_huge;
+	size_t ninactive_huge;
 
-	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.npageslabs",
-	    i, &npageslabs, size_t);
-	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.nactive",
-	    i, &nactive, size_t);
-	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.ninactive",
-	    i, &ninactive, size_t);
+	size_t npageslabs_nonhuge;
+	size_t nactive_nonhuge;
+	size_t ninactive_nonhuge;
+
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.npageslabs_huge",
+	    i, &npageslabs_huge, size_t);
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.nactive_huge",
+	    i, &nactive_huge, size_t);
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.ninactive_huge",
+	    i, &ninactive_huge, size_t);
+
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.npageslabs_nonhuge",
+	    i, &npageslabs_nonhuge, size_t);
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.nactive_nonhuge",
+	    i, &nactive_nonhuge, size_t);
+	CTL_M2_GET("stats.arenas.0.hpa_shard.full_slabs.ninactive_nonhuge",
+	    i, &ninactive_nonhuge, size_t);
 
 	size_t sec_bytes;
 	CTL_M2_GET("stats.arenas.0.hpa_sec_bytes", i, &sec_bytes, size_t);
@@ -686,39 +697,62 @@ stats_arena_hpa_shard_print(emitter_t *emitter, unsigned i) {
 	emitter_table_printf(emitter,
 	    "HPA shard stats:\n"
 	    "  In full slabs:\n"
-	    "      npageslabs: %zu\n"
-	    "      nactive: %zu\n"
-	    "      ninactive: %zu\n",
-	    npageslabs, nactive, ninactive);
+	    "      npageslabs: %zu huge, %zu nonhuge\n"
+	    "      nactive: %zu huge, %zu nonhuge \n"
+	    "      ninactive: %zu huge, %zu nonhuge \n",
+	    npageslabs_huge, npageslabs_nonhuge, nactive_huge, nactive_nonhuge,
+	    ninactive_huge, ninactive_nonhuge);
 	emitter_json_object_kv_begin(emitter, "hpa_shard");
 	emitter_json_object_kv_begin(emitter, "full_slabs");
-	emitter_json_kv(emitter, "npageslabs", emitter_type_size, &npageslabs);
-	emitter_json_kv(emitter, "nactive", emitter_type_size, &nactive);
-	emitter_json_kv(emitter, "ninactive", emitter_type_size, &ninactive);
+	emitter_json_kv(emitter, "npageslabs_huge", emitter_type_size,
+	    &npageslabs_huge);
+	emitter_json_kv(emitter, "npageslabs_nonhuge", emitter_type_size,
+	    &npageslabs_nonhuge);
+	emitter_json_kv(emitter, "nactive_huge", emitter_type_size,
+	    &nactive_huge);
+	emitter_json_kv(emitter, "nactive_nonhuge", emitter_type_size,
+	    &nactive_nonhuge);
+	emitter_json_kv(emitter, "ninactive_huge", emitter_type_size,
+	    &ninactive_huge);
+	emitter_json_kv(emitter, "ninactive_nonhuge", emitter_type_size,
+	    &ninactive_nonhuge);
 	emitter_json_object_end(emitter); /* End "full_slabs" */
 
 	COL_HDR(row, size, NULL, right, 20, size)
 	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, npageslabs, NULL, right, 13, size)
-	COL_HDR(row, nactive, NULL, right, 13, size)
-	COL_HDR(row, ninactive, NULL, right, 13, size)
+	COL_HDR(row, npageslabs_huge, NULL, right, 16, size)
+	COL_HDR(row, nactive_huge, NULL, right, 16, size)
+	COL_HDR(row, ninactive_huge, NULL, right, 16, size)
+	COL_HDR(row, npageslabs_nonhuge, NULL, right, 20, size)
+	COL_HDR(row, nactive_nonhuge, NULL, right, 20, size)
+	COL_HDR(row, ninactive_nonhuge, NULL, right, 20, size)
 
 	emitter_table_row(emitter, &header_row);
 	emitter_json_array_kv_begin(emitter, "nonfull_slabs");
 	bool in_gap = false;
 	for (pszind_t j = 0; j < PSSET_NPSIZES; j++) {
 		CTL_M2_M5_GET(
-		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.npageslabs",
-		    i, j, &npageslabs, size_t);
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.npageslabs_huge",
+		    i, j, &npageslabs_huge, size_t);
 		CTL_M2_M5_GET(
-		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.nactive",
-		    i, j, &nactive, size_t);
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.nactive_huge",
+		    i, j, &nactive_huge, size_t);
 		CTL_M2_M5_GET(
-		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.ninactive",
-		    i, j, &ninactive, size_t);
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.ninactive_huge",
+		    i, j, &ninactive_huge, size_t);
+
+		CTL_M2_M5_GET(
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.npageslabs_nonhuge",
+		    i, j, &npageslabs_nonhuge, size_t);
+		CTL_M2_M5_GET(
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.nactive_nonhuge",
+		    i, j, &nactive_nonhuge, size_t);
+		CTL_M2_M5_GET(
+		    "stats.arenas.0.hpa_shard.nonfull_slabs.0.ninactive_nonhuge",
+		    i, j, &ninactive_nonhuge, size_t);
 
 		bool in_gap_prev = in_gap;
-		in_gap = (npageslabs == 0);
+		in_gap = (npageslabs_huge == 0 && npageslabs_nonhuge == 0);
 		if (in_gap_prev && !in_gap) {
 			emitter_table_printf(emitter,
 			    "                     ---\n");
@@ -726,20 +760,29 @@ stats_arena_hpa_shard_print(emitter_t *emitter, unsigned i) {
 
 		col_size.size_val = sz_pind2sz(j);
 		col_ind.size_val = j;
-		col_npageslabs.size_val = npageslabs;
-		col_nactive.size_val = nactive;
-		col_ninactive.size_val = ninactive;
+		col_npageslabs_huge.size_val = npageslabs_huge;
+		col_nactive_huge.size_val = nactive_huge;
+		col_ninactive_huge.size_val = ninactive_huge;
+		col_npageslabs_nonhuge.size_val = npageslabs_nonhuge;
+		col_nactive_nonhuge.size_val = nactive_nonhuge;
+		col_ninactive_nonhuge.size_val = ninactive_nonhuge;
 		if (!in_gap) {
 			emitter_table_row(emitter, &row);
 		}
 
 		emitter_json_object_begin(emitter);
-		emitter_json_kv(emitter, "npageslabs", emitter_type_size,
-		    &npageslabs);
-		emitter_json_kv(emitter, "nactive", emitter_type_size,
-		    &nactive);
-		emitter_json_kv(emitter, "ninactive", emitter_type_size,
-		    &ninactive);
+		emitter_json_kv(emitter, "npageslabs_huge", emitter_type_size,
+		    &npageslabs_huge);
+		emitter_json_kv(emitter, "nactive_huge", emitter_type_size,
+		    &nactive_huge);
+		emitter_json_kv(emitter, "ninactive_huge", emitter_type_size,
+		    &ninactive_huge);
+		emitter_json_kv(emitter, "npageslabs_nonhuge", emitter_type_size,
+		    &npageslabs_nonhuge);
+		emitter_json_kv(emitter, "nactive_nonhuge", emitter_type_size,
+		    &nactive_nonhuge);
+		emitter_json_kv(emitter, "ninactive_nonhuge", emitter_type_size,
+		    &ninactive_huge);
 		emitter_json_object_end(emitter);
 	}
 	emitter_json_array_end(emitter); /* End "nonfull_slabs" */

--- a/test/unit/hpa.c
+++ b/test/unit/hpa.c
@@ -52,7 +52,7 @@ destroy_test_data(hpa_shard_t *shard) {
 }
 
 TEST_BEGIN(test_alloc_max) {
-	test_skip_if(LG_SIZEOF_PTR != 3);
+	test_skip_if(!hpa_supported());
 
 	hpa_shard_t *shard = create_test_data();
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
@@ -128,7 +128,7 @@ node_remove(mem_tree_t *tree, edata_t *edata) {
 }
 
 TEST_BEGIN(test_stress) {
-	test_skip_if(LG_SIZEOF_PTR != 3);
+	test_skip_if(!hpa_supported());
 
 	hpa_shard_t *shard = create_test_data();
 

--- a/test/unit/hpa.c
+++ b/test/unit/hpa.c
@@ -38,7 +38,8 @@ create_test_data() {
 	assert_false(err, "");
 
 	err = hpa_shard_init(&test_data->shard, &test_data->emap,
-	    &test_data->shard_edata_cache, SHARD_IND, ALLOC_MAX);
+	    test_data->base, &test_data->shard_edata_cache, SHARD_IND,
+	    ALLOC_MAX);
 	assert_false(err, "");
 
 	return (hpa_shard_t *)test_data;

--- a/test/unit/hpdata.c
+++ b/test/unit/hpdata.c
@@ -1,0 +1,61 @@
+#include "test/jemalloc_test.h"
+
+#define HPDATA_ADDR ((void *)(10 * HUGEPAGE))
+#define HPDATA_AGE 123
+
+TEST_BEGIN(test_reserve_alloc) {
+	hpdata_t hpdata;
+	hpdata_init(&hpdata, HPDATA_ADDR, HPDATA_AGE);
+
+	/* Allocating a page at a time, we should do first fit. */
+	for (size_t i = 0; i < HUGEPAGE_PAGES; i++) {
+		expect_true(hpdata_consistent(&hpdata), "");
+		expect_zu_eq(HUGEPAGE_PAGES - i,
+		    hpdata_longest_free_range_get(&hpdata), "");
+		void *alloc = hpdata_reserve_alloc(&hpdata, PAGE);
+		expect_ptr_eq((char *)HPDATA_ADDR + i * PAGE, alloc, "");
+		expect_true(hpdata_consistent(&hpdata), "");
+	}
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(0, hpdata_longest_free_range_get(&hpdata), "");
+
+	/*
+	 * Build up a bigger free-range, 2 pages at a time, until we've got 6
+	 * adjacent free pages total.  Pages 8-13 should be unreserved after
+	 * this.
+	 */
+	hpdata_unreserve(&hpdata, (char *)HPDATA_ADDR + 10 * PAGE, 2 * PAGE);
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(2, hpdata_longest_free_range_get(&hpdata), "");
+
+	hpdata_unreserve(&hpdata, (char *)HPDATA_ADDR + 12 * PAGE, 2 * PAGE);
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(4, hpdata_longest_free_range_get(&hpdata), "");
+
+	hpdata_unreserve(&hpdata, (char *)HPDATA_ADDR + 8 * PAGE, 2 * PAGE);
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(6, hpdata_longest_free_range_get(&hpdata), "");
+
+	/*
+	 * Leave page 14 reserved, but free page 15 (this test the case where
+	 * unreserving combines two ranges).
+	 */
+	hpdata_unreserve(&hpdata, (char *)HPDATA_ADDR + 15 * PAGE, PAGE);
+	/*
+	 * Longest free range shouldn't change; we've got a free range of size
+	 * 6, then a reserved page, then another free range.
+	 */
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(6, hpdata_longest_free_range_get(&hpdata), "");
+
+	/* After freeing page 14, the two ranges get combined. */
+	hpdata_unreserve(&hpdata, (char *)HPDATA_ADDR + 14 * PAGE, PAGE);
+	expect_true(hpdata_consistent(&hpdata), "");
+	expect_zu_eq(8, hpdata_longest_free_range_get(&hpdata), "");
+}
+TEST_END
+
+int main(void) {
+	return test_no_reentrancy(
+	    test_reserve_alloc);
+}

--- a/test/unit/psset.c
+++ b/test/unit/psset.c
@@ -307,14 +307,14 @@ stats_expect_empty(psset_bin_stats_t *stats) {
 static void
 stats_expect(psset_t *psset, size_t nactive) {
 	if (nactive == PAGESLAB_PAGES) {
-		expect_zu_eq(1, psset->full_slab_stats.npageslabs,
+		expect_zu_eq(1, psset->stats.full_slabs.npageslabs,
 		    "Expected a full slab");
-		expect_zu_eq(PAGESLAB_PAGES, psset->full_slab_stats.nactive,
+		expect_zu_eq(PAGESLAB_PAGES, psset->stats.full_slabs.nactive,
 		    "Should have exactly filled the bin");
-		expect_zu_eq(0, psset->full_slab_stats.ninactive,
+		expect_zu_eq(0, psset->stats.full_slabs.ninactive,
 		    "Should never have inactive pages in a full slab");
 	} else {
-		stats_expect_empty(&psset->full_slab_stats);
+		stats_expect_empty(&psset->stats.full_slabs);
 	}
 	size_t ninactive = PAGESLAB_PAGES - nactive;
 	pszind_t nonempty_pind = PSSET_NPSIZES;
@@ -324,14 +324,17 @@ stats_expect(psset_t *psset, size_t nactive) {
 	}
 	for (pszind_t i = 0; i < PSSET_NPSIZES; i++) {
 		if (i == nonempty_pind) {
-			assert_zu_eq(1, psset->slab_stats[i].npageslabs,
+			assert_zu_eq(1,
+			    psset->stats.nonfull_slabs[i].npageslabs,
 			    "Should have found a slab");
-			expect_zu_eq(nactive, psset->slab_stats[i].nactive,
+			expect_zu_eq(nactive,
+			    psset->stats.nonfull_slabs[i].nactive,
 			    "Mismatch in active pages");
-			expect_zu_eq(ninactive, psset->slab_stats[i].ninactive,
+			expect_zu_eq(ninactive,
+			    psset->stats.nonfull_slabs[i].ninactive,
 			    "Mismatch in inactive pages");
 		} else {
-			stats_expect_empty(&psset->slab_stats[i]);
+			stats_expect_empty(&psset->stats.nonfull_slabs[i]);
 		}
 	}
 }


### PR DESCRIPTION
Each of these commits is individually small, but put together they are a fairly big design shift in the HPA. We now explicitly track a whole hugepage's state in an hpa_shard-local context. This lets us make smarter decisions about when to hugeify or not, and also allows purging hugepages in a reasonable way.

For now, we only purge whole hugepages, and only when they become completely empty, but this structure will allow finer-grained / smarter strategies as we continue to evolve.