### PR TITLE
Use visibility("default") attribute for libc overrides

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3088,7 +3088,7 @@ JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
  * be implemented also, so none of glibc's malloc.o functions are added to the
  * link.
  */
-#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), used))
+#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), visibility("default")))
 /* To force macro expansion of je_ prefix before stringification. */
 #    define PREALIAS(je_fn)	ALIAS(je_fn)
 #    ifdef JEMALLOC_OVERRIDE___LIBC_CALLOC


### PR DESCRIPTION
This fixed problems we observed with [FEX's jemalloc fork](https://github.com/FEX-Emu/jemalloc) overriding libc functions, where the libc's `malloc` implementation got called instead of jemalloc's. I'm guessing `attribute((used))` is purely a compiler directive, whereas the linker only considers visibility (which is set via `-fvisibility=hidden` in our build configuration).

I haven't reproduced this with upstream jemalloc (since I'm only using our fork), but it's worth noting both tcmalloc and mimalloc have similar overrides that used `attribute((used))` in the past and have later been changed to use the `visibility` attribute instead, so this seems like a reasonable way to follow. (Compare [old tcmalloc](https://github.com/chromium/chromium/blob/84ce36326b9e2985278ae1ac8095b4b85a0653a7/third_party/tcmalloc/chromium/src/libc_override_gcc_and_weak.h#L58) to [new tcmalloc](https://github.com/google/tcmalloc/blob/98b28bc6861036aabd1bd8d3b17800012c4d8f23/tcmalloc/libc_override_gcc_and_weak.h#L35-L36), and see [mimalloc](https://github.com/microsoft/mimalloc/blob/0560fc27c08d28d523b7f741a42deb26cd01c0c6/src/alloc-override.c#L33-L38))

I'm not sure if upstream needs to keep `attribute((used))` around, though. If the user builds without `-fvisibility=hidden`, it might still have some effect. Opinions?
