### PR TITLE
Update FreeBSD image to 12.3 for cirrus ci.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ task:
         UNCOMMON_CONFIG: --with-lg-page=16 --with-malloc-conf=tcache:false
   freebsd_instance:
     matrix:
-      image: freebsd-12-2-release-amd64
+      image: freebsd-12-3-release-amd64
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - pkg upgrade -y


### PR DESCRIPTION
Cirrus CI stopped working in #2253 because the 12.2 wasn't supported anymore.