### PR TITLE
Properly detect background thread support on Darwin.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2394,7 +2394,8 @@ fi
 dnl ============================================================================
 dnl Enable background threads if possible.
 
-if test "x${have_pthread}" = "x1" -a "x${je_cv_os_unfair_lock}" != "xyes" ; then
+if test "x${have_pthread}" = "x1" -a "x${je_cv_os_unfair_lock}" != "xyes" -a \
+       "x${abi}" != "xmacho" ; then
   AC_DEFINE([JEMALLOC_BACKGROUND_THREAD], [ ], [ ])
 fi
 


### PR DESCRIPTION
When cross-compile, the host type / abi should be checked to determine
background thread compatibility.