### PR TITLE
use isb instead of yield for spin locks on arm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,10 +427,10 @@ case "${host_cpu}" in
 	HAVE_CPU_SPINWAIT=1
     AC_CACHE_VAL([je_cv_yield],
       [JE_COMPILABLE([yield instruction], [],
-                    [[__asm__ volatile("yield"); return 0;]],
+                    [[__asm__ volatile("isb"); return 0;]],
                     [je_cv_yield])])
 	if test "x${je_cv_yield}" = "xyes" ; then
-	CPU_SPINWAIT='__asm__ volatile("yield")'
+	CPU_SPINWAIT='__asm__ volatile("isb")'
 	fi
     ;;
   *)


### PR DESCRIPTION
In my tests using a micro benchmark, I found that in some cases using the `isb` (instruction synchronization barrier) instead of `yield` can improve allocation performance by 1.3% and free performance by 1.1%. Other projects have seen a similar change, such as [mysql](https://bugs.mysql.com/bug.php?id=100664), [rust](https://github.com/rust-lang/rust/pull/84725), and [wiredtiger](https://github.com/wiredtiger/wiredtiger/pull/6080) have also seen improvement with similar changes.

The idea is that the the `isb` instruction takes longer to execute than a `yield` instruction (which is usually implemented as a no-op) and therefore allows changes to a spin lock flag to propagate, eliminating the need for a slower path such as a futex or other call which results in a context switch.

