### PR TITLE
Rename prof.dump_prefix to prof.prefix

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1410,8 +1410,7 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         primarily useful for disabling the automatic final heap dump (which
         also disables leak reporting, if enabled).  The default prefix is
         <filename>jeprof</filename>.  This prefix value can be overriden by
-        <link
-        linkend="prof.dump_prefix"><mallctl>prof.dump_prefix</mallctl></link>.
+        <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>.
         </para></listitem>
       </varlistentry>
 
@@ -1492,8 +1491,7 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         where <literal>&lt;prefix&gt;</literal> is controlled by the
         <link
         linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link> and
-        <link
-        linkend="prof.dump_prefix"><mallctl>prof.dump_prefix</mallctl></link>
+        <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
         options.  By default, interval-triggered profile dumping is disabled
         (encoded as -1).
         </para></listitem>
@@ -1527,8 +1525,7 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         <filename>&lt;prefix&gt;.&lt;pid&gt;.&lt;seq&gt;.f.heap</filename>,
         where <literal>&lt;prefix&gt;</literal> is controlled by the <link
         linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link> and
-        <link
-        linkend="prof.dump_prefix"><mallctl>prof.dump_prefix</mallctl></link>
+        <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
         options.  Note that <function>atexit()</function> may allocate
         memory during application initialization and then deadlock internally
         when jemalloc in turn calls <function>atexit()</function>, so
@@ -2398,16 +2395,14 @@ struct extent_hooks_s {
         is specified, to a file according to the pattern
         <filename>&lt;prefix&gt;.&lt;pid&gt;.&lt;seq&gt;.m&lt;mseq&gt;.heap</filename>,
         where <literal>&lt;prefix&gt;</literal> is controlled by the
-        <link
-        linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link> and
-        <link
-        linkend="prof.dump_prefix"><mallctl>prof.dump_prefix</mallctl></link>
+        <link linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link>
+        and <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
         options.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="prof.dump_prefix">
+      <varlistentry id="prof.prefix">
         <term>
-          <mallctl>prof.dump_prefix</mallctl>
+          <mallctl>prof.prefix</mallctl>
           (<type>const char *</type>)
           <literal>-w</literal>
           [<option>--enable-prof</option>]
@@ -2433,8 +2428,7 @@ struct extent_hooks_s {
         <filename>&lt;prefix&gt;.&lt;pid&gt;.&lt;seq&gt;.u&lt;useq&gt;.heap</filename>,
         where <literal>&lt;prefix&gt;</literal> is controlled by the <link
         linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link> and
-        <link
-        linkend="prof.dump_prefix"><mallctl>prof.dump_prefix</mallctl></link>
+        <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
         options.</para></listitem>
       </varlistentry>
 

--- a/include/jemalloc/internal/prof_sys.h
+++ b/include/jemalloc/internal/prof_sys.h
@@ -10,7 +10,7 @@ void prof_unwind_init();
 void prof_sys_thread_name_fetch(tsd_t *tsd);
 int prof_getpid(void);
 void prof_get_default_filename(tsdn_t *tsdn, char *filename, uint64_t ind);
-bool prof_dump_prefix_set(tsdn_t *tsdn, const char *prefix);
+bool prof_prefix_set(tsdn_t *tsdn, const char *prefix);
 void prof_fdump_impl(tsd_t *tsd);
 void prof_idump_impl(tsd_t *tsd);
 bool prof_mdump_impl(tsd_t *tsd, const char *filename);

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -187,7 +187,7 @@ CTL_PROTO(prof_thread_active_init)
 CTL_PROTO(prof_active)
 CTL_PROTO(prof_dump)
 CTL_PROTO(prof_gdump)
-CTL_PROTO(prof_dump_prefix)
+CTL_PROTO(prof_prefix)
 CTL_PROTO(prof_reset)
 CTL_PROTO(prof_interval)
 CTL_PROTO(lg_prof_sample)
@@ -578,7 +578,7 @@ static const ctl_named_node_t	prof_node[] = {
 	{NAME("active"),	CTL(prof_active)},
 	{NAME("dump"),		CTL(prof_dump)},
 	{NAME("gdump"),		CTL(prof_gdump)},
-	{NAME("dump_prefix"),	CTL(prof_dump_prefix)},
+	{NAME("prefix"),	CTL(prof_prefix)},
 	{NAME("reset"),		CTL(prof_reset)},
 	{NAME("interval"),	CTL(prof_interval)},
 	{NAME("lg_sample"),	CTL(lg_prof_sample)},
@@ -3227,7 +3227,7 @@ label_return:
 }
 
 static int
-prof_dump_prefix_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
+prof_prefix_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
 	int ret;
 	const char *prefix = NULL;
@@ -3240,7 +3240,7 @@ prof_dump_prefix_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 	WRITEONLY();
 	WRITE(prefix, const char *);
 
-	ret = prof_dump_prefix_set(tsd_tsdn(tsd), prefix) ? EFAULT : 0;
+	ret = prof_prefix_set(tsd_tsdn(tsd), prefix) ? EFAULT : 0;
 label_return:
 	malloc_mutex_unlock(tsd_tsdn(tsd), &ctl_mtx);
 	return ret;

--- a/test/unit/prof_idump.c
+++ b/test/unit/prof_idump.c
@@ -26,14 +26,14 @@ TEST_BEGIN(test_idump) {
 	bool active;
 	void *p;
 
-	const char *dump_prefix = TEST_PREFIX;
+	const char *prefix = TEST_PREFIX;
 
 	test_skip_if(!config_prof);
 
 	active = true;
 
-	expect_d_eq(mallctl("prof.dump_prefix", NULL, NULL,
-	    (void *)&dump_prefix, sizeof(dump_prefix)), 0,
+	expect_d_eq(mallctl("prof.prefix", NULL, NULL, (void *)&prefix,
+	    sizeof(prefix)), 0,
 	    "Unexpected mallctl failure while overwriting dump prefix");
 
 	expect_d_eq(mallctl("prof.active", NULL, NULL, (void *)&active,


### PR DESCRIPTION
This better aligns with our naming convention.  The option has not been included
in any upstream release yet.