### PR TITLE
Move n_search outside of assert as reported by static analyzer

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -185,7 +185,8 @@ arena_decay_compute_purge_interval_impl(tsdn_t *tsdn, decay_t *decay,
 			lb = target;
 			npurge_lb = npurge;
 		}
-		assert(n_search++ < lg_floor(SMOOTHSTEP_NSTEPS) + 1);
+		assert(n_search < lg_floor(SMOOTHSTEP_NSTEPS) + 1);
+		++n_search;
 	}
 	interval = decay_interval_ns * (ub + lb) / 2;
 label_done:


### PR DESCRIPTION
Reported in:
https://github.com/jemalloc/jemalloc/issues/1334

>> CID 17475 (#1 of 1): Side effect in assertion (ASSERT_SIDE_EFFECT)
>> assert_side_effect: Argument n_search++ of assert() has a side effect. The containing function might work differently in a non-debug build.
191                assert(n_search++ < lg_floor(SMOOTHSTEP_NSTEPS) + 1);
