### PR TITLE
Fix doc large size 54 KiB error

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -630,7 +630,7 @@ for (i = 0; i < nbins; i++) {
         </row>
         <row>
           <entry>8 KiB</entry>
-          <entry>[40 KiB, 48 KiB, 54 KiB, 64 KiB]</entry>
+          <entry>[40 KiB, 48 KiB, 56 KiB, 64 KiB]</entry>
         </row>
         <row>
           <entry>16 KiB</entry>


### PR DESCRIPTION
Hi,

Fix the doc error of `54 KiB` to `56 KiB` cause the spacing is 8 KiB.

Thanks.