### PR TITLE
Fix warnings when compiled with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,7 @@ if test "x$GCC" = "xyes" ; then
       AC_DEFINE_UNQUOTED([JEMALLOC_HAS_RESTRICT])
     fi
   fi
+  JE_CFLAGS_ADD([-Werror=unknown-warning-option])
   JE_CFLAGS_ADD([-Wall])
   JE_CFLAGS_ADD([-Wextra])
   JE_CFLAGS_ADD([-Wshorten-64-to-32])


### PR DESCRIPTION
When clang sees an unknown warning option, unlike gcc it doesn't fail the build
with error. It issues a warning. Hence JE_CFLAGS_ADD with warning options that
didnt't exist in clang would still mark those options as available. This led to
several warnings when built with clang or "gcc" on OSX. This change fixes those
warnings by simply making clang fail builds with non-existent warning options.