### PR TITLE
Fix `base_ehooks_get_for_metadata`

### DIFF
--- a/include/jemalloc/internal/base.h
+++ b/include/jemalloc/internal/base.h
@@ -47,9 +47,9 @@ struct base_s {
 	ehooks_t ehooks;
 
 	/*
-	 * Use user hooks for metadata when true.
+	 * User-configurable extent hook functions for metadata allocations.
 	 */
-	bool metadata_use_hooks;
+	ehooks_t ehooks_base;
 
 	/* Protects base_alloc() and base_stats_get() operations. */
 	malloc_mutex_t mtx;
@@ -95,6 +95,7 @@ base_t *base_new(tsdn_t *tsdn, unsigned ind,
     const extent_hooks_t *extent_hooks, bool metadata_use_hooks);
 void base_delete(tsdn_t *tsdn, base_t *base);
 ehooks_t *base_ehooks_get(base_t *base);
+ehooks_t *base_ehooks_get_for_metadata(base_t *base);
 extent_hooks_t *base_extent_hooks_set(base_t *base,
     extent_hooks_t *extent_hooks);
 void *base_alloc(tsdn_t *tsdn, base_t *base, size_t size, size_t alignment);

--- a/test/unit/base.c
+++ b/test/unit/base.c
@@ -227,10 +227,39 @@ TEST_BEGIN(test_base_hooks_not_null) {
 }
 TEST_END
 
+TEST_BEGIN(test_base_ehooks_get_for_metadata_default_hook) {
+	extent_hooks_prep();
+	memcpy(&hooks, &hooks_not_null, sizeof(extent_hooks_t));
+	base_t *base;
+	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
+	base = base_new(tsdn, 0, &hooks, /* metadata_use_hooks */ false);
+	ehooks_t *ehooks = base_ehooks_get_for_metadata(base);
+	expect_true(ehooks_are_default(ehooks),
+		"Expected default extent hook functions pointer");
+	base_delete(tsdn, base);
+}
+TEST_END
+
+
+TEST_BEGIN(test_base_ehooks_get_for_metadata_custom_hook) {
+	extent_hooks_prep();
+	memcpy(&hooks, &hooks_not_null, sizeof(extent_hooks_t));
+	base_t *base;
+	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
+	base = base_new(tsdn, 0, &hooks, /* metadata_use_hooks */ true);
+	ehooks_t *ehooks = base_ehooks_get_for_metadata(base);
+	expect_ptr_eq(&hooks, ehooks_get_extent_hooks_ptr(ehooks),
+		"Expected user-specified extend hook functions pointer");
+	base_delete(tsdn, base);
+}
+TEST_END
+
 int
 main(void) {
 	return test(
 	    test_base_hooks_default,
 	    test_base_hooks_null,
-	    test_base_hooks_not_null);
+	    test_base_hooks_not_null,
+            test_base_ehooks_get_for_metadata_default_hook,
+            test_base_ehooks_get_for_metadata_custom_hook);
 }


### PR DESCRIPTION
Since #2118, jemalloc has the experimental mallctl `experimental.arenas_create_ext`, which allows passing an `arena_config_t` structure, which can be used to customize the behavior of the arena. With this addition, `base_ehooks_get_for_metadata` was also added, which is intended to return the corresponding extend hook functions:
- (1) the user-specified extend hook functions when `metadata_use_hooks` is `true`
- (2) the default extend hook functions when `metadata_use_hooks` is `false`.

However, in case (2), accessing the return value leads to a segmentation fault due to the static cast `(struct ehooks_s *)&ehooks_default_extent_hooks`. Note that `&ehooks_default_extent_hooks` is of type `const extent_hooks_t *`. I'm new to the jemalloc code base, but from my current understanding, this is not a correct way to wrap `&ehooks_default_extent_hooks` into an `ehooks_t` (or `ehooks_s`) object. Instead, `ehooks_init(...)` can be used to do so.

This PR adds two test cases for `base_ehooks_get_for_metadata` and suggests a fix for the described segmentation fault. This fix, however, also changes the interface. I am glad to receive feedback about the changes.

To reproduce the segmentation fault, a1e8bf54ff1f01ac5392e4c8387f57ad97f192dd only contains two additional test cases. Test case `test_base_ehooks_get_for_metadata_default_hook` reveals the failure.