### PR TITLE
Remove unless function prof_dump_ctl

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -3175,29 +3175,6 @@ label_return:
 }
 
 static int
-prof_dump_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
-    void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
-	int ret;
-	const char *filename = NULL;
-
-	if (!config_prof) {
-		return ENOENT;
-	}
-
-	WRITEONLY();
-	WRITE(filename, const char *);
-
-	if (prof_mdump(tsd, filename)) {
-		ret = EFAULT;
-		goto label_return;
-	}
-
-	ret = 0;
-label_return:
-	return ret;
-}
-
-static int
 prof_gdump_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
 	int ret;


### PR DESCRIPTION
`prof_dump_ctl` is a static function, it seems that no one in src/ctl.c use it.

And it seems that`prof_dump_ctl` is the only caller of `prof_mdump`, should we delete it too?