### PR TITLE
Initialize prof_leak during prof init.

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1585,7 +1585,7 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 							    "prof_leak_error is"
 							    " not allowed"
 							    " without"
-							    " prof_leak_final",
+							    " prof_final",
 							    k, klen, v, vlen);
 						} else {
 							opt_prof_leak = true;

--- a/src/prof.c
+++ b/src/prof.c
@@ -564,6 +564,9 @@ prof_boot1(void) {
 	 * opt_prof must be in its final state before any arenas are
 	 * initialized, so this function must be executed early.
 	 */
+	if (opt_prof_leak_error && !opt_prof_leak) {
+		opt_prof_leak = true;
+	}
 
 	if (opt_prof_leak && !opt_prof) {
 		/*


### PR DESCRIPTION
Otherwise, prof_leak may get set after prof_leak_error, and disagree with each
other.