### PR TITLE
Binary space optimizations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -909,6 +909,18 @@ if test "x${je_cv_fallthrough}" = "xyes" ; then
   JE_CXXFLAGS_ADD([-Wimplicit-fallthrough])
 fi
 
+dnl Check for cold attribute support.
+JE_CFLAGS_SAVE()
+JE_CFLAGS_ADD([-Werror])
+JE_CFLAGS_ADD([-herror_on_warning])
+JE_COMPILABLE([cold attribute], [],
+              [__attribute__((__cold__)) void foo();],
+              [je_cv_cold])
+JE_CFLAGS_RESTORE()
+if test "x${je_cv_cold}" = "xyes" ; then
+  AC_DEFINE([JEMALLOC_HAVE_ATTR_COLD], [ ])
+fi
+
 dnl Support optional additions to rpath.
 AC_ARG_WITH([rpath],
   [AS_HELP_STRING([--with-rpath=<rpath>], [Colon-separated rpath (ELF systems only)])],

--- a/include/jemalloc/jemalloc_defs.h.in
+++ b/include/jemalloc/jemalloc_defs.h.in
@@ -16,6 +16,9 @@
 /* Defined if fallthrough attribute is supported. */
 #undef JEMALLOC_HAVE_ATTR_FALLTHROUGH
 
+/* Defined if cold attribute is supported. */
+#undef JEMALLOC_HAVE_ATTR_COLD
+
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.

--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -85,6 +85,7 @@
 #  else
 #    define JEMALLOC_ALLOCATOR
 #  endif
+#  define JEMALLOC_COLD
 #elif defined(JEMALLOC_HAVE_ATTR)
 #  define JEMALLOC_ATTR(s) __attribute__((s))
 #  define JEMALLOC_ALIGNED(s) JEMALLOC_ATTR(aligned(s))
@@ -120,6 +121,11 @@
 #  define JEMALLOC_SECTION(s) JEMALLOC_ATTR(section(s))
 #  define JEMALLOC_RESTRICT_RETURN
 #  define JEMALLOC_ALLOCATOR
+#  ifdef JEMALLOC_HAVE_ATTR_COLD
+#    define JEMALLOC_COLD JEMALLOC_ATTR(__cold__)
+#  else
+#    define JEMALLOC_COLD
+#  endif
 #else
 #  define JEMALLOC_ATTR(s)
 #  define JEMALLOC_ALIGNED(s)
@@ -133,6 +139,7 @@
 #  define JEMALLOC_SECTION(s)
 #  define JEMALLOC_RESTRICT_RETURN
 #  define JEMALLOC_ALLOCATOR
+#  define JEMALLOC_COLD
 #endif
 
 #if defined(__APPLE__) && !defined(JEMALLOC_NO_RENAME)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3432,7 +3432,7 @@ irallocx_prof(tsd_t *tsd, void *old_ptr, size_t old_usize, size_t size,
 	return p;
 }
 
