### PR TITLE
San: Unguard guarded slabs during arena destruction

### DIFF
--- a/include/jemalloc/internal/guard.h
+++ b/include/jemalloc/internal/guard.h
@@ -14,7 +14,14 @@ extern size_t opt_san_guard_large;
 extern size_t opt_san_guard_small;
 
 void guard_pages(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata, emap_t *emap);
-void unguard_pages(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata, emap_t *emap);
+void unguard_pages(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
+    emap_t *emap);
+/*
+ * Unguard the extent, but don't modify emap boundaries. Must be called on an
+ * extent that has been erased from emap and shouldn't be placed back.
+ */
+void unguard_pages_pre_destroy(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
+    emap_t *emap);
 void tsd_san_init(tsd_t *tsd);
 
 static inline bool


### PR DESCRIPTION
When opt_retain is on, slab extents remain guarded in all states, even
retained. This works well if arena is never destroyed, because we
anticipate those slabs will be eventually reused. But if the arena is
destroyed, the slabs must be unguarded to prevent leaking guard pages.