### PR TITLE
Improve batch allocation stress test

### DIFF
--- a/test/stress/batch_alloc.c
+++ b/test/stress/batch_alloc.c
@@ -1,6 +1,10 @@
 #include "test/jemalloc_test.h"
 #include "test/bench.h"
 
+#define MIBLEN 8
+static size_t mib[MIBLEN];
+static size_t miblen = MIBLEN;
+
 #define TINY_BATCH 10
 #define TINY_BATCH_ITER (10 * 1000 * 1000)
 #define HUGE_BATCH (1000 * 1000)
@@ -27,7 +31,7 @@ batch_alloc_wrapper(size_t batch) {
 	    {batch_ptrs + batch_ptrs_next, batch, SIZE, 0};
 	size_t filled;
 	size_t len = sizeof(size_t);
-	assert_d_eq(mallctl("experimental.batch_alloc", &filled, &len,
+	assert_d_eq(mallctlbymib(mib, miblen, &filled, &len,
 	    &batch_alloc_packet, sizeof(batch_alloc_packet)), 0, "");
 	assert_zu_eq(filled, batch, "");
 }
@@ -184,6 +188,8 @@ TEST_BEGIN(test_huge_batch_with_free) {
 TEST_END
 
 int main(void) {
+	assert_d_eq(mallctlnametomib("experimental.batch_alloc", mib, &miblen),
+	    0, "");
 	return test_no_reentrancy(
 	    test_tiny_batch_without_free,
 	    test_tiny_batch_with_free,

--- a/test/stress/batch_alloc.c
+++ b/test/stress/batch_alloc.c
@@ -1,10 +1,15 @@
 #include "test/jemalloc_test.h"
 #include "test/bench.h"
 
-#define BATCH (1000 * 1000)
-#define HUGE_BATCH (100 * BATCH)
-static void *batch_ptrs[HUGE_BATCH];
-static void *item_ptrs[HUGE_BATCH];
+#define TINY_BATCH 10
+#define TINY_BATCH_ITER (10 * 1000 * 1000)
+#define HUGE_BATCH (1000 * 1000)
+#define HUGE_BATCH_ITER 100
+#define LEN (100 * 1000 * 1000)
+static void *batch_ptrs[LEN];
+static size_t batch_ptrs_next = 0;
+static void *item_ptrs[LEN];
+static size_t item_ptrs_next = 0;
 
 #define SIZE 7
 
@@ -18,7 +23,8 @@ struct batch_alloc_packet_s {
 
 static void
 batch_alloc_wrapper(size_t batch) {
-	batch_alloc_packet_t batch_alloc_packet = {batch_ptrs, batch, SIZE, 0};
+	batch_alloc_packet_t batch_alloc_packet =
+	    {batch_ptrs + batch_ptrs_next, batch, SIZE, 0};
 	size_t filled;
 	size_t len = sizeof(size_t);
 	assert_d_eq(mallctl("experimental.batch_alloc", &filled, &len,
@@ -28,14 +34,14 @@ batch_alloc_wrapper(size_t batch) {
 
 static void
 item_alloc_wrapper(size_t batch) {
-	for (size_t i = 0; i < batch; ++i) {
+	for (size_t i = item_ptrs_next, end = i + batch; i < end; ++i) {
 		item_ptrs[i] = malloc(SIZE);
 	}
 }
 
 static void
-release_and_clear(void **ptrs, size_t batch) {
-	for (size_t i = 0; i < batch; ++i) {
+release_and_clear(void **ptrs, size_t len) {
+	for (size_t i = 0; i < len; ++i) {
 		void *p = ptrs[i];
 		assert_ptr_not_null(p, "allocation failed");
 		sdallocx(p, SIZE, 0);
@@ -44,45 +50,143 @@ release_and_clear(void **ptrs, size_t batch) {
 }
 
 static void
-batch_alloc_small_can_repeat() {
-	batch_alloc_wrapper(BATCH);
-	release_and_clear(batch_ptrs, BATCH);
+batch_alloc_without_free(size_t batch) {
+	batch_alloc_wrapper(batch);
+	batch_ptrs_next += batch;
 }
 
 static void
-item_alloc_small_can_repeat() {
-	item_alloc_wrapper(BATCH);
-	release_and_clear(item_ptrs, BATCH);
+item_alloc_without_free(size_t batch) {
+	item_alloc_wrapper(batch);
+	item_ptrs_next += batch;
 }
 
-TEST_BEGIN(test_small_batch_with_free) {
-	compare_funcs(10, 100,
-	    "batch allocation", batch_alloc_small_can_repeat,
-	    "item allocation", item_alloc_small_can_repeat);
+static void
+batch_alloc_with_free(size_t batch) {
+	batch_alloc_wrapper(batch);
+	release_and_clear(batch_ptrs + batch_ptrs_next, batch);
+	batch_ptrs_next += batch;
+}
+
+static void
+item_alloc_with_free(size_t batch) {
+	item_alloc_wrapper(batch);
+	release_and_clear(item_ptrs + item_ptrs_next, batch);
+	item_ptrs_next += batch;
+}
+
+static void
+compare_without_free(size_t batch, size_t iter,
+    void (*batch_alloc_without_free_func)(void),
+    void (*item_alloc_without_free_func)(void)) {
+	assert(batch_ptrs_next == 0);
+	assert(item_ptrs_next == 0);
+	assert(batch * iter <= LEN);
+	for (size_t i = 0; i < iter; ++i) {
+		batch_alloc_without_free_func();
+		item_alloc_without_free_func();
+	}
+	release_and_clear(batch_ptrs, batch_ptrs_next);
+	batch_ptrs_next = 0;
+	release_and_clear(item_ptrs, item_ptrs_next);
+	item_ptrs_next = 0;
+	compare_funcs(0, iter,
+	    "batch allocation", batch_alloc_without_free_func,
+	    "item allocation", item_alloc_without_free_func);
+	release_and_clear(batch_ptrs, batch_ptrs_next);
+	batch_ptrs_next = 0;
+	release_and_clear(item_ptrs, item_ptrs_next);
+	item_ptrs_next = 0;
+}
+
+static void
+compare_with_free(size_t batch, size_t iter,
+    void (*batch_alloc_with_free_func)(void),
+    void (*item_alloc_with_free_func)(void)) {
+	assert(batch_ptrs_next == 0);
+	assert(item_ptrs_next == 0);
+	assert(batch * iter <= LEN);
+	for (size_t i = 0; i < iter; ++i) {
+		batch_alloc_with_free_func();
+		item_alloc_with_free_func();
+	}
+	batch_ptrs_next = 0;
+	item_ptrs_next = 0;
+	compare_funcs(0, iter,
+	    "batch allocation", batch_alloc_with_free_func,
+	    "item allocation", item_alloc_with_free_func);
+	batch_ptrs_next = 0;
+	item_ptrs_next = 0;
+}
+
+static void
+batch_alloc_without_free_tiny() {
+	batch_alloc_without_free(TINY_BATCH);
+}
+
+static void
+item_alloc_without_free_tiny() {
+	item_alloc_without_free(TINY_BATCH);
+}
+
+TEST_BEGIN(test_tiny_batch_without_free) {
+	compare_without_free(TINY_BATCH, TINY_BATCH_ITER,
+	    batch_alloc_without_free_tiny, item_alloc_without_free_tiny);
 }
 TEST_END
 
 static void
-batch_alloc_huge_cannot_repeat() {
-	batch_alloc_wrapper(HUGE_BATCH);
+batch_alloc_with_free_tiny() {
+	batch_alloc_with_free(TINY_BATCH);
 }
 
 static void
-item_alloc_huge_cannot_repeat() {
-	item_alloc_wrapper(HUGE_BATCH);
+item_alloc_with_free_tiny() {
+	item_alloc_with_free(TINY_BATCH);
+}
+
+TEST_BEGIN(test_tiny_batch_with_free) {
+	compare_with_free(TINY_BATCH, TINY_BATCH_ITER,
+	    batch_alloc_with_free_tiny, item_alloc_with_free_tiny);
+}
+TEST_END
+
+static void
+batch_alloc_without_free_huge() {
+	batch_alloc_without_free(HUGE_BATCH);
+}
+
+static void
+item_alloc_without_free_huge() {
+	item_alloc_without_free(HUGE_BATCH);
 }
 
 TEST_BEGIN(test_huge_batch_without_free) {
-	compare_funcs(0, 1,
-	    "batch allocation", batch_alloc_huge_cannot_repeat,
-	    "item allocation", item_alloc_huge_cannot_repeat);
-	release_and_clear(batch_ptrs, HUGE_BATCH);
-	release_and_clear(item_ptrs, HUGE_BATCH);
+	compare_without_free(HUGE_BATCH, HUGE_BATCH_ITER,
+	    batch_alloc_without_free_huge, item_alloc_without_free_huge);
+}
+TEST_END
+
+static void
+batch_alloc_with_free_huge() {
+	batch_alloc_with_free(HUGE_BATCH);
+}
+
+static void
+item_alloc_with_free_huge() {
+	item_alloc_with_free(HUGE_BATCH);
+}
+
+TEST_BEGIN(test_huge_batch_with_free) {
+	compare_with_free(HUGE_BATCH, HUGE_BATCH_ITER,
+	    batch_alloc_with_free_huge, item_alloc_with_free_huge);
 }
 TEST_END
 
 int main(void) {
 	return test_no_reentrancy(
-	    test_small_batch_with_free,
-	    test_huge_batch_without_free);
+	    test_tiny_batch_without_free,
+	    test_tiny_batch_with_free,
+	    test_huge_batch_without_free,
+	    test_huge_batch_with_free);
 }


### PR DESCRIPTION
There are several changes:
- Added a tiny batch size, since the batch allocation API is not only intended for huge batch size.
- Removed the very huge batch size, since there isn't any major insight we can get from that.
- Wrote two versions for both the tiny and huge batch size: one with free and one without free. The benchmark results from both versions can be useful.
- Added a "memory warmup" phase before every test. In contrast to the "CPU warmup" phase that's already in our benchmark system, this "memory warmup" phase ensures that there is enough dirty pages before every test run. Without such a "memory warmup" phase, I observed that the benchmark results could vary significantly depending on the amount of dirty pages available before the test run; for example, the result would be worse if a previous test run reduces its memory usage. Even with decay on, the "memory warmup" should be able to result in a fairer assessment. I think it can be worthwhile to add it to other benchmark tests as well, but for now, I'm only adding it to the batch allocation benchmarks.
- Used `mallctlbymib` rather than `mallctl` to focus more on the batch allocation API performance. The caching has a significant impact, as shown in the numbers I put below. I suspect that `mallctlbymib` still has a non-negligible performance toll, but there isn't any way to directly call the batch allocation API anyway (until perhaps the next major version).

I played with the new benchmark a bit, and produced some interesting results. Every number I report below is a median from three test runs.

First, some numbers showing the performance impact of
- The fast path optimization in #1962.
- The `mallctlbymib` optimization.

Without fast path opt; without `mib` opt:
```
------+----------+---------------+----------------+--------------+---------------+------
batch | w/ free? | batch ns/iter | batch ns/alloc | item ns/iter | item ns/alloc | ratio
------+----------+---------------+----------------+--------------+---------------+------
  10  |    N     |      801      |       80       |     147      |      15       |  5.45
------+----------+---------------+----------------+--------------+---------------+------
  10  |    Y     |      675      |       67       |      83      |       8       |  8.15
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    N     |     4.13M     |        4       |    8.57M     |       9       |  0.48
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    Y     |     16.1M     |       16       |    21.3M     |      21       |  0.75
------+----------+---------------+----------------+--------------+---------------+------
```
Without fast path opt; with `mib` opt:
```
------+----------+---------------+----------------+--------------+---------------+------
batch | w/ free? | batch ns/iter | batch ns/alloc | item ns/iter | item ns/alloc | ratio
------+----------+---------------+----------------+--------------+---------------+------
  10  |    N     |      676      |       68       |     144      |      14       |  4.68
------+----------+---------------+----------------+--------------+---------------+------
  10  |    Y     |      436      |       44       |      83      |       8       |  5.30
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    N     |     4.08M     |        4       |    8.58M     |       9       |  0.45
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    Y     |     16.6M     |       17       |    21.3M     |      21       |  0.75
------+----------+---------------+----------------+--------------+---------------+------
```
With fast path opt; without `mib` opt:
```
------+----------+---------------+----------------+--------------+---------------+------
batch | w/ free? | batch ns/iter | batch ns/alloc | item ns/iter | item ns/alloc | ratio
------+----------+---------------+----------------+--------------+---------------+------
  10  |    N     |      201      |       20       |      80      |       8       |  2.51
------+----------+---------------+----------------+--------------+---------------+------
  10  |    Y     |      201      |       20       |      80      |       8       |  2.56
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    N     |     3.52M     |        4       |    7.83M     |       8       |  0.44
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    Y     |     16.1M     |       16       |    22.0M     |      22       |  0.75
------+----------+---------------+----------------+--------------+---------------+------
```
With fast path opt; with `mib` opt:
```
------+----------+---------------+----------------+--------------+---------------+------
batch | w/ free? | batch ns/iter | batch ns/alloc | item ns/iter | item ns/alloc | ratio
------+----------+---------------+----------------+--------------+---------------+------
  10  |    N     |      104      |       10       |      82      |       8       |  1.20
------+----------+---------------+----------------+--------------+---------------+------
  10  |    Y     |       89      |        9       |      79      |       8       |  1.13
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    N     |     3.84M     |        4       |    8.46M     |       8       |  0.45
------+----------+---------------+----------------+--------------+---------------+------
  1M  |    Y     |     16.2M     |       16       |    21.6M     |      22       |  0.75
------+----------+---------------+----------------+--------------+---------------+------
```

Next, some numbers showing the batching effect on different batch sizes, all with both fast path opt and `mib` opt:
```
------+----------+---------------+----------------+--------------+---------------+------
batch | w/ free? | batch ns/iter | batch ns/alloc | item ns/iter | item ns/alloc | ratio
------+----------+---------------+----------------+--------------+---------------+------
   1  |    N     |       46      |       46       |      10      |      10       |  4.63
------+----------+---------------+----------------+--------------+---------------+------
   1  |    Y     |       44      |       44       |      10      |      10       |  4.56
------+----------+---------------+----------------+--------------+---------------+------
   2  |    N     |       55      |       27       |      19      |      10       |  2.90
------+----------+---------------+----------------+--------------+---------------+------
   2  |    Y     |       57      |       28       |      24      |      12       |  2.33
------+----------+---------------+----------------+--------------+---------------+------
   4  |    N     |       64      |       16       |      34      |       8       |  1.88
------+----------+---------------+----------------+--------------+---------------+------
   4  |    Y     |       67      |       17       |      38      |      10       |  1.75
------+----------+---------------+----------------+--------------+---------------+------
   8  |    N     |       87      |       11       |      67      |       8       |  1.28
------+----------+---------------+----------------+--------------+---------------+------
   8  |    Y     |       76      |       10       |      66      |       8       |  1.15
------+----------+---------------+----------------+--------------+---------------+------
  16  |    N     |      131      |        8       |     144      |       9       |  0.93
------+----------+---------------+----------------+--------------+---------------+------
  16  |    Y     |      117      |        7       |     139      |       9       |  0.88
------+----------+---------------+----------------+--------------+---------------+------
  32  |    N     |      225      |        7       |     260      |       8       |  0.89
------+----------+---------------+----------------+--------------+---------------+------
  32  |    Y     |      182      |        6       |     259      |       8       |  0.70
------+----------+---------------+----------------+--------------+---------------+------
  64  |    N     |      415      |        6       |     517      |       8       |  0.79
------+----------+---------------+----------------+--------------+---------------+------
  64  |    Y     |      310      |        5       |     482      |       8       |  0.65
------+----------+---------------+----------------+--------------+---------------+------
  128 |    N     |      798      |        6       |     1028     |       8       |  0.79
------+----------+---------------+----------------+--------------+---------------+------
  128 |    Y     |      610      |        5       |     972      |       8       |  0.63
------+----------+---------------+----------------+--------------+---------------+------
  256 |    N     |      1455     |        6       |     1930     |       8       |  0.76
------+----------+---------------+----------------+--------------+---------------+------
  256 |    Y     |      2345     |        9       |     3095     |      12       |  0.76
------+----------+---------------+----------------+--------------+---------------+------
  512 |    N     |      1840     |        4       |     4060     |       8       |  0.44
------+----------+---------------+----------------+--------------+---------------+------
  512 |    Y     |      8390     |       16       |     9320     |      18       |  0.90
------+----------+---------------+----------------+--------------+---------------+------
 1024 |    N     |      3520     |        3       |     8200     |       8       |  0.43
------+----------+---------------+----------------+--------------+---------------+------
 1024 |    Y     |     16680     |       16       |    19481     |      19       |  0.85
------+----------+---------------+----------------+--------------+---------------+------
 2048 |    N     |      8950     |        4       |    17601     |       9       |  0.52
------+----------+---------------+----------------+--------------+---------------+------
 2048 |    Y     |     34051     |       17       |    42801     |      21       |  0.82
------+----------+---------------+----------------+--------------+---------------+------
 4096 |    N     |     15300     |        4       |    34101     |       8       |  0.47
------+----------+---------------+----------------+--------------+---------------+------
 4096 |    Y     |     64252     |       16       |    79902     |      20       |  0.80
------+----------+---------------+----------------+--------------+---------------+------
```
I don't have a great way to visualize this dataset, but here are some interesting observations:
- The batch allocation performance is worse than a loop of `malloc` calls for single digit batch sizes.
- There's a sharp increase in allocation + free cost when the batch size causes `tcache` flushes.
- There's a sharp decrease in batch allocation cost when the batch size triggers batch fills from fresh arena.
- As the batch size reaches thousands, the performance numbers are pretty close to the 1M batch case reported earlier.

Note that the specific curvatures may not be widely applicable, since it depends on the `tcache` and slab sizes for the size class being tested (the smallest size class in my case).