-JEMALLOC_ALWAYS_INLINE void *
+static void *
 do_rallocx(void *ptr, size_t size, int flags, bool is_realloc) {
 	void *p;
 	tsd_t *tsd;

--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -321,6 +321,7 @@ x2s(uintmax_t x, bool alt_form, bool uppercase, char *s, size_t *slen_p) {
 	return s;
 }
 
+JEMALLOC_COLD
 size_t
 malloc_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
 	size_t i;

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -202,6 +202,7 @@ prof_log_thr_index(tsd_t *tsd, uint64_t thr_uid, const char *name) {
 
 void
 prof_try_log(tsd_t *tsd, size_t usize, prof_info_t *prof_info) {
+	cassert(config_prof);
 	prof_tctx_t *tctx = prof_info->alloc_tctx;
 	malloc_mutex_assert_owner(tsd_tsdn(tsd), tctx->tdata->lock);
 
@@ -307,6 +308,7 @@ prof_thr_node_keycomp(const void *k1, const void *k2) {
 /* Used in unit tests. */
 size_t
 prof_log_bt_count(void) {
+	cassert(config_prof);
 	size_t cnt = 0;
 	prof_bt_node_t *node = log_bt_first;
 	while (node != NULL) {
@@ -319,6 +321,7 @@ prof_log_bt_count(void) {
 /* Used in unit tests. */
 size_t
 prof_log_alloc_count(void) {
+	cassert(config_prof);
 	size_t cnt = 0;
 	prof_alloc_node_t *node = log_alloc_first;
 	while (node != NULL) {
@@ -331,6 +334,7 @@ prof_log_alloc_count(void) {
 /* Used in unit tests. */
 size_t
 prof_log_thr_count(void) {
+	cassert(config_prof);
 	size_t cnt = 0;
 	prof_thr_node_t *node = log_thr_first;
 	while (node != NULL) {
@@ -343,12 +347,14 @@ prof_log_thr_count(void) {
 /* Used in unit tests. */
 bool
 prof_log_is_logging(void) {
+	cassert(config_prof);
 	return prof_logging_state == prof_logging_state_started;
 }
 
 /* Used in unit tests. */
 bool
 prof_log_rep_check(void) {
+	cassert(config_prof);
 	if (prof_logging_state == prof_logging_state_stopped
 	    && log_tables_initialized) {
 		return true;
@@ -401,11 +407,14 @@ prof_log_rep_check(void) {
 /* Used in unit tests. */
 void
 prof_log_dummy_set(bool new_value) {
+	cassert(config_prof);
 	prof_log_dummy = new_value;
 }
 
 bool
 prof_log_start(tsdn_t *tsdn, const char *filename) {
+	cassert(config_prof);
+
 	if (!opt_prof) {
 		return true;
 	}
@@ -586,6 +595,7 @@ prof_log_emit_metadata(emitter_t *emitter) {
 #define PROF_LOG_STOP_BUFSIZE PROF_DUMP_BUFSIZE
 bool
 prof_log_stop(tsdn_t *tsdn) {
+	cassert(config_prof);
 	if (!opt_prof || !prof_booted) {
 		return true;
 	}
@@ -672,6 +682,7 @@ prof_log_stop(tsdn_t *tsdn) {
 #undef PROF_LOG_STOP_BUFSIZE
 
 bool prof_log_init(tsd_t *tsd) {
+	cassert(config_prof);
 	if (malloc_mutex_init(&log_mtx, "prof_log",
 	    WITNESS_RANK_PROF_LOG, malloc_mutex_rank_exclusive)) {
 		return true;

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -200,6 +200,7 @@ prof_log_thr_index(tsd_t *tsd, uint64_t thr_uid, const char *name) {
 	}
 }
 
+JEMALLOC_COLD
 void
 prof_try_log(tsd_t *tsd, size_t usize, prof_info_t *prof_info) {
 	cassert(config_prof);
@@ -411,6 +412,7 @@ prof_log_dummy_set(bool new_value) {
 	prof_log_dummy = new_value;
 }
 
+JEMALLOC_COLD
 bool
 prof_log_start(tsdn_t *tsdn, const char *filename) {
 	cassert(config_prof);
@@ -593,6 +595,7 @@ prof_log_emit_metadata(emitter_t *emitter) {
 }
 
 #define PROF_LOG_STOP_BUFSIZE PROF_DUMP_BUFSIZE
+JEMALLOC_COLD
 bool
 prof_log_stop(tsdn_t *tsdn) {
 	cassert(config_prof);
@@ -681,7 +684,9 @@ prof_log_stop(tsdn_t *tsdn) {
 }
 #undef PROF_LOG_STOP_BUFSIZE
 
-bool prof_log_init(tsd_t *tsd) {
+JEMALLOC_COLD
+bool
+prof_log_init(tsd_t *tsd) {
 	cassert(config_prof);
 	if (malloc_mutex_init(&log_mtx, "prof_log",
 	    WITNESS_RANK_PROF_LOG, malloc_mutex_rank_exclusive)) {

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -528,6 +528,7 @@ prof_recent_alloc_dump_node(emitter_t *emitter, prof_recent_t *node) {
 }
 
 #define PROF_RECENT_PRINT_BUFSIZE 65536
+JEMALLOC_COLD
 void
 prof_recent_alloc_dump(tsd_t *tsd, write_cb_t *write_cb, void *cbopaque) {
 	cassert(config_prof);

--- a/src/prof_recent.c
+++ b/src/prof_recent.c
@@ -63,6 +63,7 @@ increment_recent_count(tsd_t *tsd, prof_tctx_t *tctx) {
 
 bool
 prof_recent_alloc_prepare(tsd_t *tsd, prof_tctx_t *tctx) {
+	cassert(config_prof);
 	assert(opt_prof && prof_booted);
 	malloc_mutex_assert_owner(tsd_tsdn(tsd), tctx->tdata->lock);
 	malloc_mutex_assert_not_owner(tsd_tsdn(tsd), &prof_recent_alloc_mtx);
@@ -106,6 +107,7 @@ prof_recent_alloc_edata_get_no_lock(const prof_recent_t *n) {
 
 edata_t *
 prof_recent_alloc_edata_get_no_lock_test(const prof_recent_t *n) {
+	cassert(config_prof);
 	return prof_recent_alloc_edata_get_no_lock(n);
 }
 
@@ -123,16 +125,19 @@ prof_recent_alloc_edata_set(tsd_t *tsd, prof_recent_t *n, edata_t *edata) {
 
 void
 edata_prof_recent_alloc_init(edata_t *edata) {
+	cassert(config_prof);
 	edata_prof_recent_alloc_set_dont_call_directly(edata, NULL);
 }
 
 static inline prof_recent_t *
 edata_prof_recent_alloc_get_no_lock(const edata_t *edata) {
+	cassert(config_prof);
 	return edata_prof_recent_alloc_get_dont_call_directly(edata);
 }
 
 prof_recent_t *
 edata_prof_recent_alloc_get_no_lock_test(const edata_t *edata) {
+	cassert(config_prof);
 	return edata_prof_recent_alloc_get_no_lock(edata);
 }
 
@@ -189,6 +194,7 @@ edata_prof_recent_alloc_reset(tsd_t *tsd, edata_t *edata,
  */
 void
 prof_recent_alloc_reset(tsd_t *tsd, edata_t *edata) {
+	cassert(config_prof);
 	/*
 	 * Check whether the recent allocation record still exists without
 	 * trying to acquire the lock.
@@ -271,6 +277,7 @@ prof_recent_alloc_assert_count(tsd_t *tsd) {
 
 void
 prof_recent_alloc(tsd_t *tsd, edata_t *edata, size_t size, size_t usize) {
+	cassert(config_prof);
 	assert(edata != NULL);
 	prof_tctx_t *tctx = edata_prof_tctx_get(edata);
 
@@ -397,6 +404,7 @@ label_rollback:
 
 ssize_t
 prof_recent_alloc_max_ctl_read() {
+	cassert(config_prof);
 	/* Don't bother to acquire the lock. */
 	return prof_recent_alloc_max_get_no_lock();
 }
@@ -450,6 +458,7 @@ prof_recent_alloc_async_cleanup(tsd_t *tsd, prof_recent_list_t *to_delete) {
 
 ssize_t
 prof_recent_alloc_max_ctl_write(tsd_t *tsd, ssize_t max) {
+	cassert(config_prof);
 	assert(max >= -1);
 	malloc_mutex_lock(tsd_tsdn(tsd), &prof_recent_alloc_mtx);
 	prof_recent_alloc_assert_count(tsd);
@@ -521,6 +530,7 @@ prof_recent_alloc_dump_node(emitter_t *emitter, prof_recent_t *node) {
 #define PROF_RECENT_PRINT_BUFSIZE 65536
 void
 prof_recent_alloc_dump(tsd_t *tsd, write_cb_t *write_cb, void *cbopaque) {
+	cassert(config_prof);
 	malloc_mutex_lock(tsd_tsdn(tsd), &prof_recent_dump_mtx);
 	buf_writer_t buf_writer;
 	buf_writer_init(tsd_tsdn(tsd), &buf_writer, write_cb, cbopaque, NULL,
@@ -570,6 +580,7 @@ prof_recent_alloc_dump(tsd_t *tsd, write_cb_t *write_cb, void *cbopaque) {
 
 bool
 prof_recent_init() {
+	cassert(config_prof);
 	prof_recent_alloc_max_init();
 
 	if (malloc_mutex_init(&prof_recent_alloc_mtx, "prof_recent_alloc",

--- a/src/stats.c
+++ b/src/stats.c
@@ -294,6 +294,7 @@ mutex_stats_emit(emitter_t *emitter, emitter_row_t *row,
 	header_##column_name.str_val = human ? human : #column_name;
 
 
+JEMALLOC_COLD
 static void
 stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i, uint64_t uptime) {
 	size_t page;
@@ -494,6 +495,7 @@ stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i, uint64_t upti
 	}
 }
 
+JEMALLOC_COLD
 static void
 stats_arena_lextents_print(emitter_t *emitter, unsigned i, uint64_t uptime) {
 	unsigned nbins, nlextents, j;
@@ -572,6 +574,7 @@ stats_arena_lextents_print(emitter_t *emitter, unsigned i, uint64_t uptime) {
 	}
 }
 
+JEMALLOC_COLD
 static void
 stats_arena_extents_print(emitter_t *emitter, unsigned i) {
 	unsigned j;
@@ -824,6 +827,7 @@ stats_arena_mutexes_print(emitter_t *emitter, unsigned arena_ind, uint64_t uptim
 	emitter_json_object_end(emitter); /* End "mutexes". */
 }
 
+JEMALLOC_COLD
 static void
 stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
     bool mutex, bool extents, bool hpa) {
@@ -1151,6 +1155,7 @@ stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
 	}
 }
 
+JEMALLOC_COLD
 static void
 stats_general_print(emitter_t *emitter) {
 	const char *cpv;
@@ -1422,6 +1427,7 @@ stats_general_print(emitter_t *emitter) {
 	emitter_json_object_end(emitter); /* Close "arenas" */
 }
 
+JEMALLOC_COLD
 static void
 stats_print_helper(emitter_t *emitter, bool merged, bool destroyed,
     bool unmerged, bool bins, bool large, bool mutex, bool extents, bool hpa) {

--- a/test/unit/prof_log.c
+++ b/test/unit/prof_log.c
@@ -141,7 +141,9 @@ TEST_END
 
 int
 main(void) {
-	prof_log_dummy_set(true);
+	if (config_prof) {
+		prof_log_dummy_set(true);
+	}
 	return test_no_reentrancy(
 	    test_prof_log_many_logs,
 	    test_prof_log_many_traces,


### PR DESCRIPTION
This change implements a few binary size reductions:
- Even when stats and profiling are disabled, some of those functions still get included. Adding a cassert tells the compiler they're unreachable, and lets them be optimized into no-ops.
- Marking cold functions as cold treats them as such, including some space-saving optimizations. For now, the definition of cold is fairly conservative (basically, things that are manually-triggered, or can only happen once; things like prof_lookup aren't counted as cold, even though they arguably are).
- Allowing code reuse between realloc and rallocx (by removing the force inline) saves nontrivial space overhead. This does cost slightly more CPU (since we have to parse a constant 0 flag), but that's quite cheap in practice, especially given that the realloc pathways are cold generally.

Binary size before this change, under common configurations:
(no stats, no profiling) 456k
(stats but no profiling) 624k
(stats and profiling): 720k

And size after:
(no stats, no profiling) 372k (18.4% savings)
(stats but no profiling) 512k (17.9% savings)
(stats and profiling) 620k (13.9% savings)

The first of these is the one I care about the most, since it's the configuration being shipped in the space-sensitive applications we know about.