### PR TITLE
Do not disable SEC by default for 64k pages platforms

### DIFF
--- a/include/jemalloc/internal/sec_opts.h
+++ b/include/jemalloc/internal/sec_opts.h
@@ -46,7 +46,7 @@ struct sec_opts_s {
 	/* nshards */							\
 	4,								\
 	/* max_alloc */							\
-	32 * 1024,							\
+	(32 * 1024) < PAGE ? PAGE : (32 * 1024),			\
 	/* max_bytes */							\
 	256 * 1024,							\
 	/* bytes_after_flush */						\

--- a/src/sec.c
+++ b/src/sec.c
@@ -23,7 +23,7 @@ sec_bin_init(sec_bin_t *bin) {
 bool
 sec_init(tsdn_t *tsdn, sec_t *sec, base_t *base, pai_t *fallback,
     const sec_opts_t *opts) {
-	assert(opts->max_alloc > 0);
+	assert(opts->max_alloc >= PAGE);
 
 	size_t max_alloc = PAGE_FLOOR(opts->max_alloc);
 	pszind_t npsizes = sz_psz2ind(max_alloc) + 1;


### PR DESCRIPTION
Default SEC max_alloc option value was 32k, disabling SEC for platforms with
lg-page=16. This change enables SEC for all platforms, making minimum max_alloc
value equal to PAGE.