### PR TITLE
Prefetch the next object returned by malloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1481,6 +1481,16 @@ if test "x$enable_xmalloc" = "x1" ; then
 fi
 AC_SUBST([enable_xmalloc])
 
+dnl Do not enable prefetching objects by default.
+dnl Because __builtin_prefetch() is used, this is also controlled by __GNUC__.
+AC_ARG_WITH([prefetch-objects],
+  [AS_HELP_STRING([--with-prefetch-objects=<prefetch-objects>],
+   [Number of cache lines to prefetch for allocated objects])])
+if test "x$with_prefetch_objects" = "x" ; then
+  with_prefetch_objects="0"
+fi
+AC_DEFINE_UNQUOTED([JEMALLOC_PREFETCH_OBJECTS], [$with_prefetch_objects], [ ])
+
 dnl Support cache-oblivious allocation alignment by default.
 AC_ARG_ENABLE([cache-oblivious],
   [AS_HELP_STRING([--disable-cache-oblivious],

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -284,7 +284,8 @@ cache_bin_low_water_adjust(cache_bin_t *bin) {
 }
 
 JEMALLOC_ALWAYS_INLINE void *
-cache_bin_alloc_impl(cache_bin_t *bin, bool *success, bool adjust_low_water) {
+cache_bin_alloc_impl(cache_bin_t *bin, bool *success, bool adjust_low_water,
+    size_t size) {
 	/*
 	 * success (instead of ret) should be checked upon the return of this
 	 * function.  We avoid checking (ret == NULL) because there is never a
@@ -307,8 +308,7 @@ cache_bin_alloc_impl(cache_bin_t *bin, bool *success, bool adjust_low_water) {
 	 */
 	if (likely(low_bits != bin->low_bits_low_water)) {
 		bin->stack_head = new_head;
-		*success = true;
-		return ret;
+		goto label_return_succ;
 	}
 	if (!adjust_low_water) {
 		*success = false;
@@ -322,20 +322,56 @@ cache_bin_alloc_impl(cache_bin_t *bin, bool *success, bool adjust_low_water) {
 	if (likely(low_bits != bin->low_bits_empty)) {
 		bin->stack_head = new_head;
 		bin->low_bits_low_water = (uint16_t)(uintptr_t)new_head;
-		*success = true;
-		return ret;
+		goto label_return_succ;
 	}
 	*success = false;
 	return NULL;
+
+label_return_succ:
+	*success = true;
+
+#if JEMALLOC_PREFETCH_OBJECTS > 0 && defined(__GNUC__)
+#define PREFETCH_CACHELINE_AT(ptr, i)                                  \
+	__builtin_prefetch((void *)((uintptr_t)ptr + CACHELINE * i))
+
+	if (likely((uint16_t)(uintptr_t)new_head != bin->low_bits_empty)) {
+		/* Prefetch the object that will be returned next. */
+		if (size <= CACHELINE) {
+			PREFETCH_CACHELINE_AT(*new_head, 0);
+#if JEMALLOC_PREFETCH_OBJECTS > 1
+		} else if (size <= CACHELINE * 2) {
+			void *next = *new_head;
+			PREFETCH_CACHELINE_AT(next, 0);
+			PREFETCH_CACHELINE_AT(next, 1);
+#if JEMALLOC_PREFETCH_OBJECTS > 2
+		} else if (size <= CACHELINE * 4) {
+			void *next = *new_head;
+			PREFETCH_CACHELINE_AT(next, 0);
+			PREFETCH_CACHELINE_AT(next, 1);
+			PREFETCH_CACHELINE_AT(next, 2);
+			PREFETCH_CACHELINE_AT(next, 3);
+#if JEMALLOC_PREFETCH_OBJECTS > 4
+		} else if (size <= CACHELINE * JEMALLOC_PREFETCH_OBJECTS) {
+			void *next = *new_head;
+			for (size_t i = 0; i * CACHELINE < size; ++i)
+				PREFETCH_CACHELINE_AT(next, i);
+#endif
+#endif
+#endif
+		}
+	}
+#undef PREFETCH_CACHELINE_AT
+#endif
+	return ret;
 }
 
 /*
  * Allocate an item out of the bin, failing if we're at the low-water mark.
  */
 JEMALLOC_ALWAYS_INLINE void *
-cache_bin_alloc_easy(cache_bin_t *bin, bool *success) {
+cache_bin_alloc_easy(cache_bin_t *bin, bool *success, size_t size) {
 	/* We don't look at info if we're not adjusting low-water. */
-	return cache_bin_alloc_impl(bin, success, false);
+	return cache_bin_alloc_impl(bin, success, false, size);
 }
 
 /*
@@ -343,8 +379,8 @@ cache_bin_alloc_easy(cache_bin_t *bin, bool *success) {
  * mark (and failing only if the bin is empty).
  */
 JEMALLOC_ALWAYS_INLINE void *
-cache_bin_alloc(cache_bin_t *bin, bool *success) {
-	return cache_bin_alloc_impl(bin, success, true);
+cache_bin_alloc(cache_bin_t *bin, bool *success, size_t size) {
+	return cache_bin_alloc_impl(bin, success, true, size);
 }
 
 JEMALLOC_ALWAYS_INLINE cache_bin_sz_t

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -182,6 +182,9 @@
 /* Support lazy locking (avoid locking unless a second thread is launched). */
 #undef JEMALLOC_LAZY_LOCK
 
+/* Enable prefetching allocated objects. */
+#undef JEMALLOC_PREFETCH_OBJECTS
+
 /*
  * Minimum allocation alignment is 2^LG_QUANTUM bytes (ignoring tiny size
  * classes).

--- a/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -323,12 +323,12 @@ imalloc_fastpath(size_t size, void *(fallback_alloc)(size_t)) {
 	 * don't touch the low water mark.  The compiler won't do this
 	 * duplication on its own.
 	 */
-	ret = cache_bin_alloc_easy(bin, &tcache_success);
+	ret = cache_bin_alloc_easy(bin, &tcache_success, size);
 	if (tcache_success) {
 		fastpath_success_finish(tsd, allocated_after, bin, ret);
 		return ret;
 	}
-	ret = cache_bin_alloc(bin, &tcache_success);
+	ret = cache_bin_alloc(bin, &tcache_success, size);
 	if (tcache_success) {
 		fastpath_success_finish(tsd, allocated_after, bin, ret);
 		return ret;

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -36,7 +36,7 @@ extern tcaches_t	*tcaches;
 
 size_t	tcache_salloc(tsdn_t *tsdn, const void *ptr);
 void	*tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
-    cache_bin_t *tbin, szind_t binind, bool *tcache_success);
+    cache_bin_t *tbin, szind_t binind, bool *tcache_success, size_t size);
 
 void	tcache_bin_flush_small(tsd_t *tsd, tcache_t *tcache, cache_bin_t *tbin,
     szind_t binind, unsigned rem);

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -48,7 +48,7 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 
 	assert(binind < SC_NBINS);
 	cache_bin_t *bin = &tcache->bins[binind];
-	ret = cache_bin_alloc(bin, &tcache_success);
+	ret = cache_bin_alloc(bin, &tcache_success, size);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		bool tcache_hard_success;
@@ -63,7 +63,7 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 		}
 
 		ret = tcache_alloc_small_hard(tsd_tsdn(tsd), arena, tcache,
-		    bin, binind, &tcache_hard_success);
+		    bin, binind, &tcache_hard_success, size);
 		if (tcache_hard_success == false) {
 			return NULL;
 		}
@@ -89,7 +89,7 @@ tcache_alloc_large(tsd_t *tsd, arena_t *arena, tcache_t *tcache, size_t size,
 
 	assert(binind >= SC_NBINS && binind < nhbins);
 	cache_bin_t *bin = &tcache->bins[binind];
-	ret = cache_bin_alloc(bin, &tcache_success);
+	ret = cache_bin_alloc(bin, &tcache_success, size);
 	assert(tcache_success == (ret != NULL));
 	if (unlikely(!tcache_success)) {
 		/*

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -221,7 +221,7 @@ tcache_gc_dalloc_event_handler(tsd_t *tsd, uint64_t elapsed) {
 void *
 tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena,
     tcache_t *tcache, cache_bin_t *cache_bin, szind_t binind,
-    bool *tcache_success) {
+    bool *tcache_success, size_t size) {
 	tcache_slow_t *tcache_slow = tcache->tcache_slow;
 	void *ret;
 
@@ -231,7 +231,7 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena,
 	arena_cache_bin_fill_small(tsdn, arena, cache_bin,
 	    &tcache_bin_info[binind], binind, nfill);
 	tcache_slow->bin_refilled[binind] = true;
-	ret = cache_bin_alloc(cache_bin, tcache_success);
+	ret = cache_bin_alloc(cache_bin, tcache_success, size);
 
 	return ret;
 }

--- a/test/unit/cache_bin.c
+++ b/test/unit/cache_bin.c
@@ -1,5 +1,8 @@
 #include "test/jemalloc_test.h"
 
+/* Object size is for prefeching, irrelevant with other functionalities. */
+#define OBJ_SIZE 128
+
 static void
 do_fill_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
     cache_bin_sz_t ncached_max, cache_bin_sz_t nfill_attempt,
@@ -18,7 +21,7 @@ do_fill_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	cache_bin_low_water_set(bin);
 
 	for (cache_bin_sz_t i = 0; i < nfill_succeed; i++) {
-		ptr = cache_bin_alloc(bin, &success);
+		ptr = cache_bin_alloc(bin, &success, OBJ_SIZE);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, (void *)&ptrs[i],
 		    "Should pop in order filled");
@@ -50,7 +53,7 @@ do_flush_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	expect_true(cache_bin_ncached_get_local(bin, info) == nfill - nflush,
 	    "");
 	while (cache_bin_ncached_get_local(bin, info) > 0) {
-		cache_bin_alloc(bin, &success);
+		cache_bin_alloc(bin, &success, OBJ_SIZE);
 	}
 }
 
@@ -77,7 +80,7 @@ do_batch_alloc_test(cache_bin_t *bin, cache_bin_info_t *info, void **ptrs,
 	    (cache_bin_sz_t)n, "");
 	while (cache_bin_ncached_get_local(bin, info) > 0) {
 		bool success;
-		cache_bin_alloc(bin, &success);
+		cache_bin_alloc(bin, &success, OBJ_SIZE);
 	}
 	free(out);
 }
@@ -109,11 +112,11 @@ TEST_BEGIN(test_cache_bin) {
 	expect_true(cache_bin_ncached_get_local(&bin, &info) == 0, "");
 	expect_true(cache_bin_low_water_get(&bin, &info) == 0, "");
 
-	ptr = cache_bin_alloc_easy(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success, OBJ_SIZE);
 	expect_false(success, "Shouldn't successfully allocate when empty");
 	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
 
-	ptr = cache_bin_alloc(&bin, &success);
+	ptr = cache_bin_alloc(&bin, &success,OBJ_SIZE);
 	expect_false(success, "Shouldn't successfully allocate when empty");
 	expect_ptr_null(ptr, "Shouldn't get a non-null pointer on failure");
 
@@ -147,7 +150,7 @@ TEST_BEGIN(test_cache_bin) {
 		 * This should fail -- the easy variant can't change the low
 		 * water mark.
 		 */
-		ptr = cache_bin_alloc_easy(&bin, &success);
+		ptr = cache_bin_alloc_easy(&bin, &success, OBJ_SIZE);
 		expect_ptr_null(ptr, "");
 		expect_false(success, "");
 		expect_true(cache_bin_low_water_get(&bin, &info)
@@ -156,7 +159,7 @@ TEST_BEGIN(test_cache_bin) {
 		    == ncached_max - i, "");
 
 		/* This should succeed, though. */
-		ptr = cache_bin_alloc(&bin, &success);
+		ptr = cache_bin_alloc(&bin, &success, OBJ_SIZE);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, &ptrs[ncached_max - i - 1],
 		    "Alloc should pop in stack order");
@@ -167,10 +170,10 @@ TEST_BEGIN(test_cache_bin) {
 	}
 	/* Now we're empty -- all alloc attempts should fail. */
 	expect_true(cache_bin_ncached_get_local(&bin, &info) == 0, "");
-	ptr = cache_bin_alloc_easy(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success, OBJ_SIZE);
 	expect_ptr_null(ptr, "");
 	expect_false(success, "");
-	ptr = cache_bin_alloc(&bin, &success);
+	ptr = cache_bin_alloc(&bin, &success, OBJ_SIZE);
 	expect_ptr_null(ptr, "");
 	expect_false(success, "");
 
@@ -189,18 +192,18 @@ TEST_BEGIN(test_cache_bin) {
 		 * Size is bigger than low water -- the reduced version should
 		 * succeed.
 		 */
-		ptr = cache_bin_alloc_easy(&bin, &success);
+		ptr = cache_bin_alloc_easy(&bin, &success, OBJ_SIZE);
 		expect_true(success, "");
 		expect_ptr_eq(ptr, &ptrs[i], "");
 	}
 	/* But now, we've hit low-water. */
-	ptr = cache_bin_alloc_easy(&bin, &success);
+	ptr = cache_bin_alloc_easy(&bin, &success, OBJ_SIZE);
 	expect_false(success, "");
 	expect_ptr_null(ptr, "");
 
 	/* We're going to test filling -- we must be empty to start. */
 	while (cache_bin_ncached_get_local(&bin, &info)) {
-		cache_bin_alloc(&bin, &success);
+		cache_bin_alloc(&bin, &success, OBJ_SIZE);
 		expect_true(success, "");
 	}
 


### PR DESCRIPTION
When small allocations are very frequent, this can speed up accessing
allocated memory. And if that is not the case, the cost is little.

- Added config option `with-prefetch-objects` to control how many cache
  lines to prefetch at most. Objects larger than this amount of cache lines
   are not prefetched.
- By default with-prefetch-objects=0 (disabled).
- __builtin_prefetch() is used.