### PR TITLE
Implement use-after-free detection using junk and stash

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -284,6 +284,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/thread_event.c \
 	$(srcroot)test/unit/ticker.c \
 	$(srcroot)test/unit/tsd.c \
+	$(srcroot)test/unit/uaf.c \
 	$(srcroot)test/unit/witness.c \
 	$(srcroot)test/unit/zero.c \
 	$(srcroot)test/unit/zero_realloc_abort.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1564,6 +1564,23 @@ if test "x$enable_opt_size_checks" = "x1" ; then
 fi
 AC_SUBST([enable_opt_size_checks])
 
+dnl Do not check for use-after-free by default.
+AC_ARG_ENABLE([uaf-detection],
+  [AS_HELP_STRING([--enable-uaf-detection],
+  [Allow sampled junk-filling on deallocation to detect use-after-free])],
+[if test "x$enable_uaf_detection" = "xno" ; then
+  enable_uaf_detection="0"
+else
+  enable_uaf_detection="1"
+fi
+],
+[enable_uaf_detection="0"]
+)
+if test "x$enable_uaf_detection" = "x1" ; then
+  AC_DEFINE([JEMALLOC_UAF_DETECTION], [ ])
+fi
+AC_SUBST([enable_uaf_detection])
+
 JE_COMPILABLE([a program using __builtin_unreachable], [
 void foo (void) {
   __builtin_unreachable();

--- a/include/jemalloc/internal/arena_stats.h
+++ b/include/jemalloc/internal/arena_stats.h
@@ -73,6 +73,7 @@ struct arena_stats_s {
 
 	/* Number of bytes cached in tcache associated with this arena. */
 	size_t			tcache_bytes; /* Derived. */
+	size_t			tcache_stashed_bytes; /* Derived. */
 
 	mutex_prof_data_t mutex_prof_data[mutex_prof_num_arena_mutexes];
 

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -371,13 +371,15 @@ cache_bin_alloc(cache_bin_t *bin, bool *success) {
 
 JEMALLOC_ALWAYS_INLINE cache_bin_sz_t
 cache_bin_alloc_batch(cache_bin_t *bin, size_t num, void **out) {
-	size_t n = cache_bin_ncached_get_internal(bin, /* racy */ false);
+	cache_bin_sz_t n = cache_bin_ncached_get_internal(bin,
+	    /* racy */ false);
 	if (n > num) {
-		n = num;
+		n = (cache_bin_sz_t)num;
 	}
 	memcpy(out, bin->stack_head, n * sizeof(void *));
 	bin->stack_head += n;
 	cache_bin_low_water_adjust(bin);
+
 	return n;
 }
 

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -415,6 +415,9 @@
 /* Performs additional size checks when defined. */
 #undef JEMALLOC_OPT_SIZE_CHECKS
 
+/* Allows sampled junk and stash for checking use-after-free when defined. */
+#undef JEMALLOC_UAF_DETECTION
+
 /* Darwin VM_MAKE_TAG support */
 #undef JEMALLOC_HAVE_VM_MAKE_TAG
 

--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -35,6 +35,9 @@ extern const char *zero_realloc_mode_names[];
 extern atomic_zu_t zero_realloc_count;
 extern bool opt_cache_oblivious;
 
+/* Escape free-fastpath when ptr & mask == 0 (for sanitization purpose). */
+extern uintptr_t san_cache_bin_nonfast_mask;
+
 /* Number of CPUs. */
 extern unsigned ncpus;
 

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -198,6 +198,14 @@ static const bool config_opt_size_checks =
 #endif
     ;
 
+static const bool config_uaf_detection =
+#if defined(JEMALLOC_UAF_DETECTION) || defined(JEMALLOC_DEBUG)
+    true
+#else
+    false
+#endif
+    ;
+
 /* Whether or not the C++ extensions are enabled. */
 static const bool config_enable_cxx =
 #ifdef JEMALLOC_ENABLE_CXX

--- a/include/jemalloc/internal/san.h
+++ b/include/jemalloc/internal/san.h
@@ -76,7 +76,7 @@ san_one_side_guarded_sz(size_t size) {
 }
 
 static inline bool
-san_enabled(void) {
+san_guard_enabled(void) {
 	return (opt_san_guard_large != 0 || opt_san_guard_small != 0);
 }
 

--- a/include/jemalloc/internal/san.h
+++ b/include/jemalloc/internal/san.h
@@ -10,9 +10,16 @@
 #define SAN_GUARD_LARGE_EVERY_N_EXTENTS_DEFAULT 0
 #define SAN_GUARD_SMALL_EVERY_N_EXTENTS_DEFAULT 0
 
+#define SAN_LG_UAF_ALIGN_DEFAULT (-1)
+#define SAN_CACHE_BIN_NONFAST_MASK_DEFAULT (uintptr_t)(-1)
+
+static const uintptr_t uaf_detect_junk = (uintptr_t)0x5b5b5b5b5b5b5b5bULL;
+
 /* 0 means disabled, i.e. never guarded. */
 extern size_t opt_san_guard_large;
 extern size_t opt_san_guard_small;
+/* -1 means disabled, i.e. never check for use-after-free. */
+extern ssize_t opt_lg_san_uaf_align;
 
 void san_guard_pages(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     emap_t *emap, bool left, bool right, bool remap);
@@ -24,7 +31,10 @@ void san_unguard_pages(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
  */
 void san_unguard_pages_pre_destroy(tsdn_t *tsdn, ehooks_t *ehooks,
     edata_t *edata, emap_t *emap);
+void san_check_stashed_ptrs(void **ptrs, size_t nstashed, size_t usize);
+
 void tsd_san_init(tsd_t *tsd);
+void san_init(ssize_t lg_san_uaf_align);
 
 static inline void
 san_guard_pages_two_sided(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
@@ -119,6 +129,64 @@ san_slab_extent_decide_guard(tsdn_t *tsdn, ehooks_t *ehooks) {
 		assert(tsd_san_extents_until_guard_small_get(tsd) >= 1);
 		return false;
 	}
+}
+
+static inline void
+san_junk_ptr_locations(void *ptr, size_t usize, void **first, void **mid,
+    void **last) {
+	size_t ptr_sz = sizeof(void *);
+
+	*first = ptr;
+
+	*mid = (void *)((uintptr_t)ptr + ((usize >> 1) & ~(ptr_sz - 1)));
+	assert(*first != *mid || usize == ptr_sz);
+	assert((uintptr_t)*first <= (uintptr_t)*mid);
+
+	/*
+	 * When usize > 32K, the gap between requested_size and usize might be
+	 * greater than 4K -- this means the last write may access an
+	 * likely-untouched page (default settings w/ 4K pages).  However by
+	 * default the tcache only goes up to the 32K size class, and is usually
+	 * tuned lower instead of higher, which makes it less of a concern.
+	 */
+	*last = (void *)((uintptr_t)ptr + usize - sizeof(uaf_detect_junk));
+	assert(*first != *last || usize == ptr_sz);
+	assert(*mid != *last || usize <= ptr_sz * 2);
+	assert((uintptr_t)*mid <= (uintptr_t)*last);
+}
+
+static inline bool
+san_junk_ptr_should_slow(void) {
+	/*
+	 * The latter condition (pointer size greater than the min size class)
+	 * is not expected -- fall back to the slow path for simplicity.
+	 */
+	return config_debug || (LG_SIZEOF_PTR > SC_LG_TINY_MIN);
+}
+
+static inline void
+san_junk_ptr(void *ptr, size_t usize) {
+	if (san_junk_ptr_should_slow()) {
+		memset(ptr, (char)uaf_detect_junk, usize);
+		return;
+	}
+
+	void *first, *mid, *last;
+	san_junk_ptr_locations(ptr, usize, &first, &mid, &last);
+	*(uintptr_t *)first = uaf_detect_junk;
+	*(uintptr_t *)mid = uaf_detect_junk;
+	*(uintptr_t *)last = uaf_detect_junk;
+}
+
+static inline bool
+san_uaf_detection_enabled(void) {
+	bool ret = config_uaf_detection && (opt_lg_san_uaf_align != -1);
+	if (config_uaf_detection && ret) {
+		assert(san_cache_bin_nonfast_mask == ((uintptr_t)1 <<
+		    opt_lg_san_uaf_align) - 1);
+	}
+
+	return ret;
 }
 
 #endif /* JEMALLOC_INTERNAL_GUARD_H */

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -34,23 +34,25 @@ extern cache_bin_info_t *tcache_bin_info;
  */
 extern tcaches_t	*tcaches;
 
-size_t	tcache_salloc(tsdn_t *tsdn, const void *ptr);
-void	*tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
+size_t tcache_salloc(tsdn_t *tsdn, const void *ptr);
+void *tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
     cache_bin_t *tbin, szind_t binind, bool *tcache_success);
 
-void	tcache_bin_flush_small(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
+void tcache_bin_flush_small(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
     szind_t binind, unsigned rem);
-void	tcache_bin_flush_large(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
+void tcache_bin_flush_large(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
     szind_t binind, unsigned rem);
-void	tcache_arena_reassociate(tsdn_t *tsdn, tcache_slow_t *tcache_slow,
+void tcache_bin_flush_stashed(tsd_t *tsd, tcache_t *tcache, cache_bin_t *bin,
+    szind_t binind, bool is_small);
+void tcache_arena_reassociate(tsdn_t *tsdn, tcache_slow_t *tcache_slow,
     tcache_t *tcache, arena_t *arena);
 tcache_t *tcache_create_explicit(tsd_t *tsd);
-void	tcache_cleanup(tsd_t *tsd);
-void	tcache_stats_merge(tsdn_t *tsdn, tcache_t *tcache, arena_t *arena);
-bool	tcaches_create(tsd_t *tsd, base_t *base, unsigned *r_ind);
-void	tcaches_flush(tsd_t *tsd, unsigned ind);
-void	tcaches_destroy(tsd_t *tsd, unsigned ind);
-bool	tcache_boot(tsdn_t *tsdn, base_t *base);
+void tcache_cleanup(tsd_t *tsd);
+void tcache_stats_merge(tsdn_t *tsdn, tcache_t *tcache, arena_t *arena);
+bool tcaches_create(tsd_t *tsd, base_t *base, unsigned *r_ind);
+void tcaches_flush(tsd_t *tsd, unsigned ind);
+void tcaches_destroy(tsd_t *tsd, unsigned ind);
+bool tcache_boot(tsdn_t *tsdn, base_t *base);
 void tcache_arena_associate(tsdn_t *tsdn, tcache_slow_t *tcache_slow,
     tcache_t *tcache, arena_t *arena);
 void tcache_prefork(tsdn_t *tsdn);

--- a/src/arena.c
+++ b/src/arena.c
@@ -157,6 +157,8 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 			cache_bin_t *cache_bin = &descriptor->bins[i];
 			astats->tcache_bytes +=
 			    cache_bin_ncached_get_remote(cache_bin,
+			    &tcache_bin_info[i]) * sz_index2size(i) +
+			    cache_bin_nstashed_get(cache_bin,
 			    &tcache_bin_info[i]) * sz_index2size(i);
 		}
 	}

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -2,6 +2,8 @@
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
 #include "jemalloc/internal/bit_util.h"
+#include "jemalloc/internal/cache_bin.h"
+#include "jemalloc/internal/safety_check.h"
 
 void
 cache_bin_info_init(cache_bin_info_t *info,

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -290,6 +290,7 @@ CTL_PROTO(stats_arenas_i_base)
 CTL_PROTO(stats_arenas_i_internal)
 CTL_PROTO(stats_arenas_i_metadata_thp)
 CTL_PROTO(stats_arenas_i_tcache_bytes)
+CTL_PROTO(stats_arenas_i_tcache_stashed_bytes)
 CTL_PROTO(stats_arenas_i_resident)
 CTL_PROTO(stats_arenas_i_abandoned_vm)
 CTL_PROTO(stats_arenas_i_hpa_sec_bytes)
@@ -787,6 +788,8 @@ static const ctl_named_node_t stats_arenas_i_node[] = {
 	{NAME("internal"),	CTL(stats_arenas_i_internal)},
 	{NAME("metadata_thp"),	CTL(stats_arenas_i_metadata_thp)},
 	{NAME("tcache_bytes"),	CTL(stats_arenas_i_tcache_bytes)},
+	{NAME("tcache_stashed_bytes"),
+	    CTL(stats_arenas_i_tcache_stashed_bytes)},
 	{NAME("resident"),	CTL(stats_arenas_i_resident)},
 	{NAME("abandoned_vm"),	CTL(stats_arenas_i_abandoned_vm)},
 	{NAME("hpa_sec_bytes"),	CTL(stats_arenas_i_hpa_sec_bytes)},
@@ -1169,6 +1172,8 @@ MUTEX_PROF_ARENA_MUTEXES
 		    &astats->astats.pa_shard_stats.pac_stats.abandoned_vm);
 
 		sdstats->astats.tcache_bytes += astats->astats.tcache_bytes;
+		sdstats->astats.tcache_stashed_bytes +=
+		    astats->astats.tcache_stashed_bytes;
 
 		if (ctl_arena->arena_ind == 0) {
 			sdstats->astats.uptime = astats->astats.uptime;
@@ -3503,6 +3508,8 @@ CTL_RO_CGEN(config_stats, stats_arenas_i_metadata_thp,
     arenas_i(mib[2])->astats->astats.metadata_thp, size_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_tcache_bytes,
     arenas_i(mib[2])->astats->astats.tcache_bytes, size_t)
+CTL_RO_CGEN(config_stats, stats_arenas_i_tcache_stashed_bytes,
+    arenas_i(mib[2])->astats->astats.tcache_stashed_bytes, size_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_resident,
     arenas_i(mib[2])->astats->astats.resident,
     size_t)

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -150,6 +150,7 @@ CTL_PROTO(opt_prof_recent_alloc_max)
 CTL_PROTO(opt_prof_stats)
 CTL_PROTO(opt_prof_sys_thread_name)
 CTL_PROTO(opt_prof_time_res)
+CTL_PROTO(opt_lg_san_uaf_align)
 CTL_PROTO(opt_zero_realloc)
 CTL_PROTO(tcache_create)
 CTL_PROTO(tcache_flush)
@@ -472,6 +473,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_stats"),	CTL(opt_prof_stats)},
 	{NAME("prof_sys_thread_name"),	CTL(opt_prof_sys_thread_name)},
 	{NAME("prof_time_resolution"),	CTL(opt_prof_time_res)},
+	{NAME("lg_san_uaf_align"),	CTL(opt_lg_san_uaf_align)},
 	{NAME("zero_realloc"),	CTL(opt_zero_realloc)}
 };
 
@@ -2201,6 +2203,8 @@ CTL_RO_NL_CGEN(config_prof, opt_prof_sys_thread_name, opt_prof_sys_thread_name,
     bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_time_res,
     prof_time_res_mode_names[opt_prof_time_res], const char *)
+CTL_RO_NL_CGEN(config_uaf_detection, opt_lg_san_uaf_align,
+    opt_lg_san_uaf_align, ssize_t)
 CTL_RO_NL_GEN(opt_zero_realloc,
     zero_realloc_mode_names[opt_zero_realloc_action], const char *)
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1055,7 +1055,7 @@ stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
 	size_t large_allocated;
 	uint64_t large_nmalloc, large_ndalloc, large_nrequests, large_nfills,
 	    large_nflushes;
-	size_t tcache_bytes, abandoned_vm;
+	size_t tcache_bytes, tcache_stashed_bytes, abandoned_vm;
 	uint64_t uptime;
 
 	CTL_GET("arenas.page", &page, size_t);
@@ -1344,6 +1344,7 @@ stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
 	GET_AND_EMIT_MEM_STAT(internal)
 	GET_AND_EMIT_MEM_STAT(metadata_thp)
 	GET_AND_EMIT_MEM_STAT(tcache_bytes)
+	GET_AND_EMIT_MEM_STAT(tcache_stashed_bytes)
 	GET_AND_EMIT_MEM_STAT(resident)
 	GET_AND_EMIT_MEM_STAT(abandoned_vm)
 	GET_AND_EMIT_MEM_STAT(extent_avail)

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -553,7 +553,7 @@ tcache_bin_flush_stashed(tsd_t *tsd, tcache_t *tcache, cache_bin_t *cache_bin,
 	cache_bin_sz_t orig_cached = cache_bin_ncached_get_local(cache_bin,
 	    info);
 
-	cache_bin_sz_t nstashed = cache_bin_nstashed_get(cache_bin, info);
+	cache_bin_sz_t nstashed = cache_bin_nstashed_get_local(cache_bin, info);
 	assert(orig_cached + nstashed <= cache_bin_info_ncached_max(info));
 	if (nstashed == 0) {
 		return;
@@ -567,7 +567,7 @@ tcache_bin_flush_stashed(tsd_t *tsd, tcache_t *tcache, cache_bin_t *cache_bin,
 	    is_small);
 	cache_bin_finish_flush_stashed(cache_bin, info);
 
-	assert(cache_bin_nstashed_get(cache_bin, info) == 0);
+	assert(cache_bin_nstashed_get_local(cache_bin, info) == 0);
 	assert(cache_bin_ncached_get_local(cache_bin, info) == orig_cached);
 	assert(head_content == *cache_bin->stack_head);
 }

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -418,7 +418,8 @@ tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *cache_bin,
 
 		/* Deallocate whatever we can. */
 		unsigned ndeferred = 0;
-		arena_dalloc_bin_locked_info_t dalloc_bin_info;
+		/* Init only to avoid used-uninitialized warning. */
+		arena_dalloc_bin_locked_info_t dalloc_bin_info = {0};
 		if (small) {
 			arena_dalloc_bin_locked_begin(&dalloc_bin_info, binind);
 		}

--- a/test/include/test/arena_util.h
+++ b/test/include/test/arena_util.h
@@ -26,6 +26,12 @@ do_arena_create(ssize_t dirty_decay_ms, ssize_t muzzy_decay_ms) {
 
 static inline void
 do_arena_destroy(unsigned arena_ind) {
+	/* 
+	 * For convenience, flush tcache in case there are cached items.
+	 * However not assert success since the tcache may be disabled.
+	 */
+	mallctl("thread.tcache.flush", NULL, NULL, NULL, 0);
+
 	size_t mib[3];
 	size_t miblen = sizeof(mib)/sizeof(size_t);
 	expect_d_eq(mallctlnametomib("arena.0.destroy", mib, &miblen), 0,

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -82,27 +82,30 @@ do_batch_alloc_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	free(out);
 }
 
+static void
+test_bin_init(cache_bin_t *bin, cache_bin_info_t *info) {
+	size_t size;
+	size_t alignment;
+	cache_bin_info_compute_alloc(info, 1, &size, &alignment);
+	void *mem = mallocx(size, MALLOCX_ALIGN(alignment));
+	assert_ptr_not_null(mem, "Unexpected mallocx failure");
+
+	size_t cur_offset = 0;
+	cache_bin_preincrement(info, 1, mem, &cur_offset);
+	cache_bin_init(bin, info, mem, &cur_offset);
+	cache_bin_postincrement(info, 1, mem, &cur_offset);
+	assert_zu_eq(cur_offset, size, "Should use all requested memory");
+}
+
 TEST_BEGIN(test_cache_bin) {
 	const int ncached_max = 100;
 	bool success;
 	void *ptr;
 
-	cache_bin_t bin;
 	cache_bin_info_t info;
 	cache_bin_info_init(&info, ncached_max);
-
-	size_t size;
-	size_t alignment;
-	cache_bin_info_compute_alloc(&info, 1, &size, &alignment);
-	void *mem = mallocx(size, MALLOCX_ALIGN(alignment));
-	assert_ptr_not_null(mem, "Unexpected mallocx failure");
-
-	size_t cur_offset = 0;
-	cache_bin_preincrement(&info, 1, mem, &cur_offset);
-	cache_bin_init(&bin, &info, mem, &cur_offset);
-	cache_bin_postincrement(&info, 1, mem, &cur_offset);
-
-	assert_zu_eq(cur_offset, size, "Should use all requested memory");
+	cache_bin_t bin;
+	test_bin_init(&bin, &info);
 
 	/* Initialize to empty; should then have 0 elements. */
 	expect_d_eq(ncached_max, cache_bin_info_ncached_max(&info), "");
@@ -258,7 +261,123 @@ TEST_BEGIN(test_cache_bin) {
 }
 TEST_END
 
+static void
+do_flush_stashed_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
+    cache_bin_sz_t nfill, cache_bin_sz_t nstash) {
+	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
+	    "Bin not empty");
+	expect_true(cache_bin_nstashed_get(bin, info) == 0, "Bin not empty");
+	expect_true(nfill + nstash <= info->ncached_max, "Exceeded max");
+
+	bool ret;
+	/* Fill */
+	for (cache_bin_sz_t i = 0; i < nfill; i++) {
+		ret = cache_bin_dalloc_easy(bin, &ptrs[i]);
+		expect_true(ret, "Unexpected fill failure");
+	}
+	expect_true(cache_bin_ncached_get_local(bin, info) == nfill,
+	    "Wrong cached count");
+
+	/* Stash */
+	for (cache_bin_sz_t i = 0; i < nstash; i++) {
+		ret = cache_bin_stash(bin, &ptrs[i + nfill]);
+		expect_true(ret, "Unexpected stash failure");
+	}
+	expect_true(cache_bin_nstashed_get(bin, info) == nstash,
+	    "Wrong stashed count");
+
+	if (nfill + nstash == info->ncached_max) {
+		ret = cache_bin_dalloc_easy(bin, &ptrs[0]);
+		expect_false(ret, "Should not dalloc into a full bin");
+		ret = cache_bin_stash(bin, &ptrs[0]);
+		expect_false(ret, "Should not stash into a full bin");
+	}
+
+	/* Alloc filled ones */
+	for (cache_bin_sz_t i = 0; i < nfill; i++) {
+		void *ptr = cache_bin_alloc(bin, &ret);
+		expect_true(ret, "Unexpected alloc failure");
+		/* Verify it's not from the stashed range. */
+		expect_true((uintptr_t)ptr < (uintptr_t)&ptrs[nfill],
+		    "Should not alloc stashed ptrs");
+	}
+	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
+	    "Wrong cached count");
+	expect_true(cache_bin_nstashed_get(bin, info) == nstash,
+	    "Wrong stashed count");
+
+	cache_bin_alloc(bin, &ret);
+	expect_false(ret, "Should not alloc stashed");
+
+	/* Clear stashed ones */
+	cache_bin_finish_flush_stashed(bin, info);
+	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
+	    "Wrong cached count");
+	expect_true(cache_bin_nstashed_get(bin, info) == 0,
+	    "Wrong stashed count");
+
+	cache_bin_alloc(bin, &ret);
+	expect_false(ret, "Should not alloc from empty bin");
+}
+
+TEST_BEGIN(test_cache_bin_stash) {
+	const int ncached_max = 100;
+
+	cache_bin_t bin;
+	cache_bin_info_t info;
+	cache_bin_info_init(&info, ncached_max);
+	test_bin_init(&bin, &info);
+
+	/*
+	 * The content of this array is not accessed; instead the interior
+	 * addresses are used to insert / stash into the bins as test pointers.
+	 */
+	void **ptrs = mallocx(sizeof(void *) * (ncached_max + 1), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+	bool ret;
+	for (cache_bin_sz_t i = 0; i < ncached_max; i++) {
+		expect_true(cache_bin_ncached_get_local(&bin, &info) ==
+		    (i / 2 + i % 2), "Wrong ncached value");
+		expect_true(cache_bin_nstashed_get(&bin, &info) == i / 2,
+		    "Wrong nstashed value");
+		if (i % 2 == 0) {
+			cache_bin_dalloc_easy(&bin, &ptrs[i]);
+		} else {
+			ret = cache_bin_stash(&bin, &ptrs[i]);
+			expect_true(ret, "Should be able to stash into a "
+			    "non-full cache bin");
+		}
+	}
+	ret = cache_bin_dalloc_easy(&bin, &ptrs[0]);
+	expect_false(ret, "Should not dalloc into a full cache bin");
+	ret = cache_bin_stash(&bin, &ptrs[0]);
+	expect_false(ret, "Should not stash into a full cache bin");
+	for (cache_bin_sz_t i = 0; i < ncached_max; i++) {
+		void *ptr = cache_bin_alloc(&bin, &ret);
+		if (i < ncached_max / 2) {
+			expect_true(ret, "Should be able to alloc");
+			uintptr_t diff = ((uintptr_t)ptr - (uintptr_t)&ptrs[0])
+			    / sizeof(void *);
+			expect_true(diff % 2 == 0, "Should be able to alloc");
+		} else {
+			expect_false(ret, "Should not alloc stashed");
+			expect_true(cache_bin_nstashed_get(&bin, &info) ==
+			    ncached_max / 2, "Wrong nstashed value");
+		}
+	}
+
+	test_bin_init(&bin, &info);
+	do_flush_stashed_test(&bin, &info, ptrs, ncached_max, 0);
+	do_flush_stashed_test(&bin, &info, ptrs, 0, ncached_max);
+	do_flush_stashed_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 2);
+	do_flush_stashed_test(&bin, &info, ptrs, ncached_max / 4, ncached_max / 2);
+	do_flush_stashed_test(&bin, &info, ptrs, ncached_max / 2, ncached_max / 4);
+	do_flush_stashed_test(&bin, &info, ptrs, ncached_max / 4, ncached_max / 4);
+}
+TEST_END
+
 int
 main(void) {
-	return test(test_cache_bin);
+	return test(test_cache_bin,
+		test_cache_bin_stash);
 }

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -266,7 +266,8 @@ do_flush_stashed_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
     cache_bin_sz_t nfill, cache_bin_sz_t nstash) {
 	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
 	    "Bin not empty");
-	expect_true(cache_bin_nstashed_get(bin, info) == 0, "Bin not empty");
+	expect_true(cache_bin_nstashed_get_local(bin, info) == 0,
+	    "Bin not empty");
 	expect_true(nfill + nstash <= info->ncached_max, "Exceeded max");
 
 	bool ret;
@@ -283,7 +284,7 @@ do_flush_stashed_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 		ret = cache_bin_stash(bin, &ptrs[i + nfill]);
 		expect_true(ret, "Unexpected stash failure");
 	}
-	expect_true(cache_bin_nstashed_get(bin, info) == nstash,
+	expect_true(cache_bin_nstashed_get_local(bin, info) == nstash,
 	    "Wrong stashed count");
 
 	if (nfill + nstash == info->ncached_max) {
@@ -303,7 +304,7 @@ do_flush_stashed_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	}
 	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
 	    "Wrong cached count");
-	expect_true(cache_bin_nstashed_get(bin, info) == nstash,
+	expect_true(cache_bin_nstashed_get_local(bin, info) == nstash,
 	    "Wrong stashed count");
 
 	cache_bin_alloc(bin, &ret);
@@ -313,7 +314,7 @@ do_flush_stashed_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	cache_bin_finish_flush_stashed(bin, info);
 	expect_true(cache_bin_ncached_get_local(bin, info) == 0,
 	    "Wrong cached count");
-	expect_true(cache_bin_nstashed_get(bin, info) == 0,
+	expect_true(cache_bin_nstashed_get_local(bin, info) == 0,
 	    "Wrong stashed count");
 
 	cache_bin_alloc(bin, &ret);
@@ -338,7 +339,7 @@ TEST_BEGIN(test_cache_bin_stash) {
 	for (cache_bin_sz_t i = 0; i < ncached_max; i++) {
 		expect_true(cache_bin_ncached_get_local(&bin, &info) ==
 		    (i / 2 + i % 2), "Wrong ncached value");
-		expect_true(cache_bin_nstashed_get(&bin, &info) == i / 2,
+		expect_true(cache_bin_nstashed_get_local(&bin, &info) == i / 2,
 		    "Wrong nstashed value");
 		if (i % 2 == 0) {
 			cache_bin_dalloc_easy(&bin, &ptrs[i]);
@@ -361,7 +362,7 @@ TEST_BEGIN(test_cache_bin_stash) {
 			expect_true(diff % 2 == 0, "Should be able to alloc");
 		} else {
 			expect_false(ret, "Should not alloc stashed");
-			expect_true(cache_bin_nstashed_get(&bin, &info) ==
+			expect_true(cache_bin_nstashed_get_local(&bin, &info) ==
 			    ncached_max / 2, "Wrong nstashed value");
 		}
 	}

--- a/test/unit/hpa_background_thread.c
+++ b/test/unit/hpa_background_thread.c
@@ -129,7 +129,7 @@ TEST_BEGIN(test_hpa_background_thread_purges) {
 	test_skip_if(!hpa_supported());
 	test_skip_if(!have_background_thread);
 	/* Skip since guarded pages cannot be allocated from hpa. */
-	test_skip_if(san_enabled());
+	test_skip_if(san_guard_enabled());
 
 	unsigned arena_ind = create_arena();
 	/*
@@ -145,7 +145,7 @@ TEST_BEGIN(test_hpa_background_thread_enable_disable) {
 	test_skip_if(!hpa_supported());
 	test_skip_if(!have_background_thread);
 	/* Skip since guarded pages cannot be allocated from hpa. */
-	test_skip_if(san_enabled());
+	test_skip_if(san_guard_enabled());
 
 	unsigned arena_ind = create_arena();
 

--- a/test/unit/retained.c
+++ b/test/unit/retained.c
@@ -104,7 +104,7 @@ TEST_BEGIN(test_retained) {
 
 	arena_ind = do_arena_create(NULL);
 	sz = nallocx(HUGEPAGE, 0);
-	size_t guard_sz = san_enabled() ? SAN_PAGE_GUARDS_SIZE : 0;
+	size_t guard_sz = san_guard_enabled() ? SAN_PAGE_GUARDS_SIZE : 0;
 	esz = sz + sz_large_pad + guard_sz;
 
 	atomic_store_u(&epoch, 0, ATOMIC_RELAXED);

--- a/test/unit/stats.c
+++ b/test/unit/stats.c
@@ -367,7 +367,7 @@ TEST_END
 static void
 test_tcache_bytes_for_usize(size_t usize) {
 	uint64_t epoch;
-	size_t tcache_bytes;
+	size_t tcache_bytes, tcache_stashed_bytes;
 	size_t sz = sizeof(tcache_bytes);
 
 	void *ptr = mallocx(usize, 0);
@@ -377,7 +377,11 @@ test_tcache_bytes_for_usize(size_t usize) {
 	assert_d_eq(mallctl(
 	    "stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL) ".tcache_bytes",
 	    &tcache_bytes, &sz, NULL, 0), 0, "Unexpected mallctl failure");
-	size_t tcache_bytes_before = tcache_bytes;
+	assert_d_eq(mallctl(
+	    "stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL)
+	    ".tcache_stashed_bytes", &tcache_stashed_bytes, &sz, NULL, 0), 0,
+	    "Unexpected mallctl failure");
+	size_t tcache_bytes_before = tcache_bytes + tcache_stashed_bytes;
 	dallocx(ptr, 0);
 
 	expect_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sizeof(epoch)),
@@ -385,7 +389,11 @@ test_tcache_bytes_for_usize(size_t usize) {
 	assert_d_eq(mallctl(
 	    "stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL) ".tcache_bytes",
 	    &tcache_bytes, &sz, NULL, 0), 0, "Unexpected mallctl failure");
-	size_t tcache_bytes_after = tcache_bytes;
+	assert_d_eq(mallctl(
+	    "stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL)
+	    ".tcache_stashed_bytes", &tcache_stashed_bytes, &sz, NULL, 0), 0,
+	    "Unexpected mallctl failure");
+	size_t tcache_bytes_after = tcache_bytes + tcache_stashed_bytes;
 	assert_zu_eq(tcache_bytes_after - tcache_bytes_before,
 	    usize, "Incorrectly attributed a free");
 }

--- a/test/unit/tcache_max.c
+++ b/test/unit/tcache_max.c
@@ -152,6 +152,7 @@ TEST_BEGIN(test_tcache_max) {
 	test_skip_if(!config_stats);
 	test_skip_if(!opt_tcache);
 	test_skip_if(opt_prof);
+	test_skip_if(san_uaf_detection_enabled());
 
 	for (alloc_option = alloc_option_start;
 	     alloc_option < alloc_option_end;

--- a/test/unit/tcache_max.sh
+++ b/test/unit/tcache_max.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="tcache_max:1024"
+export MALLOC_CONF="tcache_max:1024,lg_san_uaf_align:-1"

--- a/test/unit/uaf.c
+++ b/test/unit/uaf.c
@@ -1,0 +1,225 @@
+#include "test/jemalloc_test.h"
+#include "test/arena_util.h"
+
+#include "jemalloc/internal/cache_bin.h"
+#include "jemalloc/internal/safety_check.h"
+
+static size_t san_uaf_align;
+
+static bool fake_abort_called;
+void fake_abort(const char *message) {
+	(void)message;
+	fake_abort_called = true;
+}
+
+static void
+test_write_after_free_pre(void) {
+	safety_check_set_abort(&fake_abort);
+	fake_abort_called = false;
+}
+
+static void
+test_write_after_free_post(void) {
+	assert_d_eq(mallctl("thread.tcache.flush", NULL, NULL, NULL, 0),
+	    0, "Unexpected tcache flush failure");
+	expect_true(fake_abort_called, "Use-after-free check didn't fire.");
+	safety_check_set_abort(NULL);
+}
+
+static bool
+uaf_detection_enabled(void) {
+	if (!config_uaf_detection) {
+		return false;
+	}
+
+	ssize_t lg_san_uaf_align;
+	size_t sz = sizeof(lg_san_uaf_align);
+	assert_d_eq(mallctl("opt.lg_san_uaf_align", &lg_san_uaf_align, &sz,
+	    NULL, 0), 0, "Unexpected mallctl failure");
+	if (lg_san_uaf_align < 0) {
+		return false;
+	}
+	assert_zd_ge(lg_san_uaf_align, LG_PAGE, "san_uaf_align out of range");
+	san_uaf_align = (size_t)1 << lg_san_uaf_align;
+
+	bool tcache_enabled;
+	sz = sizeof(tcache_enabled);
+	assert_d_eq(mallctl("thread.tcache.enabled", &tcache_enabled, &sz, NULL,
+	    0), 0, "Unexpected mallctl failure");
+	if (!tcache_enabled) {
+		return false;
+	}
+
+	return true;
+}
+
+static void
+test_use_after_free(size_t alloc_size, bool write_after_free) {
+	void *ptr = (void *)(uintptr_t)san_uaf_align;
+	assert_true(cache_bin_nonfast_aligned(ptr), "Wrong alignment");
+	ptr = (void *)((uintptr_t)123 * (uintptr_t)san_uaf_align);
+	assert_true(cache_bin_nonfast_aligned(ptr), "Wrong alignment");
+	ptr = (void *)((uintptr_t)san_uaf_align + 1);
+	assert_false(cache_bin_nonfast_aligned(ptr), "Wrong alignment");
+
+	/*
+	 * Disable purging (-1) so that all dirty pages remain committed, to
+	 * make use-after-free tolerable.
+	 */
+	unsigned arena_ind = do_arena_create(-1, -1);
+	int flags = MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE;
+
+	size_t n_max = san_uaf_align * 2;
+	void **items = mallocx(n_max * sizeof(void *), flags);
+	assert_ptr_not_null(items, "Unexpected mallocx failure");
+
+	bool found = false;
+	size_t iter = 0;
+	char magic = 's';
+	assert_d_eq(mallctl("thread.tcache.flush", NULL, NULL, NULL, 0),
+	    0, "Unexpected tcache flush failure");
+	while (!found) {
+		ptr = mallocx(alloc_size, flags);
+		assert_ptr_not_null(ptr, "Unexpected mallocx failure");
+
+		found = cache_bin_nonfast_aligned(ptr);
+		*(char *)ptr = magic;
+		items[iter] = ptr;
+		assert_zu_lt(iter++, n_max, "No aligned ptr found");
+	}
+
+	if (write_after_free) {
+		test_write_after_free_pre();
+	}
+	bool junked = false;
+	while (iter-- != 0) {
+		char *volatile mem = items[iter];
+		assert_c_eq(*mem, magic, "Unexpected memory content");
+		free(mem);
+		if (*mem != magic) {
+			junked = true;
+			assert_c_eq(*mem, (char)uaf_detect_junk,
+			    "Unexpected junk-filling bytes");
+			if (write_after_free) {
+				*(char *)mem = magic + 1;
+			}
+		}
+		/* Flush tcache (including stashed). */
+		assert_d_eq(mallctl("thread.tcache.flush", NULL, NULL, NULL, 0),
+		    0, "Unexpected tcache flush failure");
+	}
+	expect_true(junked, "Aligned ptr not junked");
+	if (write_after_free) {
+		test_write_after_free_post();
+	}
+
+	dallocx(items, flags);
+	do_arena_destroy(arena_ind);
+}
+
+TEST_BEGIN(test_read_after_free) {
+	test_skip_if(!uaf_detection_enabled());
+
+	test_use_after_free(sizeof(void *), /* write_after_free */ false);
+	test_use_after_free(sizeof(void *) + 1, /* write_after_free */ false);
+	test_use_after_free(16, /* write_after_free */ false);
+	test_use_after_free(20, /* write_after_free */ false);
+	test_use_after_free(32, /* write_after_free */ false);
+	test_use_after_free(33, /* write_after_free */ false);
+	test_use_after_free(48, /* write_after_free */ false);
+	test_use_after_free(64, /* write_after_free */ false);
+	test_use_after_free(65, /* write_after_free */ false);
+	test_use_after_free(129, /* write_after_free */ false);
+	test_use_after_free(255, /* write_after_free */ false);
+	test_use_after_free(256, /* write_after_free */ false);
+}
+TEST_END
+
+TEST_BEGIN(test_write_after_free) {
+	test_skip_if(!uaf_detection_enabled());
+
+	test_use_after_free(sizeof(void *), /* write_after_free */ true);
+	test_use_after_free(sizeof(void *) + 1, /* write_after_free */ true);
+	test_use_after_free(16, /* write_after_free */ true);
+	test_use_after_free(20, /* write_after_free */ true);
+	test_use_after_free(32, /* write_after_free */ true);
+	test_use_after_free(33, /* write_after_free */ true);
+	test_use_after_free(48, /* write_after_free */ true);
+	test_use_after_free(64, /* write_after_free */ true);
+	test_use_after_free(65, /* write_after_free */ true);
+	test_use_after_free(129, /* write_after_free */ true);
+	test_use_after_free(255, /* write_after_free */ true);
+	test_use_after_free(256, /* write_after_free */ true);
+}
+TEST_END
+
+static bool
+check_allocated_intact(void **allocated, size_t n_alloc) {
+	for (unsigned i = 0; i < n_alloc; i++) {
+		void *ptr = *(void **)allocated[i];
+		bool found = false;
+		for (unsigned j = 0; j < n_alloc; j++) {
+			if (ptr == allocated[j]) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+TEST_BEGIN(test_use_after_free_integration) {
+	test_skip_if(!uaf_detection_enabled());
+
+	unsigned arena_ind = do_arena_create(-1, -1);
+	int flags = MALLOCX_ARENA(arena_ind);
+
+	size_t n_alloc = san_uaf_align * 2;
+	void **allocated = mallocx(n_alloc * sizeof(void *), flags);
+	assert_ptr_not_null(allocated, "Unexpected mallocx failure");
+
+	for (unsigned i = 0; i < n_alloc; i++) {
+		allocated[i] = mallocx(sizeof(void *) * 8, flags);
+		assert_ptr_not_null(allocated[i], "Unexpected mallocx failure");
+		if (i > 0) {
+			/* Emulate a circular list. */
+			*(void **)allocated[i] = allocated[i - 1];
+		}
+	}
+	*(void **)allocated[0] = allocated[n_alloc - 1];
+	expect_true(check_allocated_intact(allocated, n_alloc),
+	    "Allocated data corrupted");
+
+	for (unsigned i = 0; i < n_alloc; i++) {
+		free(allocated[i]);
+	}
+	/* Read-after-free */
+	expect_false(check_allocated_intact(allocated, n_alloc),
+	    "Junk-filling not detected");
+
+	test_write_after_free_pre();
+	for (unsigned i = 0; i < n_alloc; i++) {
+		allocated[i] = mallocx(sizeof(void *), flags);
+		assert_ptr_not_null(allocated[i], "Unexpected mallocx failure");
+		*(void **)allocated[i] = (void *)(uintptr_t)i;
+	}
+	/* Write-after-free */
+	for (unsigned i = 0; i < n_alloc; i++) {
+		free(allocated[i]);
+		*(void **)allocated[i] = NULL;
+	}
+	test_write_after_free_post();
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_read_after_free,
+	    test_write_after_free,
+	    test_use_after_free_integration);
+}

--- a/test/unit/uaf.sh
+++ b/test/unit/uaf.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="lg_san_uaf_align:12"


### PR DESCRIPTION
On deallocation, sampled pointers (specially aligned) get junked and stashed
into tcache (to prevent immediate reuse).  The expected behavior is to have
read-after-free corrupted and stopped by the junk-filling, while
write-after-free is checked when flushing the stashed pointers.