### PR TITLE
Add opt.experimental_infallible_new.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ test/include/test/jemalloc_test.h
 test/include/test/jemalloc_test_defs.h
 
 /test/integration/[A-Za-z]*
+!/test/integration/cpp/
 !/test/integration/[A-Za-z]*.*
 /test/integration/*.[od]
 /test/integration/*.out

--- a/Makefile.in
+++ b/Makefile.in
@@ -309,7 +309,9 @@ TESTS_INTEGRATION += \
 endif
 ifeq (@enable_cxx@, 1)
 CPP_SRCS := $(srcroot)src/jemalloc_cpp.cpp
-TESTS_INTEGRATION_CPP := $(srcroot)test/integration/cpp/basic.cpp
+TESTS_INTEGRATION_CPP := $(srcroot)test/integration/cpp/basic.cpp \
+	$(srcroot)test/integration/cpp/infallible_new_true.cpp \
+	$(srcroot)test/integration/cpp/infallible_new_false.cpp
 else
 CPP_SRCS :=
 TESTS_INTEGRATION_CPP :=

--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,9 @@ if test "x$enable_cxx" = "x1" ; then
     enable_cxx="0"
   fi
 fi
+if test "x$enable_cxx" = "x1"; then
+  AC_DEFINE([JEMALLOC_ENABLE_CXX], [ ])
+fi
 AC_SUBST([enable_cxx])
 AC_SUBST([CONFIGURE_CXXFLAGS])
 AC_SUBST([SPECIFIED_CXXFLAGS])

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -401,6 +401,9 @@
 /* Performs additional safety checks when defined. */
 #undef JEMALLOC_OPT_SAFETY_CHECKS
 
+/* Is C++ support being built? */
+#undef JEMALLOC_ENABLE_CXX
+
 /* Performs additional size checks when defined. */
 #undef JEMALLOC_OPT_SIZE_CHECKS
 

--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -26,6 +26,7 @@ extern void (*junk_free_callback)(void *ptr, size_t size);
 extern void (*junk_alloc_callback)(void *ptr, size_t size);
 extern bool opt_utrace;
 extern bool opt_xmalloc;
+extern bool opt_experimental_infallible_new;
 extern bool opt_zero;
 extern unsigned opt_narenas;
 extern zero_realloc_action_t opt_zero_realloc_action;

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -198,6 +198,15 @@ static const bool config_opt_size_checks =
 #endif
     ;
 
+/* Whether or not the C++ extensions are enabled. */
+static const bool config_enable_cxx =
+#ifdef JEMALLOC_ENABLE_CXX
+    true
+#else
+    false
+#endif
+;
+
 #if defined(_WIN32) || defined(JEMALLOC_HAVE_SCHED_GETCPU)
 /* Currently percpu_arena depends on sched_getcpu. */
 #define JEMALLOC_PERCPU_ARENA

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -141,6 +141,7 @@ void (*junk_free_callback)(void *ptr, size_t size) = &default_junk_free;
 
 bool	opt_utrace = false;
 bool	opt_xmalloc = false;
+bool	opt_experimental_infallible_new = false;
 bool	opt_zero = false;
 unsigned	opt_narenas = 0;
 fxp_t		opt_narenas_ratio = FXP_INIT_INT(4);
@@ -1307,6 +1308,12 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			if (config_xmalloc) {
 				CONF_HANDLE_BOOL(opt_xmalloc, "xmalloc")
 			}
