### PR TITLE
Moved debug_config check outside of the loop

### DIFF
--- a/src/hpa.c
+++ b/src/hpa.c
@@ -740,7 +740,9 @@ hpa_alloc_batch(tsdn_t *tsdn, pai_t *self, size_t size, size_t nallocs,
 			assert(edata_pai_get(edata) == EXTENT_PAI_HPA);
 			assert(edata_state_get(edata) == extent_state_active);
 			assert(edata_arena_ind_get(edata) == shard->ind);
-			assert(edata_szind_get_maybe_invalid(edata) == SC_NSIZES);
+			assert(
+				edata_szind_get_maybe_invalid(edata) ==
+				SC_NSIZES);
 			assert(!edata_slab_get(edata));
 			assert(edata_committed_get(edata));
 			assert(edata_base_get(edata) == edata_addr_get(edata));

--- a/src/hpa.c
+++ b/src/hpa.c
@@ -733,17 +733,19 @@ hpa_alloc_batch(tsdn_t *tsdn, pai_t *self, size_t size, size_t nallocs,
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	edata_t *edata;
-	ql_foreach(edata, &results->head, ql_link_active) {
-		emap_assert_mapped(tsdn, shard->emap, edata);
-		assert(edata_pai_get(edata) == EXTENT_PAI_HPA);
-		assert(edata_state_get(edata) == extent_state_active);
-		assert(edata_arena_ind_get(edata) == shard->ind);
-		assert(edata_szind_get_maybe_invalid(edata) == SC_NSIZES);
-		assert(!edata_slab_get(edata));
-		assert(edata_committed_get(edata));
-		assert(edata_base_get(edata) == edata_addr_get(edata));
-		assert(edata_base_get(edata) != NULL);
+	if (config_debug)	{
+		edata_t *edata;
+		ql_foreach(edata, &results->head, ql_link_active) {
+			emap_assert_mapped(tsdn, shard->emap, edata);
+			assert(edata_pai_get(edata) == EXTENT_PAI_HPA);
+			assert(edata_state_get(edata) == extent_state_active);
+			assert(edata_arena_ind_get(edata) == shard->ind);
+			assert(edata_szind_get_maybe_invalid(edata) == SC_NSIZES);
+			assert(!edata_slab_get(edata));
+			assert(edata_committed_get(edata));
+			assert(edata_base_get(edata) == edata_addr_get(edata));
+			assert(edata_base_get(edata) != NULL);
+		}
 	}
 	return nsuccess;
 }


### PR DESCRIPTION
Moved `debug_check` outside of the loop so that the whole loop can be optimized out when `debug_check==false`.

Here is what the asm looks like before the change - the loop traverses through the list
`   0000000000000410 <_hpa_alloc_batch>:

     5c0: 48 8b 52 28                       mov	rdx, qword ptr [rdx + 40]
     5c4: 48 39 c2                     	cmp	rdx, rax
     5c7: 48 0f 44 d1                  	cmove	rdx, rcx
     5cb: 48 85 d2                     	test	rdx, rdx
     5ce: 75 f0                        	        jne	0x5c0 <_hpa_alloc_batch+0x1b0>
`

After the change this code is complete gone.