### PR TITLE
add experimental.arenas_create_ext mallctl

### DIFF
--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -91,7 +91,7 @@ bool arena_retain_grow_limit_get_set(tsd_t *tsd, arena_t *arena,
 unsigned arena_nthreads_get(arena_t *arena, bool internal);
 void arena_nthreads_inc(arena_t *arena, bool internal);
 void arena_nthreads_dec(arena_t *arena, bool internal);
-arena_t *arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+arena_t *arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config);
 bool arena_init_huge(void);
 bool arena_is_huge(unsigned arena_ind);
 arena_t *arena_choose_huge(tsd_t *tsd);

--- a/include/jemalloc/internal/arena_types.h
+++ b/include/jemalloc/internal/arena_types.h
@@ -41,4 +41,18 @@ typedef enum {
  */
 #define OVERSIZE_THRESHOLD_DEFAULT (8 << 20)
 
+struct arena_config_s {
+	/* extent hooks to be used for the arena */
+	struct extent_hooks_s *extent_hooks;
+
+	/*
+	 * Use extent hooks for metadata (base) allocations when true.
+	 */
+	bool metadata_use_hooks;
+};
+
+typedef struct arena_config_s arena_config_t;
+
+extern const arena_config_t arena_config_default;
+
 #endif /* JEMALLOC_INTERNAL_ARENA_TYPES_H */

--- a/include/jemalloc/internal/base.h
+++ b/include/jemalloc/internal/base.h
@@ -46,6 +46,11 @@ struct base_s {
 	 */
 	ehooks_t ehooks;
 
+	/*
+	 * Use user hooks for metadata when true.
+	 */
+	bool metadata_use_hooks;
+
 	/* Protects base_alloc() and base_stats_get() operations. */
 	malloc_mutex_t mtx;
 
@@ -87,7 +92,7 @@ metadata_thp_enabled(void) {
 
 base_t *b0get(void);
 base_t *base_new(tsdn_t *tsdn, unsigned ind,
-    const extent_hooks_t *extent_hooks);
+    const extent_hooks_t *extent_hooks, bool metadata_use_hooks);
 void base_delete(tsdn_t *tsdn, base_t *base);
 ehooks_t *base_ehooks_get(base_t *base);
 extent_hooks_t *base_extent_hooks_set(base_t *base,

--- a/include/jemalloc/internal/base_structs.h
+++ b/include/jemalloc/internal/base_structs.h
@@ -25,6 +25,11 @@ struct base_s {
 	 */
 	ehooks_t ehooks;
 
+	/*
+	 * Use user hooks for metadata when true.
+	 */
+	bool metadata_use_hooks;
+
 	/* Protects base_alloc() and base_stats_get() operations. */
 	malloc_mutex_t mtx;
 

--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -57,7 +57,7 @@ void *bootstrap_calloc(size_t num, size_t size);
 void bootstrap_free(void *ptr);
 void arena_set(unsigned ind, arena_t *arena);
 unsigned narenas_total_get(void);
-arena_t *arena_init(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+arena_t *arena_init(tsdn_t *tsdn, unsigned ind, const arena_config_t *config);
 arena_t *arena_choose_hard(tsd_t *tsd, bool internal);
 void arena_migrate(tsd_t *tsd, unsigned oldind, unsigned newind);
 void iarena_cleanup(tsd_t *tsd);

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -66,7 +66,7 @@ arena_get(tsdn_t *tsdn, unsigned ind, bool init_if_missing) {
 	if (unlikely(ret == NULL)) {
 		if (init_if_missing) {
 			ret = arena_init(tsdn, ind,
-			    (extent_hooks_t *)&ehooks_default_extent_hooks);
+			    &arena_config_default);
 		}
 	}
 	return ret;

--- a/src/arena.c
+++ b/src/arena.c
@@ -55,6 +55,11 @@ static unsigned nbins_total;
 
 static unsigned huge_arena_ind;
 
+const arena_config_t arena_config_default = {
+	/* .extent_hooks = */ (extent_hooks_t *)&ehooks_default_extent_hooks,
+	/* .metadata_use_hooks = */ true,
+};
+
 /******************************************************************************/
 /*
  * Function prototypes for static functions that are referenced prior to
@@ -1427,7 +1432,6 @@ arena_set_extent_hooks(tsd_t *tsd, arena_t *arena,
 	return ret;
 }
 
-
 dss_prec_t
 arena_dss_prec_get(arena_t *arena) {
 	return (dss_prec_t)atomic_load_u(&arena->dss_prec, ATOMIC_ACQUIRE);
@@ -1494,7 +1498,7 @@ arena_nthreads_dec(arena_t *arena, bool internal) {
 }
 
 arena_t *
-arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
+arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config) {
 	arena_t *arena;
 	base_t *base;
 	unsigned i;
@@ -1502,7 +1506,8 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	if (ind == 0) {
 		base = b0get();
 	} else {
-		base = base_new(tsdn, ind, extent_hooks);
+		base = base_new(tsdn, ind, config->extent_hooks,
+		    config->metadata_use_hooks);
 		if (base == NULL) {
 			return NULL;
 		}

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -313,6 +313,7 @@ INDEX_PROTO(experimental_arenas_i)
 CTL_PROTO(experimental_prof_recent_alloc_max)
 CTL_PROTO(experimental_prof_recent_alloc_dump)
 CTL_PROTO(experimental_batch_alloc)
+CTL_PROTO(experimental_arenas_create_ext)
 
 #define MUTEX_STATS_CTL_PROTO_GEN(n)					\
 CTL_PROTO(stats_##n##_num_ops)						\
@@ -867,6 +868,7 @@ static const ctl_named_node_t experimental_node[] = {
 	{NAME("hooks"),		CHILD(named, experimental_hooks)},
 	{NAME("utilization"),	CHILD(named, experimental_utilization)},
 	{NAME("arenas"),	CHILD(indexed, experimental_arenas)},
+	{NAME("arenas_create_ext"),	CTL(experimental_arenas_create_ext)},
 	{NAME("prof_recent"),	CHILD(named, experimental_prof_recent)},
 	{NAME("batch_alloc"),	CTL(experimental_batch_alloc)},
 	{NAME("thread"),	CHILD(named, experimental_thread)}
@@ -1239,7 +1241,7 @@ ctl_arena_refresh(tsdn_t *tsdn, arena_t *arena, ctl_arena_t *ctl_sdarena,
 }
 
 static unsigned
-ctl_arena_init(tsd_t *tsd, extent_hooks_t *extent_hooks) {
+ctl_arena_init(tsd_t *tsd, const arena_config_t *config) {
 	unsigned arena_ind;
 	ctl_arena_t *ctl_arena;
 
@@ -1257,7 +1259,7 @@ ctl_arena_init(tsd_t *tsd, extent_hooks_t *extent_hooks) {
 	}
 
 	/* Initialize new arena. */
-	if (arena_init(tsd_tsdn(tsd), arena_ind, extent_hooks) == NULL) {
+	if (arena_init(tsd_tsdn(tsd), arena_ind, config) == NULL) {
 		return UINT_MAX;
 	}
 
@@ -2874,8 +2876,11 @@ arena_i_extent_hooks_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 				extent_hooks_t *new_extent_hooks
 				    JEMALLOC_CC_SILENCE_INIT(NULL);
 				WRITE(new_extent_hooks, extent_hooks_t *);
+				arena_config_t config = arena_config_default;
+				config.extent_hooks = new_extent_hooks;
+
 				arena = arena_init(tsd_tsdn(tsd), arena_ind,
-				    new_extent_hooks);
+				    &config);
 				if (arena == NULL) {
 					ret = EFAULT;
 					goto label_return;
@@ -3062,20 +3067,43 @@ static int
 arenas_create_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
 	int ret;
-	extent_hooks_t *extent_hooks;
 	unsigned arena_ind;
 
 	malloc_mutex_lock(tsd_tsdn(tsd), &ctl_mtx);
 
 	VERIFY_READ(unsigned);
-	extent_hooks = (extent_hooks_t *)&ehooks_default_extent_hooks;
-	WRITE(extent_hooks, extent_hooks_t *);
-	if ((arena_ind = ctl_arena_init(tsd, extent_hooks)) == UINT_MAX) {
+	arena_config_t config = arena_config_default;
+	WRITE(config.extent_hooks, extent_hooks_t *);
+	if ((arena_ind = ctl_arena_init(tsd, &config)) == UINT_MAX) {
 		ret = EAGAIN;
 		goto label_return;
 	}
 	READ(arena_ind, unsigned);
 
+	ret = 0;
+label_return:
+	malloc_mutex_unlock(tsd_tsdn(tsd), &ctl_mtx);
+	return ret;
+}
+
+static int
+experimental_arenas_create_ext_ctl(tsd_t *tsd,
+    const size_t *mib, size_t miblen,
+    void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
+	int ret;
+	unsigned arena_ind;
+
+	malloc_mutex_lock(tsd_tsdn(tsd), &ctl_mtx);
+
+	arena_config_t config = arena_config_default;
+	VERIFY_READ(unsigned);
+	WRITE(config, arena_config_t);
+
+	if ((arena_ind = ctl_arena_init(tsd, &config)) == UINT_MAX) {
+		ret = EAGAIN;
+		goto label_return;
+	}
+	READ(arena_ind, unsigned);
 	ret = 0;
 label_return:
 	malloc_mutex_unlock(tsd_tsdn(tsd), &ctl_mtx);

--- a/test/unit/base.c
+++ b/test/unit/base.c
@@ -32,7 +32,8 @@ TEST_BEGIN(test_base_hooks_default) {
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	base = base_new(tsdn, 0,
-	    (extent_hooks_t *)&ehooks_default_extent_hooks);
+	    (extent_hooks_t *)&ehooks_default_extent_hooks,
+	    /* metadata_use_hooks */ true);
 
 	if (config_stats) {
 		base_stats_get(tsdn, base, &allocated0, &resident, &mapped,
@@ -74,7 +75,7 @@ TEST_BEGIN(test_base_hooks_null) {
 	memcpy(&hooks, &hooks_null, sizeof(extent_hooks_t));
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
-	base = base_new(tsdn, 0, &hooks);
+	base = base_new(tsdn, 0, &hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new() failure");
 
 	if (config_stats) {
@@ -120,7 +121,7 @@ TEST_BEGIN(test_base_hooks_not_null) {
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	did_alloc = false;
-	base = base_new(tsdn, 0, &hooks);
+	base = base_new(tsdn, 0, &hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new() failure");
 	expect_true(did_alloc, "Expected alloc");
 

--- a/test/unit/edata_cache.c
+++ b/test/unit/edata_cache.c
@@ -5,7 +5,7 @@
 static void
 test_edata_cache_init(edata_cache_t *edata_cache) {
 	base_t *base = base_new(TSDN_NULL, /* ind */ 1,
-	    &ehooks_default_extent_hooks);
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	assert_ptr_not_null(base, "");
 	bool err = edata_cache_init(edata_cache, base);
 	assert_false(err, "");

--- a/test/unit/hpa.c
+++ b/test/unit/hpa.c
@@ -37,7 +37,7 @@ static hpa_shard_t *
 create_test_data(hpa_hooks_t *hooks, hpa_shard_opts_t *opts) {
 	bool err;
 	base_t *base = base_new(TSDN_NULL, /* ind */ SHARD_IND,
-	    &ehooks_default_extent_hooks);
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	assert_ptr_not_null(base, "");
 
 	test_data_t *test_data = malloc(sizeof(test_data_t));

--- a/test/unit/pa.c
+++ b/test/unit/pa.c
@@ -53,7 +53,8 @@ test_data_t *init_test_data(ssize_t dirty_decay_ms, ssize_t muzzy_decay_ms) {
 	assert_ptr_not_null(test_data, "");
 	init_test_extent_hooks(&test_data->hooks);
 
-	base_t *base = base_new(TSDN_NULL, /* ind */ 1, &test_data->hooks);
+	base_t *base = base_new(TSDN_NULL, /* ind */ 1,
+	    &test_data->hooks, /* metadata_use_hooks */ true);
 	assert_ptr_not_null(base, "");
 
 	test_data->base = base;

--- a/test/unit/rtree.c
+++ b/test/unit/rtree.c
@@ -12,7 +12,8 @@ TEST_BEGIN(test_rtree_read_empty) {
 
 	tsdn = tsdn_fetch();
 
-	base_t *base = base_new(tsdn, 0, &ehooks_default_extent_hooks);
+	base_t *base = base_new(tsdn, 0,
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new failure");
 
 	rtree_t *rtree = &test_rtree;
@@ -52,7 +53,8 @@ TEST_BEGIN(test_rtree_extrema) {
 
 	tsdn_t *tsdn = tsdn_fetch();
 
-	base_t *base = base_new(tsdn, 0, &ehooks_default_extent_hooks);
+	base_t *base = base_new(tsdn, 0,
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new failure");
 
 	rtree_t *rtree = &test_rtree;
@@ -103,7 +105,8 @@ TEST_END
 
 TEST_BEGIN(test_rtree_bits) {
 	tsdn_t *tsdn = tsdn_fetch();
-	base_t *base = base_new(tsdn, 0, &ehooks_default_extent_hooks);
+	base_t *base = base_new(tsdn, 0,
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new failure");
 
 	uintptr_t keys[] = {PAGE, PAGE + 1,
@@ -152,7 +155,8 @@ TEST_BEGIN(test_rtree_random) {
 	sfmt_t *sfmt = init_gen_rand(SEED);
 	tsdn_t *tsdn = tsdn_fetch();
 
-	base_t *base = base_new(tsdn, 0, &ehooks_default_extent_hooks);
+	base_t *base = base_new(tsdn, 0,
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new failure");
 
 	uintptr_t keys[NSET];
@@ -250,7 +254,8 @@ test_rtree_range_write(tsdn_t *tsdn, rtree_t *rtree, uintptr_t start,
 
 TEST_BEGIN(test_rtree_range) {
 	tsdn_t *tsdn = tsdn_fetch();
-	base_t *base = base_new(tsdn, 0, &ehooks_default_extent_hooks);
+	base_t *base = base_new(tsdn, 0,
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 	expect_ptr_not_null(base, "Unexpected base_new failure");
 
 	rtree_t *rtree = &test_rtree;

--- a/test/unit/sec.c
+++ b/test/unit/sec.c
@@ -42,7 +42,7 @@ test_sec_init(sec_t *sec, pai_t *fallback, size_t nshards, size_t max_alloc,
 	 * short-running, and SECs are arena-scoped in reality.
 	 */
 	base_t *base = base_new(TSDN_NULL, /* ind */ 123,
-	    &ehooks_default_extent_hooks);
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 
 	bool err = sec_init(TSDN_NULL, sec, base, fallback, &opts);
 	assert_false(err, "Unexpected initialization failure");
@@ -420,7 +420,7 @@ TEST_BEGIN(test_nshards_0) {
 	/* See the note above -- we can't use the real tsd. */
 	tsdn_t *tsdn = TSDN_NULL;
 	base_t *base = base_new(TSDN_NULL, /* ind */ 123,
-	    &ehooks_default_extent_hooks);
+	    &ehooks_default_extent_hooks, /* metadata_use_hooks */ true);
 
 	sec_opts_t opts = SEC_OPTS_DEFAULT;
 	opts.nshards = 0;


### PR DESCRIPTION
This mallctl accepts an arena_config_t structure which
can be used to customize the behavior of the arena.
Right now it contains extent_hooks and a new option,
metadata_use_hooks, which controls whether the extent
hooks are also used for metadata allocation.

The medata_use_hooks option has two main use cases:

1. In heterogeneous memory systems, to avoid metadata
being placed on potentially slower memory.

2. Avoiding virtual memory from being leaked as a result
of metadata allocation failure originating in an extent hook.

Closes #2095 

---
This is more of an RFC than anything else. I'm not entirely sure if adding this option is the right thing to do to solve the underlying problem. We want to use jemalloc extent hooks to allocate from a file-based DAX* mapping, which initially appeared to be working just fine. Still, we found physically deallocating pages to be very expensive. This is expected because deallocation has to punch a hole in the file and deallocate the underlying file system extent. So we've tried to avoid deallocating pages in the hooks implementation, but this led to runaway problems with virtual address space leaks in near OOM conditions (abandoned_vm) - which we then traced back to jemalloc's inability to allocate additional metadata when splitting extents. These address space leaks (from `extents_abandon_vm` function) are especially problematic for this type of file-based mapping because they only call the purge hooks (to avoid leaking physical space), which are difficult to implement differently than through `madvise(..., MADV_REMOVE)` which again has to punch a hole in the file...
Avoiding the use of hooks for internal metadata made it so that address space isn't leaked unless the OS runs out of main memory. And, as a nice bonus, using main memory (which is very likely the lowest-latency memory in a system) for metadata is ought to have a positive impact on overall system performance. 

I'm also not confident about the API - I considered multiple different solutions like adding a "use_for_metadata" to the extent hooks structure or adding a flag indicating metadata allocation to alloc/dealloc hook functions, but this would not be backward-compatible. I also briefly considered adding a global option, but configuring this on a per-arena basis is useful.
Instead, I added a single independent arena option that users can set after configuring the extent hooks. This is fully backward-compatible and unintrusive. The downside is that some base allocations might happen using the hooks when an arena is first created with the extent hooks defined - but the reverse is already the case when *not* providing the extent hooks during arena creation (from `arena.<i>.extent_hooks ` docs: `The functions must be capable of operating on all extant extents associated with arena <i>, usually by passing unknown extents to the replaced functions`), so I'm not sure if this is a problem.

\* DAX - direct access, this is used to "directly access" heterogeneous memory on Linux