### PR TITLE
Fix test config of lg_san_uaf_align.

### DIFF
--- a/test/include/test/san.h
+++ b/test/include/test/san.h
@@ -1,3 +1,11 @@
+#if defined(JEMALLOC_UAF_DETECTION) || defined(JEMALLOC_DEBUG)
+#  define TEST_SAN_UAF_ALIGN_ENABLE "lg_san_uaf_align:12"
+#  define TEST_SAN_UAF_ALIGN_DISABLE "lg_san_uaf_align:-1"
+#else
+#  define TEST_SAN_UAF_ALIGN_ENABLE ""
+#  define TEST_SAN_UAF_ALIGN_DISABLE ""
+#endif
+
 static inline bool
 extent_is_guarded(tsdn_t *tsdn, void *ptr) {
 	edata_t *edata = emap_edata_lookup(tsdn, &arena_emap_global, ptr);

--- a/test/unit/tcache_max.c
+++ b/test/unit/tcache_max.c
@@ -1,4 +1,7 @@
 #include "test/jemalloc_test.h"
+#include "test/san.h"
+
+const char *malloc_conf = TEST_SAN_UAF_ALIGN_DISABLE;
 
 enum {
 	alloc_option_start = 0,

--- a/test/unit/tcache_max.sh
+++ b/test/unit/tcache_max.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="tcache_max:1024,lg_san_uaf_align:-1"
+export MALLOC_CONF="tcache_max:1024"

--- a/test/unit/uaf.c
+++ b/test/unit/uaf.c
@@ -1,8 +1,12 @@
 #include "test/jemalloc_test.h"
 #include "test/arena_util.h"
+#include "test/san.h"
 
 #include "jemalloc/internal/cache_bin.h"
+#include "jemalloc/internal/san.h"
 #include "jemalloc/internal/safety_check.h"
+
+const char *malloc_conf = TEST_SAN_UAF_ALIGN_ENABLE;
 
 static size_t san_uaf_align;
 
@@ -28,7 +32,7 @@ test_write_after_free_post(void) {
 
 static bool
 uaf_detection_enabled(void) {
-	if (!config_uaf_detection) {
+	if (!config_uaf_detection || !san_uaf_detection_enabled()) {
 		return false;
 	}
 

--- a/test/unit/uaf.sh
+++ b/test/unit/uaf.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-export MALLOC_CONF="lg_san_uaf_align:12"


### PR DESCRIPTION
The option may be configure-disabled, which resulted in the invalid options
output from the tests.