+			if (config_enable_cxx) {
+				CONF_HANDLE_BOOL(
+				    opt_experimental_infallible_new,
+				    "experimental_infallible_new")
+			}
+
 			CONF_HANDLE_BOOL(opt_tcache, "tcache")
 			CONF_HANDLE_SIZE_T(opt_tcache_max, "tcache_max",
 			    0, TCACHE_MAXCLASS_LIMIT, CONF_DONT_CHECK_MIN,

--- a/src/jemalloc_cpp.cpp
+++ b/src/jemalloc_cpp.cpp
@@ -56,6 +56,12 @@ void	operator delete[](void* ptr, std::size_t size, std::align_val_t al) noexcep
 JEMALLOC_NOINLINE
 static void *
 handleOOM(std::size_t size, bool nothrow) {
+	if (opt_experimental_infallible_new) {
+		safety_check_fail("<jemalloc>: Allocation failed and "
+		    "opt.experimental_infallible_new is true. Aborting.\n");
+		return nullptr;
+	}
+
 	void *ptr = nullptr;
 
 	while (ptr == nullptr) {
@@ -93,7 +99,6 @@ fallback_impl(std::size_t size) noexcept(IsNoExcept) {
 	if (likely(ptr != nullptr)) {
 		return ptr;
 	}
-
 	return handleOOM(size, IsNoExcept);
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1501,6 +1501,7 @@ stats_general_print(emitter_t *emitter) {
 	OPT_WRITE_BOOL("zero")
 	OPT_WRITE_BOOL("utrace")
 	OPT_WRITE_BOOL("xmalloc")
+	OPT_WRITE_BOOL("experimental_infallible_new")
 	OPT_WRITE_BOOL("tcache")
 	OPT_WRITE_SIZE_T("tcache_max")
 	OPT_WRITE_UNSIGNED("tcache_nslots_small_min")

--- a/test/integration/cpp/basic.cpp
+++ b/test/integration/cpp/basic.cpp
@@ -1,4 +1,3 @@
-#include <memory>
 #include "test/jemalloc_test.h"
 
 TEST_BEGIN(test_basic) {

--- a/test/integration/cpp/infallible_new_false.cpp
+++ b/test/integration/cpp/infallible_new_false.cpp
@@ -1,0 +1,23 @@
+#include <memory>
+
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_failing_alloc) {
+	bool saw_exception = false;
+	try {
+		/* Too big of an allocation to succeed. */
+		void *volatile ptr = ::operator new((size_t)-1);
+		(void)ptr;
+	} catch (...) {
+		saw_exception = true;
+	}
+	expect_true(saw_exception, "Didn't get a failure");
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_failing_alloc);
+}
+

--- a/test/integration/cpp/infallible_new_false.sh
+++ b/test/integration/cpp/infallible_new_false.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+XMALLOC_STR=""
+if [ "x${enable_xmalloc}" = "x1" ] ; then
+  XMALLOC_STR="xmalloc:false,"
+fi
+
+export MALLOC_CONF="${XMALLOC_STR}experimental_infallible_new:false"

--- a/test/integration/cpp/infallible_new_true.cpp
+++ b/test/integration/cpp/infallible_new_true.cpp
@@ -1,0 +1,61 @@
+#include <stdio.h>
+
+/*
+ * We can't test C++ in unit tests, and we can't change the safety check failure
+ * hook in integration tests.  So we check that we *actually* abort on failure,
+ * by forking and checking the child process exit code.
+ */
+
+/* It's a unix system? */
+#ifdef __unix__
+/* I know this! */
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/wait.h>
+static const bool can_fork = true;
+#else
+static const bool can_fork = false;
+#endif
+
+#include "test/jemalloc_test.h"
+
+TEST_BEGIN(test_failing_alloc) {
+	test_skip_if(!can_fork);
+#ifdef __unix__
+	pid_t pid = fork();
+	expect_d_ne(pid, -1, "Unexpected fork failure");
+	if (pid == 0) {
+		/*
+		 * In the child, we'll print an error message to stderr before
+		 * exiting.  Close stderr to avoid spamming output for this
+		 * expected failure.
+		 */
+		fclose(stderr);
+		try {
+			/* Too big of an allocation to succeed. */
+			void *volatile ptr = ::operator new((size_t)-1);
+			(void)ptr;
+		} catch (...) {
+			/*
+			 * Swallow the exception; remember, we expect this to
+			 * fail via an abort within new, not because an
+			 * exception didn't get caught.
+			 */
+		}
+	} else {
+		int status;
+		pid_t err = waitpid(pid, &status, 0);
+		expect_d_ne(-1, err, "waitpid failure");
+		expect_false(WIFEXITED(status),
+		    "Should have seen an abnormal failure");
+	}
+#endif
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_failing_alloc);
+}
+

--- a/test/integration/cpp/infallible_new_true.sh
+++ b/test/integration/cpp/infallible_new_true.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+XMALLOC_STR=""
+if [ "x${enable_xmalloc}" = "x1" ] ; then
+  XMALLOC_STR="xmalloc:false,"
+fi
+
+export MALLOC_CONF="${XMALLOC_STR}experimental_infallible_new:true"


### PR DESCRIPTION
This allows a guarantee that operator new never throws, without the heavyweight option of turning on xmalloc.

Fix the .gitignore rules to include test/integration/cpp while we're here.