### PR TITLE
Added jeprof --debug-syms-by-id option

### DIFF
--- a/bin/jeprof.in
+++ b/bin/jeprof.in
@@ -240,6 +240,7 @@ Miscellaneous:
    --test              Run unit tests
    --help              This message
    --version           Version information
+   --debug-syms-by-id  (Linux only) Find debug symbol files by build ID as well as by name
 
 Environment Variables:
    JEPROF_TMPDIR        Profiles directory. Defaults to \$HOME/jeprof
@@ -365,6 +366,7 @@ sub Init() {
   $main::opt_tools   = "";
   $main::opt_debug   = 0;
   $main::opt_test    = 0;
+  $main::opt_debug_syms_by_id = 0;
 
   # These are undocumented flags used only by unittests.
   $main::opt_test_stride = 0;
@@ -433,6 +435,7 @@ sub Init() {
              "tools=s"        => \$main::opt_tools,
              "test!"          => \$main::opt_test,
              "debug!"         => \$main::opt_debug,
+             "debug-syms-by-id!" => \$main::opt_debug_syms_by_id,
              # Undocumented flags used only by unittests:
              "test_stride=i"  => \$main::opt_test_stride,
       ) || usage("Invalid option(s)");
@@ -577,6 +580,11 @@ sub Init() {
   foreach (@prefix_list) {
     s|/+$||;
   }
+
+  # Flag to prevent us from trying over and over to use
+  #  elfutils if it's not installed (used only with
+  #  --debug-syms-by-id option).
+  $main::gave_up_on_elfutils = 0;
 }
 
 sub FilterAndPrint {
@@ -4492,15 +4500,53 @@ sub FindLibrary {
 # For libc libraries, the copy in /usr/lib/debug contains debugging symbols
 sub DebuggingLibrary {
   my $file = shift;
-  if ($file =~ m|^/|) {
-      if (-f "/usr/lib/debug$file") {
-        return "/usr/lib/debug$file";
-      } elsif (-f "/usr/lib/debug$file.debug") {
-        return "/usr/lib/debug$file.debug";
-      }
+      
+  if ($file !~ m|^/|) {
+    return undef;
   }
+      
+  # Find debug symbol file if it's named after the library's name.
+  
+  if (-f "/usr/lib/debug$file") {                 
+    if($main::opt_debug) { print STDERR "found debug info for $file in /usr/lib/debug$file\n"; }
+    return "/usr/lib/debug$file";
+  } elsif (-f "/usr/lib/debug$file.debug") {
+    if($main::opt_debug) { print STDERR "found debug info for $file in /usr/lib/debug$file.debug\n"; }
+    return "/usr/lib/debug$file.debug"; 
+  }
+
+  if(!$main::opt_debug_syms_by_id) {
+    if($main::opt_debug) { print STDERR "no debug symbols found for $file\n" };
+    return undef;
+  }
+
+  # Find debug file if it's named after the library's build ID.
+  
+  my $readelf = '';
+  if (!$main::gave_up_on_elfutils) {
+    $readelf = qx/eu-readelf -n ${file}/;
+    if ($?) {
+      print STDERR "Cannot run eu-readelf. To use --debug-syms-by-id you must be on Linux, with elfutils installed.\n";
+      $main::gave_up_on_elfutils = 1;
+      return undef;
+    }
+    my $buildID = $1 if $readelf =~ /Build ID: ([A-Fa-f0-9]+)/s;
+    if (defined $buildID && length $buildID > 0) {
+      my $symbolFile = '/usr/lib/debug/.build-id/' . substr($buildID, 0, 2) . '/' . substr($buildID, 2) . '.debug';
+      if (-e $symbolFile) {
+        if($main::opt_debug) { print STDERR "found debug symbol file $symbolFile for $file\n" };
+        return $symbolFile;
+      } else {
+        if($main::opt_debug) { print STDERR "no debug symbol file found for $file, build ID: $buildID\n" };
+        return undef;
+      }
+    }
+  }
+
+  if($main::opt_debug) { print STDERR "no debug symbols found for $file, build ID unknown\n" };
   return undef;
 }
+
 
 # Parse text section header of a library using objdump
 sub ParseTextSectionHeaderFromObjdump {

--- a/src/safety_check.c
+++ b/src/safety_check.c
@@ -10,7 +10,7 @@ void safety_check_fail_sized_dealloc(bool current_dealloc, const void *ptr,
 
 	safety_check_fail("<jemalloc>: size mismatch detected (true size %zu "
 	    "vs input size %zu), likely caused by application sized "
-	    "dealloction bugs (source address: %p, %s). Suggest building with "
+	    "deallocation bugs (source address: %p, %s). Suggest building with "
 	    "--enable-debug or address sanitizer for debugging. Abort.\n",
 	    true_size, input_size, ptr, src);
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -1476,8 +1476,9 @@ stats_general_print(emitter_t *emitter) {
 		 * representation.
 		 */
 		if (u32v == (uint32_t)-1) {
+			const char *neg1 = "-1";
 			emitter_kv(emitter, "hpa_dirty_mult",
-			    "opt.hpa_dirty_mult", emitter_type_string, "-1");
+			    "opt.hpa_dirty_mult", emitter_type_string, &neg1);
 		} else {
 			char buf[FXP_BUF_SIZE];
 			fxp_print(u32v, buf);


### PR DESCRIPTION
Improved jeprof's ability to find installed debug symbol packages based on https://stackoverflow.com/a/64038064/370707

```
apt install -y openjdk-8-jdk

$ cat HelloWorld.java 
public class HelloWorld {

    public static void main(String[] args) {
        // Prints "Hello, World" to the terminal window.
        System.out.println("Hello, World");
    }

}

$ javac HelloWorld.java

$ export LD_PRELOAD=/usr/lib/libjemalloc.so
 $ export MALLOC_CONF=prof:true,lg_prof_interval:20,prof_prefix:/tmp/jemalloc-java

$ java HelloWorld 

$ export LD_PRELOAD=

$ apt install -y openjdk-8-dbg
$ dpkg -L openjdk-8-dbg
...
/usr/lib/debug/.build-id/03/17f517a518dee47febb310f62e609737e1dc63.debug
...
/usr/lib/debug/.build-id/05/73a57ddc18e75eecd35598cc9bbb68d0110a80.debug
...

$ jeprof |& grep debug-syms
   --debug-syms-by-id  (Linux only) Find debug symbol files by build ID as well as by name

$  jeprof --show_bytes --text `which java` /tmp/jemalloc-java*.heap
...
Total: 6024978 B
 6024978 100.0% 100.0%  6024978 100.0% je_prof_backtrace
       0   0.0% 100.0%   540842   9.0% 0x00007f2ff49862a2
       0   0.0% 100.0%   524352   8.7% 0x00007f2ff4993b86
       0   0.0% 100.0%  5484135  91.0% AsyncGetCallTrace
       0   0.0% 100.0%  4418940  73.3% JLI_GetStdArgc
       0   0.0% 100.0%  4418940  73.3% JNI_CreateJavaVM
       0   0.0% 100.0%  6024978 100.0% JVM_FindSignal
       0   0.0% 100.0%  6024978 100.0% JVM_handle_linux_signal
       0   0.0% 100.0%  6024978 100.0% SUNWprivate_1.1
       0   0.0% 100.0%  4959783  82.3% clone
       0   0.0% 100.0%  6024978 100.0% imalloc (inline)
       0   0.0% 100.0%  6024978 100.0% imalloc_body (inline)
       0   0.0% 100.0%  6024978 100.0% je_malloc_default
       0   0.0% 100.0%  6024978 100.0% prof_alloc_prep (inline)
       0   0.0% 100.0%  4959783  82.3% start_thread
...

$ jeprof   --debug-syms-by-id  --show_bytes --text `which java` /tmp/jemalloc-java*.heap
...
Can't exec "eu-readelf": No such file or directory at /root/jemalloc/bin/jeprof line 4527.
Cannot run eu-readelf. To use --debug-syms-by-id you must be on Linux, with elfutils installed
...

$ apt install -y elfutils 
$ jeprof    --debug-syms-by-id  --show_bytes --text `which java` /tmp/jemalloc-java*.heap
...
Total: 6024978 B
 6024978 100.0% 100.0%  6024978 100.0% je_prof_backtrace
       0   0.0% 100.0%   540842   9.0% 0x00007f2ff49862a2
       0   0.0% 100.0%   524352   8.7% 0x00007f2ff4993b86
       0   0.0% 100.0%  2235733  37.1% Arena::Arena
       0   0.0% 100.0%  1081685  18.0% Arena::grow
       0   0.0% 100.0%   524352   8.7% CHeapObj::operator new
       0   0.0% 100.0%  1081685  18.0% ChunkPool::allocate
       0   0.0% 100.0%   524352   8.7% ClassFileParser::parseClassFile
       0   0.0% 100.0%   524352   8.7% ClassFileParser::parse_constant_pool
       0   0.0% 100.0%   524352   8.7% ClassLoader::load_classfile
       0   0.0% 100.0%   540842   9.0% CompileBroker::compiler_thread_loop
       0   0.0% 100.0%   540842   9.0% CompileBroker::init_compiler_runtime
       0   0.0% 100.0%   540842   9.0% Compiler::initialize
       0   0.0% 100.0%   540842   9.0% CompressedWriteStream::write_int_mb
       0   0.0% 100.0%   524352   8.7% ConstantPool::allocate
       0   0.0% 100.0%   524352   8.7% ConstantPool::klass_at_impl
       0   0.0% 100.0%   524384   8.7% GCMemoryManager::initialize_gc_stat_info
       0   0.0% 100.0%   524384   8.7% GCStatInfo::GCStatInfo
       0   0.0% 100.0%   524352   8.7% InterpreterRuntime::_new
       0   0.0% 100.0%   540842   9.0% InterpreterRuntime::prepare_native_call
       0   0.0% 100.0%  4418940  73.3% JNI_CreateJavaVM
       0   0.0% 100.0%  4418940  73.3% JavaMain
       0   0.0% 100.0%   540842   9.0% JavaThread::run
       0   0.0% 100.0%   540842   9.0% JavaThread::thread_main_inner
       0   0.0% 100.0%   524384   8.7% MemoryService::set_universe_heap
       0   0.0% 100.0%   540842   9.0% NativeLookup::lookup
       0   0.0% 100.0%   540842   9.0% NativeLookup::lookup_base
       0   0.0% 100.0%   540842   9.0% NativeLookup::lookup_entry
       0   0.0% 100.0%   540842   9.0% NativeLookup::lookup_style
       0   0.0% 100.0%   540842   9.0% OopMap::set_callee_saved
       0   0.0% 100.0%   540842   9.0% Runtime1::generate_blob_for
       0   0.0% 100.0%   540842   9.0% Runtime1::generate_code_for
       0   0.0% 100.0%   540842   9.0% Runtime1::generate_handle_exception
       0   0.0% 100.0%   540842   9.0% Runtime1::initialize
       0   0.0% 100.0%  2235733  37.1% SymbolTable::initialize_symbols
       0   0.0% 100.0%   524352   8.7% SystemDictionary::load_instance_class
       0   0.0% 100.0%   524352   8.7% SystemDictionary::resolve_instance_class_or_null
       0   0.0% 100.0%   524352   8.7% SystemDictionary::resolve_or_fail
       0   0.0% 100.0%   524352   8.7% SystemDictionary::resolve_super_or_fail
       0   0.0% 100.0%  4418940  73.3% Threads::create_vm
       0   0.0% 100.0%  4418940  73.3% call_continuation
       0   0.0% 100.0%  4959783  82.3% clone
       0   0.0% 100.0%   540842   9.0% generate_oop_map [clone .constprop.12]
       0   0.0% 100.0%  6024978 100.0% imalloc (inline)
       0   0.0% 100.0%  6024978 100.0% imalloc_body (inline)
       0   0.0% 100.0%  4418940  73.3% init_globals
       0   0.0% 100.0%   540842   9.0% java_start
       0   0.0% 100.0%  6024978 100.0% je_malloc_default
       0   0.0% 100.0%  6024978 100.0% os::malloc
       0   0.0% 100.0%  6024978 100.0% prof_alloc_prep (inline)
       0   0.0% 100.0%  4959783  82.3% start_thread
       0   0.0% 100.0%   540842   9.0% stringStream::stringStream
       0   0.0% 100.0%  3894556  64.6% universe_init
       0   0.0% 100.0%   524384   8.7% universe_post_init

```