### PR TITLE
Lower the num_threads in the stress test of test/unit/prof_recent

### DIFF
--- a/test/unit/prof_recent.c
+++ b/test/unit/prof_recent.c
@@ -553,7 +553,7 @@ TEST_END
 #undef DUMP_ERROR
 #undef DUMP_OUT_SIZE
 
-#define N_THREADS 16
+#define N_THREADS 8
 #define N_PTRS 512
 #define N_CTLS 8
 #define N_ITERS 2048


### PR DESCRIPTION
This takes a fair amount of resources.  Under high concurrency it was causing
resource exhaustion such as pthread_create and mmap failures.

The other direction would be, to limit the concurrency of `run_tests.sh`. However the current high concurrency gives us more contention / context switches which are valuable to all tests.