### PR TITLE
Mark head state during dss alloc.

### DIFF
--- a/src/extent_dss.c
+++ b/src/extent_dss.c
@@ -140,6 +140,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 				goto label_oom;
 			}
 
+			bool head_state = opt_retain ? EXTENT_IS_HEAD :
+			    EXTENT_NOT_HEAD;
 			/*
 			 * Compute how much page-aligned gap space (if any) is
 			 * necessary to satisfy alignment.  This space can be
@@ -157,7 +159,7 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 				    SC_NSIZES, extent_sn_next(
 					&arena->pa_shard.pac),
 				    extent_state_active, false, true,
-				    EXTENT_PAI_PAC, EXTENT_NOT_HEAD);
+				    EXTENT_PAI_PAC, head_state);
 			}
 			/*
 			 * Compute the address just past the end of the desired
@@ -206,7 +208,7 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 					    arena_ind_get(arena), ret, size,
 					    size, false, SC_NSIZES,
 					    extent_state_active, false, true,
-					    EXTENT_PAI_PAC, EXTENT_NOT_HEAD);
+					    EXTENT_PAI_PAC, head_state);
 					if (extent_purge_forced_wrapper(tsdn,
 					    ehooks, &edata, 0, size)) {
 						memset(ret, 0, size);


### PR DESCRIPTION
Specifically, the extent_dalloc_gap relies on the correct head state to
coalesce.