### PR TITLE
Add the profiling settings for tests explicit.

### DIFF
--- a/test/unit/hpa_background_thread.c
+++ b/test/unit/hpa_background_thread.c
@@ -104,8 +104,8 @@ expect_purging(unsigned arena_ind, bool expect_deferred) {
 		dallocx(ptr, MALLOCX_TCACHE_NONE);
 		empty_ndirty = get_empty_ndirty(arena_ind);
 		if (expect_deferred) {
-			expect_true(empty_ndirty == 0 || empty_ndirty == 1,
-			    "Unexpected extra dirty page count: %zu",
+			expect_true(empty_ndirty == 0 || empty_ndirty == 1 ||
+			    opt_prof, "Unexpected extra dirty page count: %zu",
 			    empty_ndirty);
 		} else {
 			assert_zu_eq(0, empty_ndirty,

--- a/test/unit/inspect.sh
+++ b/test/unit/inspect.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:false"
+fi

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -368,7 +368,10 @@ TEST_BEGIN(test_tcache_none) {
 	/* Make sure that tcache-based allocation returns p, not q. */
 	void *p1 = mallocx(42, 0);
 	expect_ptr_not_null(p1, "Unexpected mallocx() failure");
-	expect_ptr_eq(p0, p1, "Expected tcache to allocate cached region");
+	if (!opt_prof) {
+		expect_ptr_eq(p0, p1,
+		    "Expected tcache to allocate cached region");
+	}
 
 	/* Clean up. */
 	dallocx(p1, MALLOCX_TCACHE_NONE);
@@ -904,6 +907,7 @@ TEST_BEGIN(test_prof_active) {
 	 * test_mallctl_opt was already enough.
 	 */
 	test_skip_if(!config_prof);
+	test_skip_if(opt_prof);
 
 	bool active, old;
 	size_t len = sizeof(bool);

--- a/test/unit/prof_active.sh
+++ b/test/unit/prof_active.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,prof_thread_active_init:false,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_active:true,prof_thread_active_init:false,lg_prof_sample:0"
 fi

--- a/test/unit/prof_hook.sh
+++ b/test/unit/prof_hook.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0"
 fi
 

--- a/test/unit/prof_log.sh
+++ b/test/unit/prof_log.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0"
 fi

--- a/test/unit/prof_recent.sh
+++ b/test/unit/prof_recent.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_recent_alloc_max:3"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0,prof_recent_alloc_max:3"
 fi

--- a/test/unit/prof_stats.sh
+++ b/test/unit/prof_stats.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_stats:true"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0,prof_stats:true"
 fi

--- a/test/unit/prof_sys_thread_name.sh
+++ b/test/unit/prof_sys_thread_name.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0,prof_sys_thread_name:true"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0,prof_sys_thread_name:true"
 fi

--- a/test/unit/prof_tctx.sh
+++ b/test/unit/prof_tctx.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0"
 fi

--- a/test/unit/safety_check.sh
+++ b/test/unit/safety_check.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "x${enable_prof}" = "x1" ] ; then
-  export MALLOC_CONF="prof:true,lg_prof_sample:0"
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0"
 fi

--- a/test/unit/size_check.sh
+++ b/test/unit/size_check.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:false"
+fi

--- a/test/unit/tcache_max.c
+++ b/test/unit/tcache_max.c
@@ -151,6 +151,7 @@ test_tcache_max_impl(void) {
 TEST_BEGIN(test_tcache_max) {
 	test_skip_if(!config_stats);
 	test_skip_if(!opt_tcache);
+	test_skip_if(opt_prof);
 
 	for (alloc_option = alloc_option_start;
 	     alloc_option < alloc_option_end;


### PR DESCRIPTION
Many profiling related tests make assumptions on the profiling settings,
e.g. opt_prof is off by default, and prof_active is default on when opt_prof is
on.  However the default settings can be changed via --with-malloc-conf at build
time.  Fixing the tests by adding the assumed settings explicitly.

Locally tested with both `prof:true,prof_active:true` and `prof_true,prof_active:false`