### PR TITLE
HPA: Correctly calculate retained pages

### DIFF
--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -292,7 +292,7 @@ hpdata_ndirty_get(hpdata_t *hpdata) {
 
 static inline size_t
 hpdata_nretained_get(hpdata_t *hpdata) {
-	return hpdata->h_nactive - hpdata->h_ntouched;
+	return HUGEPAGE_PAGES - hpdata->h_ntouched;
 }
 
 static inline void


### PR DESCRIPTION
Retained pages are those which haven't been touched and are unbacked from OS
perspective. For a pageslab their number should equal "total pages in slab"
minus "touched pages".