### PR TITLE
Mutex: Tweak internal spin count.

### DIFF
--- a/src/mutex.c
+++ b/src/mutex.c
@@ -13,7 +13,7 @@
  * Based on benchmark results, a fixed spin with this amount of retries works
  * well for our critical sections.
  */
-int64_t opt_mutex_max_spin = 250;
+int64_t opt_mutex_max_spin = 600;
 
 /******************************************************************************/
 /* Data. */


### PR DESCRIPTION
The recent pairing heap optimizations flattened the lock hold time profile.
This was a win for raw cycle counts, but ended up causing us to "just miss"
acquiring the mutex before sleeping more often.  Bump those counts.