### PR TITLE
Makefile.in: make sure doc generated before install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -582,14 +582,14 @@ install_lib: install_lib_static
 endif
 install_lib: install_lib_pc
 
-install_doc_html:
+install_doc_html: build_doc_html
 	$(INSTALL) -d $(DATADIR)/doc/jemalloc$(install_suffix)
 	@for d in $(DOCS_HTML); do \
 	echo "$(INSTALL) -m 644 $$d $(DATADIR)/doc/jemalloc$(install_suffix)"; \
 	$(INSTALL) -m 644 $$d $(DATADIR)/doc/jemalloc$(install_suffix); \
 done
 
-install_doc_man:
+install_doc_man: build_doc_man
 	$(INSTALL) -d $(MANDIR)/man3
 	@for d in $(DOCS_MAN3); do \
 	echo "$(INSTALL) -m 644 $$d $(MANDIR)/man3"; \


### PR DESCRIPTION
There is a race between the doc generation and the doc installation,
so make the install depend on the build for doc to fix the error occurs
sometimes as below:
 | TOPDIR/tmp-glibc/hosttools/install: cannot stat 'doc/jemalloc.3': No such file or directory
 | make: *** [Makefile:513: install_doc_man] Error 1

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>