### PR TITLE
Redefine functions with test hooks only for tests

### DIFF
--- a/include/jemalloc/internal/test_hooks.h
+++ b/include/jemalloc/internal/test_hooks.h
@@ -4,16 +4,21 @@
 extern JEMALLOC_EXPORT void (*test_hooks_arena_new_hook)();
 extern JEMALLOC_EXPORT void (*test_hooks_libc_hook)();
 
-#define JEMALLOC_HOOK(fn, hook) ((void)(hook != NULL && (hook(), 0)), fn)
+#if defined(JEMALLOC_JET) || defined(JEMALLOC_UNIT_TEST)
+#  define JEMALLOC_TEST_HOOK(fn, hook) ((void)(hook != NULL && (hook(), 0)), fn)
 
-#define open JEMALLOC_HOOK(open, test_hooks_libc_hook)
-#define read JEMALLOC_HOOK(read, test_hooks_libc_hook)
-#define write JEMALLOC_HOOK(write, test_hooks_libc_hook)
-#define readlink JEMALLOC_HOOK(readlink, test_hooks_libc_hook)
-#define close JEMALLOC_HOOK(close, test_hooks_libc_hook)
-#define creat JEMALLOC_HOOK(creat, test_hooks_libc_hook)
-#define secure_getenv JEMALLOC_HOOK(secure_getenv, test_hooks_libc_hook)
+#  define open JEMALLOC_TEST_HOOK(open, test_hooks_libc_hook)
+#  define read JEMALLOC_TEST_HOOK(read, test_hooks_libc_hook)
+#  define write JEMALLOC_TEST_HOOK(write, test_hooks_libc_hook)
+#  define readlink JEMALLOC_TEST_HOOK(readlink, test_hooks_libc_hook)
+#  define close JEMALLOC_TEST_HOOK(close, test_hooks_libc_hook)
+#  define creat JEMALLOC_TEST_HOOK(creat, test_hooks_libc_hook)
+#  define secure_getenv JEMALLOC_TEST_HOOK(secure_getenv, test_hooks_libc_hook)
 /* Note that this is undef'd and re-define'd in src/prof.c. */
-#define _Unwind_Backtrace JEMALLOC_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
+#  define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
+#else
+#  define JEMALLOC_TEST_HOOK(fn, hook) fn
+#endif
+
 
 #endif /* JEMALLOC_INTERNAL_TEST_HOOKS_H */

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -20,7 +20,7 @@
  */
 #undef _Unwind_Backtrace
 #include <unwind.h>
-#define _Unwind_Backtrace JEMALLOC_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
+#define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
 #endif
 
 /******************************************************************************/

--- a/test/unit/test_hooks.c
+++ b/test/unit/test_hooks.c
@@ -12,7 +12,7 @@ func_to_hook(int arg1, int arg2) {
 	return arg1 + arg2;
 }
 
-#define func_to_hook JEMALLOC_HOOK(func_to_hook, test_hooks_libc_hook)
+#define func_to_hook JEMALLOC_TEST_HOOK(func_to_hook, test_hooks_libc_hook)
 
 TEST_BEGIN(unhooked_call) {
 	test_hooks_libc_hook = NULL;


### PR DESCRIPTION
Android build has issues with these defines, this will allow the build to
succeed if it doesn't need to build the tests.