### PR TITLE
Optimize away a branch on the free fastpath.

### DIFF
--- a/include/jemalloc/internal/rtree.h
+++ b/include/jemalloc/internal/rtree.h
@@ -330,28 +330,27 @@ rtree_leaf_elm_state_update(tsdn_t *tsdn, rtree_t *rtree,
 }
 
 /*
- * Tries to look up the key in the L1 cache, returning it if there's a hit, or
- * NULL if there's a miss.
- * Key is allowed to be NULL; returns NULL in this case.
+ * Tries to look up the key in the L1 cache, returning false if there's a hit, or
+ * true if there's a miss.
+ * Key is allowed to be NULL; returns true in this case.
  */
-JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
+JEMALLOC_ALWAYS_INLINE bool
 rtree_leaf_elm_lookup_fast(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    uintptr_t key) {
-	rtree_leaf_elm_t *elm;
-
+    uintptr_t key, rtree_leaf_elm_t **elm) {
 	size_t slot = rtree_cache_direct_map(key);
 	uintptr_t leafkey = rtree_leafkey(key);
 	assert(leafkey != RTREE_LEAFKEY_INVALID);
 
-	if (likely(rtree_ctx->cache[slot].leafkey == leafkey)) {
-		rtree_leaf_elm_t *leaf = rtree_ctx->cache[slot].leaf;
-		assert(leaf != NULL);
-		uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
-		elm = &leaf[subkey];
-		return elm;
-	} else {
-		return NULL;
+	if (unlikely(rtree_ctx->cache[slot].leafkey != leafkey)) {
+		return true;
 	}
+
+	rtree_leaf_elm_t *leaf = rtree_ctx->cache[slot].leaf;
+	assert(leaf != NULL);
+	uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
+	*elm = &leaf[subkey];
+
+	return false;
 }
 
 JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
@@ -449,16 +448,22 @@ rtree_metadata_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 }
 
 /*
- * Returns true on error.
+ * Returns true when the request cannot be fulfilled by fastpath.
  */
 static inline bool
 rtree_metadata_try_read_fast(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
     uintptr_t key, rtree_metadata_t *r_rtree_metadata) {
-	rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup_fast(tsdn, rtree, rtree_ctx,
-	    key);
-	if (elm == NULL) {
+	rtree_leaf_elm_t *elm;
+	/*
+	 * Should check the bool return value (lookup success or not) instead of
+	 * elm == NULL (which will result in an extra branch).  This is because
+	 * when the cache lookup succeeds, there will never be a NULL pointer
+	 * returned (which is unknown to the compiler).
+	 */
+	if (rtree_leaf_elm_lookup_fast(tsdn, rtree, rtree_ctx, key, &elm)) {
 		return true;
 	}
+	assert(elm != NULL);
 	*r_rtree_metadata = rtree_leaf_elm_read(tsdn, rtree, elm,
 	    /* dependent */ true).metadata;
 	return false;


### PR DESCRIPTION
On the rtree metadata lookup fast path, there will never be a NULL returned when
the cache key matches (which is unknown to the compiler).  The previous logic
was checking for NULL return value, resulting in the extra branch (in addition to
the cache key match checking).  Make the lookup_fast return a bool to indicate
cache miss / match, so that the extra branch is avoided.

Confirmed tha the branch in the middle below is removed -- between the key 
matching branch (at the beginning) and the is_slab checking (at the end).

       │    rtree_leaf_elm_lookup_fast():                                      
       │            if (likely(rtree_ctx->cache[slot].leafkey == leafkey)) {   
    0.18 │      and  $0xf0,%eax                                                  
    4.67 │      add  %rsi,%rax                                                   
       │      add  %rcx,%rax                                                   
    10.29 │      cmp  0x1b0(%rax),%rdx                                            
       │    . jne  b0                                                          
       │    rtree_subkey():                                                    
       │            return ((key >> shiftbits) & mask);                        
    0.01 │      mov  %rdi,%r8                                                    
    1.69 │      shr  $0x9,%r8                                                    
       │    rtree_leaf_elm_lookup_fast():                                      
       │                    rtree_leaf_elm_t *leaf = rtree_ctx->cache[slot].lea
       │                    assert(leaf != NULL);                              
       │                    uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1
       │                    elm = &leaf[subkey];                               
    0.02 │      and  $0x1ffff8,%r8d                                              
       │    rtree_metadata_try_read_fast():                                    
       │    static inline bool                                                 
       │    rtree_metadata_try_read_fast(tsdn_t *tsdn, rtree_t *rtree, rtree_ct
       │        uintptr_t key, rtree_metadata_t *r_rtree_metadata) {           
       │            rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup_fast(tsdn, rt
       │                key);                                                  
       │            if (elm == NULL) {                                         
    2.78 │      add  0x1b8(%rax),%r8                                             
       >>>>>>>>>>>>>>>>>>>>>>>          │    . je   b0            /* This branch removed */   
       │    atomic_load_p():                                                   
       │     */                                                                
       │    #if (LG_SIZEOF_PTR == 3 || LG_SIZEOF_INT == 3)                     
       │    #  define JEMALLOC_ATOMIC_U64                                      
       │    #endif                                                             
       │                                                                       
       │    JEMALLOC_GENERATE_ATOMICS(void *, p, LG_SIZEOF_PTR)                
    13.07 │      mov  (%r8),%r9                                                   
       │    rtree_leaf_elm_bits_decode():                                      
       │            contents.metadata.szind = bits >> LG_VADDR;                
    1.91 │      mov  %r9,%r10                                                    
    3.18 │      shr  $0x30,%r10                                                  
       │    free_fastpath():                                                   
       │            if (!size_hint) {                                          
       │                    bool err = emap_alloc_ctx_try_lookup_fast(tsd,     
       │                        &arena_emap_global, ptr, &alloc_ctx);          
       │                                                                       
       │                    /* Note: profiled objects will have alloc_ctx.slab 
       │                    if (unlikely(err || !alloc_ctx.slab)) {            
    0.09 │      and  $0x1,%r9d                                                   
       │    . je   b0                                                          
