### PR TITLE
Fix the time-since computation in HPA.

### DIFF
--- a/include/jemalloc/internal/hpa_hooks.h
+++ b/include/jemalloc/internal/hpa_hooks.h
@@ -9,6 +9,7 @@ struct hpa_hooks_s {
 	void (*hugify)(void *ptr, size_t size);
 	void (*dehugify)(void *ptr, size_t size);
 	void (*curtime)(nstime_t *r_time, bool first_reading);
+	uint64_t (*ms_since)(nstime_t *r_time);
 };
 
 extern hpa_hooks_t hpa_hooks_default;

--- a/include/jemalloc/internal/nstime.h
+++ b/include/jemalloc/internal/nstime.h
@@ -35,6 +35,7 @@ void nstime_isubtract(nstime_t *time, uint64_t subtrahend);
 void nstime_imultiply(nstime_t *time, uint64_t multiplier);
 void nstime_idivide(nstime_t *time, uint64_t divisor);
 uint64_t nstime_divide(const nstime_t *time, const nstime_t *divisor);
+uint64_t nstime_ns_since(const nstime_t *past);
 
 typedef bool (nstime_monotonic_t)(void);
 extern nstime_monotonic_t *JET_MUTABLE nstime_monotonic;

--- a/src/hpa_hooks.c
+++ b/src/hpa_hooks.c
@@ -9,6 +9,7 @@ static void hpa_hooks_purge(void *ptr, size_t size);
 static void hpa_hooks_hugify(void *ptr, size_t size);
 static void hpa_hooks_dehugify(void *ptr, size_t size);
 static void hpa_hooks_curtime(nstime_t *r_nstime, bool first_reading);
+static uint64_t hpa_hooks_ms_since(nstime_t *past_nstime);
 
 hpa_hooks_t hpa_hooks_default = {
 	&hpa_hooks_map,
@@ -17,6 +18,7 @@ hpa_hooks_t hpa_hooks_default = {
 	&hpa_hooks_hugify,
 	&hpa_hooks_dehugify,
 	&hpa_hooks_curtime,
+	&hpa_hooks_ms_since
 };
 
 static void *
@@ -53,4 +55,9 @@ hpa_hooks_curtime(nstime_t *r_nstime, bool first_reading) {
 		nstime_init_zero(r_nstime);
 	}
 	nstime_update(r_nstime);
+}
+
+static uint64_t
+hpa_hooks_ms_since(nstime_t *past_nstime) {
+	return nstime_ns_since(past_nstime) / 1000 / 1000;
 }

--- a/src/nstime.c
+++ b/src/nstime.c
@@ -158,6 +158,19 @@ nstime_divide(const nstime_t *time, const nstime_t *divisor) {
 	return time->ns / divisor->ns;
 }
 
+/* Returns time since *past, w/o updating *past. */
+uint64_t
+nstime_ns_since(const nstime_t *past) {
+	nstime_assert_initialized(past);
+
+	nstime_t now;
+	nstime_copy(&now, past);
+	nstime_update(&now);
+
+	assert(nstime_compare(&now, past) >= 0);
+	return now.ns - past->ns;
+}
+
 #ifdef _WIN32
 #  define NSTIME_MONOTONIC true
 static void

--- a/test/unit/hpa.c
+++ b/test/unit/hpa.c
@@ -1,6 +1,7 @@
 #include "test/jemalloc_test.h"
 
 #include "jemalloc/internal/hpa.h"
+#include "jemalloc/internal/nstime.h"
 
 #define SHARD_IND 111
 
@@ -353,6 +354,11 @@ defer_test_curtime(nstime_t *r_time, bool first_reading) {
 	*r_time = defer_curtime;
 }
 
+static uint64_t
+defer_test_ms_since(nstime_t *past_time) {
+	return (nstime_ns(&defer_curtime) - nstime_ns(past_time)) / 1000 / 1000;
+}
+
 TEST_BEGIN(test_defer_time) {
 	test_skip_if(!hpa_supported());
 
@@ -363,6 +369,7 @@ TEST_BEGIN(test_defer_time) {
 	hooks.hugify = &defer_test_hugify;
 	hooks.dehugify = &defer_test_dehugify;
 	hooks.curtime = &defer_test_curtime;
+	hooks.ms_since = &defer_test_ms_since;
 
 	hpa_shard_opts_t opts = test_hpa_shard_opts_default;
 	opts.deferral_allowed = true;

--- a/test/unit/nstime.c
+++ b/test/unit/nstime.c
@@ -201,6 +201,33 @@ TEST_BEGIN(test_nstime_divide) {
 }
 TEST_END
 
+void
+test_nstime_since_once(nstime_t *t) {
+	nstime_t old_t;
+	nstime_copy(&old_t, t);
+
+	uint64_t ns_since = nstime_ns_since(t);
+	nstime_update(t);
+
+	nstime_t new_t;
+	nstime_copy(&new_t, t);
+	nstime_subtract(&new_t, &old_t);
+
+	expect_u64_ge(nstime_ns(&new_t), ns_since,
+	    "Incorrect time since result");
+}
+
+TEST_BEGIN(test_nstime_ns_since) {
+	nstime_t t;
+
+	nstime_init_update(&t);
+	for (uint64_t i = 0; i < 10000; i++) {
+		/* Keeps updating t and verifies ns_since is valid. */
+		test_nstime_since_once(&t);
+	}
+}
+TEST_END
+
 TEST_BEGIN(test_nstime_monotonic) {
 	nstime_monotonic();
 }
@@ -220,5 +247,6 @@ main(void) {
 	    test_nstime_imultiply,
 	    test_nstime_idivide,
 	    test_nstime_divide,
+	    test_nstime_ns_since,
 	    test_nstime_monotonic);
 }


### PR DESCRIPTION
nstime module guarantees monotonic clock update within a single nstime_t.  This
means, if two separate nstime_t variables are read and updated separately,
nstime_subtract between them may result in underflow.  Fixed by switching to the
time since utility provided by nstime.