### PR TITLE
Add Cirrus CI testing matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,30 @@ env:
   ARCH: amd64
 
 task:
+  matrix:
+      env:
+        DEBUG_CONFIG: --enable-debug
+      env:
+        DEBUG_CONFIG: --disable-debug
+  matrix:
+    - env:
+        PROF_CONFIG: --enable-prof
+    - env:
+        PROF_CONFIG: --disable-prof
+  matrix:
+    - name: 64-bit
+      env:
+        CC:
+        CXX:
+    - name: 32-bit
+      env:
+        CC: cc -m32
+        CXX: c++ -m32
+  matrix:
+    - env:
+        UNCOMMON_CONFIG:
+    - env:
+        UNCOMMON_CONFIG: --with-lg-page=16 --with-malloc-conf=tcache:false
   freebsd_instance:
     matrix:
       image: freebsd-12-2-release-amd64
@@ -12,11 +36,10 @@ task:
     - pkg install -y autoconf gmake
   script:
     - autoconf
-    #- ./configure ${COMPILER_FLAGS:+       CC="$CC $COMPILER_FLAGS"       CXX="$CXX $COMPILER_FLAGS" }       $CONFIGURE_FLAGS
     # We don't perfectly track freebsd stdlib.h definitions.  This is fine when
     # we count as a system header, but breaks otherwise, like during these
     # tests.
-    - ./configure --with-jemalloc-prefix=ci_
+    - ./configure --with-jemalloc-prefix=ci_ ${DEBUG_CONFIG} ${PROF_CONFIG} ${UNCOMMON_CONFIG}
     - export JFLAG=`sysctl -n kern.smp.cpus`
     - gmake -j${JFLAG}
     - gmake -j${JFLAG} tests


### PR DESCRIPTION
Contains 16 testing configs -- a mix of debug, prof, -m32 plus a few uncommon options.

This helps our FreeBSD coverage.