### PR TITLE
Fix stats for "tcache_max" (was "lg_tcache_max")

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -1498,7 +1498,7 @@ stats_general_print(emitter_t *emitter) {
 	OPT_WRITE_BOOL("utrace")
 	OPT_WRITE_BOOL("xmalloc")
 	OPT_WRITE_BOOL("tcache")
-	OPT_WRITE_SSIZE_T("lg_tcache_max")
+	OPT_WRITE_SIZE_T("tcache_max")
 	OPT_WRITE_UNSIGNED("tcache_nslots_small_min")
 	OPT_WRITE_UNSIGNED("tcache_nslots_small_max")
 	OPT_WRITE_UNSIGNED("tcache_nslots_large")


### PR DESCRIPTION
Seems like this option was changed here: c8209150f9d219a137412b06431c9d52839c7272
And maybe this got missed.