### PR TITLE
PerCPU cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=tcache:false"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes
     - os: freebsd
       arch: amd64
@@ -57,31 +60,73 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --with-lg-page=16 --with-malloc-conf=tcache:false"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug"
     - os: freebsd
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
     - os: freebsd
       arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=tcache:false"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind --enable-cpu-cache"
     - os: freebsd
       arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --with-lg-page=16 --with-malloc-conf=tcache:false"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
     - os: freebsd
       arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false"
     - os: freebsd
       arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
       env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --enable-prof --enable-prof-libunwind --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-debug --with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
+    - os: freebsd
+      arch: amd64
+      env: CC=gcc CXX=g++ CROSS_COMPILE_32BIT=yes CONFIGURE_FLAGS="--enable-prof --enable-prof-libunwind --with-lg-page=16 --with-malloc-conf=tcache:false --enable-cpu-cache"
     - os: linux
       arch: amd64
       env: CC=gcc CXX=g++ EXTRA_CFLAGS="-Werror -Wno-array-bounds"
@@ -109,6 +154,9 @@ jobs:
     - os: linux
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
@@ -142,6 +190,9 @@ jobs:
     - os: linux
       arch: amd64
       env: CC=clang CXX=clang++ CONFIGURE_FLAGS="--with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes"
+    - os: linux
+      arch: amd64
+      env: CC=clang CXX=clang++ CONFIGURE_FLAGS="--enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes"
     - os: linux
       arch: amd64
       env: CC=clang CXX=clang++ CONFIGURE_FLAGS="--with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes"
@@ -201,6 +252,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-debug --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -225,6 +279,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-prof --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -246,6 +303,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-stats --with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-stats --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-stats --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -264,6 +324,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-libdl --with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-libdl --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--disable-libdl --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -279,6 +342,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-opt-safety-checks --with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-opt-safety-checks --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-opt-safety-checks --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -291,6 +357,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-opt-safety-checks --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
@@ -301,6 +370,18 @@ jobs:
     - os: linux
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache --with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache --with-malloc-conf=dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache --with-malloc-conf=percpu_arena:percpu" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache --with-malloc-conf=background_thread:true" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-malloc-conf=tcache:false,dss:primary" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
@@ -373,6 +454,9 @@ jobs:
     - os: osx
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes -Wno-deprecated-declarations"
+    - os: osx
+      arch: amd64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--enable-cpu-cache" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes -Wno-deprecated-declarations"
     - os: osx
       arch: amd64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds -Wno-unknown-warning-option -Wno-ignored-attributes -Wno-deprecated-declarations"

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,7 @@ enable_shared := @enable_shared@
 enable_static := @enable_static@
 enable_prof := @enable_prof@
 enable_zone_allocator := @enable_zone_allocator@
+enable_cpu_cache := @enable_cpu_cache@
 enable_experimental_smallocx := @enable_experimental_smallocx@
 MALLOC_CONF := @JEMALLOC_CPREFIX@MALLOC_CONF
 link_whole_archive := @link_whole_archive@
@@ -156,6 +157,11 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/ticker.c \
 	$(srcroot)src/tsd.c \
 	$(srcroot)src/witness.c
+ifeq ($(enable_cpu_cache), 1)
+C_SRCS += $(srcroot)src/ccache.c
+else
+C_SRCS += $(srcroot)src/ccache_dummy.c
+endif
 ifeq ($(enable_zone_allocator), 1)
 C_SRCS += $(srcroot)src/zone.c
 endif
@@ -291,6 +297,9 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/zero_realloc_free.c \
 	$(srcroot)test/unit/zero_realloc_alloc.c \
 	$(srcroot)test/unit/zero_reallocs.c
+ifeq ($(enable_cpu_cache), 1)
+TESTS_UNIT += $(srcroot)test/unit/ccache.c
+endif
 ifeq (@enable_prof@, 1)
 TESTS_UNIT += \
 	$(srcroot)test/unit/arena_reset_prof.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1611,6 +1611,26 @@ else
   AC_DEFINE([JEMALLOC_INTERNAL_UNREACHABLE], [abort], [ ])
 fi
 
+AC_ARG_ENABLE([cpu-cache],
+  [AS_HELP_STRING([--enable-cpu-cache],
+  [Enable per-CPU cache])],
+[if test "x$enable_cpu_cache" = "xyes" ; then
+  if test "x${host_cpu}" != "xx86_64"; then
+    AC_MSG_ERROR([--enable-cpu-cache is only available for x86_64])
+  fi
+  enable_cpu_cache="1"
+else
+  enable_cpu_cache="0"
+fi
+],
+[enable_cpu_cache="0"]
+)
+AC_CHECK_HEADERS([linux/rseq.h], , [enable_cpu_cache="0"])
+if test "x$enable_cpu_cache" = "x1" ; then
+  AC_DEFINE([JEMALLOC_CPU_CACHE], [ ])
+fi
+AC_SUBST([enable_cpu_cache])
+
 dnl ============================================================================
 dnl Check for  __builtin_ffsl(), then ffsl(3), and fail if neither are found.
 dnl One of those two functions should (theoretically) exist on all platforms

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -7,6 +7,7 @@
 #include "jemalloc/internal/hook.h"
 #include "jemalloc/internal/pages.h"
 #include "jemalloc/internal/stats.h"
+#include "jemalloc/internal/ccache.h"
 
 /*
  * When the amount of pages to be purged exceeds this amount, deferred purge
@@ -60,10 +61,9 @@ uint64_t arena_time_until_deferred(tsdn_t *tsdn, arena_t *arena);
 void arena_do_deferred_work(tsdn_t *tsdn, arena_t *arena);
 void arena_reset(tsd_t *tsd, arena_t *arena);
 void arena_destroy(tsd_t *tsd, arena_t *arena);
-void arena_cache_bin_fill_small(tsdn_t *tsdn, arena_t *arena,
-    cache_bin_t *cache_bin, cache_bin_info_t *cache_bin_info, szind_t binind,
-    const unsigned nfill);
-
+void arena_flush(tsd_t *tsd, arena_t *arena, cache_bin_ptr_array_t *ptrs,
+    szind_t binind, unsigned nflush, cache_bin_stats_t *stats, bool small,
+    bool ccache);
 void *arena_malloc_hard(tsdn_t *tsdn, arena_t *arena, size_t size,
     szind_t ind, bool zero);
 void *arena_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize,
@@ -103,6 +103,8 @@ bool arena_is_huge(unsigned arena_ind);
 arena_t *arena_choose_huge(tsd_t *tsd);
 bin_t *arena_bin_choose(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     unsigned *binshard);
+unsigned arena_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind, void **ptrs,
+    const unsigned nfill, cache_bin_stats_t *stats);
 size_t arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     void **ptrs, size_t nfill, bool zero);
 bool arena_boot(sc_data_t *sc_data, base_t *base, bool hpa);

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -103,8 +103,8 @@ bool arena_is_huge(unsigned arena_ind);
 arena_t *arena_choose_huge(tsd_t *tsd);
 bin_t *arena_bin_choose(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     unsigned *binshard);
-unsigned arena_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind, void **ptrs,
-    const unsigned nfill, cache_bin_stats_t *stats);
+unsigned arena_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind,
+    void **ptrs, const unsigned nfill, cache_bin_stats_t *stats, bool ccache);
 size_t arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     void **ptrs, size_t nfill, bool zero);
 bool arena_boot(sc_data_t *sc_data, base_t *base, bool hpa);

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -293,7 +293,7 @@ arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
 			    slow_path);
 		}
 	} else if (config_cpu_cache && szind < ccache_maxind) {
-		ccache_free(tsdn_tsd(tsdn), ptr, szind, /* small= */ true);
+		ccache_free(tsdn_tsd(tsdn), ptr, szind, /* small= */ false);
 	} else {
 		edata_t *edata = emap_edata_lookup(tsdn, &arena_emap_global,
 		    ptr);

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -10,6 +10,7 @@
 #include "jemalloc/internal/sc.h"
 #include "jemalloc/internal/sz.h"
 #include "jemalloc/internal/ticker.h"
+#include "jemalloc/internal/ccache.h"
 
 static inline arena_t *
 arena_get_from_edata(edata_t *edata) {
@@ -155,8 +156,12 @@ arena_malloc(tsdn_t *tsdn, arena_t *arena, size_t size, szind_t ind, bool zero,
 			return tcache_alloc_large(tsdn_tsd(tsdn), arena,
 			    tcache, size, ind, zero, slow_path);
 		}
-		/* (size > tcache_maxclass) case falls through. */
-		assert(size > tcache_maxclass);
+		if (likely(size <= ccache_maxclass && arena &&
+		    arena_is_auto(arena))) {
+			assert(!tsdn_null(tsdn));
+			return ccache_alloc(tsdn_tsd(tsdn), arena, size, ind,
+			    zero, false);
+		}
 	}
 
 	return arena_malloc_hard(tsdn, arena, size, ind, zero);
@@ -287,6 +292,8 @@ arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
 			tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr, szind,
 			    slow_path);
 		}
+	} else if (config_cpu_cache && szind <= ccache_maxind) {
+		ccache_free(tsdn_tsd(tsdn), ptr, szind, true);
 	} else {
 		edata_t *edata = emap_edata_lookup(tsdn, &arena_emap_global,
 		    ptr);
@@ -305,6 +312,7 @@ arena_dalloc(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	assert(ptr != NULL);
 
 	if (unlikely(tcache == NULL)) {
+		/* If we disable tcache, let's disable CPU cache as well */
 		arena_dalloc_no_tcache(tsdn, ptr);
 		return;
 	}

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -293,7 +293,7 @@ arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
 			    slow_path);
 		}
 	} else if (config_cpu_cache && szind < ccache_maxind) {
-		ccache_free(tsdn_tsd(tsdn), ptr, szind, true);
+		ccache_free(tsdn_tsd(tsdn), ptr, szind, /* small= */ true);
 	} else {
 		edata_t *edata = emap_edata_lookup(tsdn, &arena_emap_global,
 		    ptr);

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -156,8 +156,8 @@ arena_malloc(tsdn_t *tsdn, arena_t *arena, size_t size, szind_t ind, bool zero,
 			return tcache_alloc_large(tsdn_tsd(tsdn), arena,
 			    tcache, size, ind, zero, slow_path);
 		}
-		if (likely(size <= ccache_maxclass && arena &&
-		    arena_is_auto(arena))) {
+		if (likely(config_cpu_cache && size < ccache_maxclass && arena
+		    && arena_is_auto(arena))) {
 			assert(!tsdn_null(tsdn));
 			return ccache_alloc(tsdn_tsd(tsdn), arena, size, ind,
 			    zero, false);
@@ -292,7 +292,7 @@ arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
 			tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr, szind,
 			    slow_path);
 		}
-	} else if (config_cpu_cache && szind <= ccache_maxind) {
+	} else if (config_cpu_cache && szind < ccache_maxind) {
 		ccache_free(tsdn_tsd(tsdn), ptr, szind, true);
 	} else {
 		edata_t *edata = emap_edata_lookup(tsdn, &arena_emap_global,

--- a/include/jemalloc/internal/arena_stats.h
+++ b/include/jemalloc/internal/arena_stats.h
@@ -100,14 +100,27 @@ arena_stats_init(tsdn_t *tsdn, arena_stats_t *arena_stats) {
 }
 
 static inline void
-arena_stats_large_flush_nrequests_add(tsdn_t *tsdn, arena_stats_t *arena_stats,
+arena_stats_large_flush_update_stats(tsdn_t *tsdn, arena_stats_t *arena_stats,
+    szind_t szind, cache_bin_stats_t *tstats, bool add_nrequests) {
+	LOCKEDINT_MTX_LOCK(tsdn, arena_stats->mtx);
+	arena_stats_large_t *lstats = &arena_stats->lstats[szind - SC_NBINS];
+	if (add_nrequests) {
+		assert(tstats);
+		locked_inc_u64(tsdn, LOCKEDINT_MTX(arena_stats->mtx),
+		    &lstats->nrequests, tstats->nrequests);
+	}
+	locked_inc_u64(tsdn, LOCKEDINT_MTX(arena_stats->mtx),
+	    &lstats->nflushes, 1);
+	LOCKEDINT_MTX_UNLOCK(tsdn, arena_stats->mtx);
+}
+
+static inline void
+arena_stats_large_nrequests_add(tsdn_t *tsdn, arena_stats_t *arena_stats,
     szind_t szind, uint64_t nrequests) {
 	LOCKEDINT_MTX_LOCK(tsdn, arena_stats->mtx);
 	arena_stats_large_t *lstats = &arena_stats->lstats[szind - SC_NBINS];
 	locked_inc_u64(tsdn, LOCKEDINT_MTX(arena_stats->mtx),
 	    &lstats->nrequests, nrequests);
-	locked_inc_u64(tsdn, LOCKEDINT_MTX(arena_stats->mtx),
-	    &lstats->nflushes, 1);
 	LOCKEDINT_MTX_UNLOCK(tsdn, arena_stats->mtx);
 }
 

--- a/include/jemalloc/internal/ccache.h
+++ b/include/jemalloc/internal/ccache.h
@@ -25,7 +25,8 @@ uint32_t ccache_nflushes_get();
 uint32_t ccache_nfills_get();
 
 /* Functions operating on TLS */
-void tsd_ccache_init(tsd_t *tsd);
+bool tsd_ccache_init(tsd_t *tsd);
+bool ccache_cleanup(tsd_t *tsd);
 void ccache_merge_tstats(tsdn_t *tsdn);
 
 /* Non thread-safe functions, use only without contention, e.g. in tests */

--- a/include/jemalloc/internal/ccache.h
+++ b/include/jemalloc/internal/ccache.h
@@ -8,8 +8,11 @@
 #include "jemalloc/internal/tsd_types.h"
 #include "jemalloc/internal/base.h"
 
-extern szind_t ccache_maxind;
+extern bool opt_ccache;
+extern size_t opt_ccache_max;
+
 extern szind_t ccache_minind;
+extern szind_t ccache_maxind;
 extern size_t ccache_maxclass;
 
 bool ccache_init(tsdn_t *tsdn, base_t *base);

--- a/include/jemalloc/internal/ccache.h
+++ b/include/jemalloc/internal/ccache.h
@@ -1,0 +1,33 @@
+#ifndef JEMALLOC_INTERNAL_CCACHE_H
+#define JEMALLOC_INTERNAL_CCACHE_H
+
+#include "jemalloc/internal/sz.h"
+#include "jemalloc/internal/pages.h"
+
+#include "jemalloc/internal/arena_types.h"
+#include "jemalloc/internal/tsd_types.h"
+#include "jemalloc/internal/base.h"
+
+extern szind_t ccache_maxind;
+extern szind_t ccache_minind;
+extern size_t ccache_maxclass;
+
+bool ccache_init(tsdn_t *tsdn, base_t *base);
+void* ccache_alloc(tsd_t *tsd, arena_t *arena,
+    size_t size, szind_t ind, bool zero, bool small);
+bool ccache_free(tsd_t *tsd, void *ptr, szind_t ind, bool small);
+
+/* Stats */
+uint32_t ccache_nflushes_get();
+uint32_t ccache_nfills_get();
+
+/* Functions operating on TLS */
+void tsd_ccache_init(tsd_t *tsd);
+void ccache_merge_tstats(tsdn_t *tsdn);
+
+/* Non thread-safe functions, use only without contention, e.g. in tests */
+void ccache_full_flush_unsafe();
+bool ccache_is_empty_unsafe();
+int ccache_ncached_elements_unsafe();
+
+#endif /* JEMALLOC_INTERNAL_CCACHE_H */

--- a/include/jemalloc/internal/ccache_types.h
+++ b/include/jemalloc/internal/ccache_types.h
@@ -13,12 +13,12 @@
 
 #define CCACHE_TDATA_ZERO_INITIALIZER {0}
 
-#define CCACHE_BIN_ELEMENTS ((CACHELINE * 2 - sizeof(void **)) / sizeof(void *))
+#define CCACHE_BIN_ELEMENTS ((CACHELINE * 5 - sizeof(void **)) / sizeof(void *))
 #define CCACHE_LG_MAXCLASS_LIMIT 23 /* 8 MiB */
 #define CCACHE_MAXCLASS_LIMIT ((size_t)1 << CCACHE_LG_MAXCLASS_LIMIT)
 #define CCACHE_NBINS_LIMIT                                                     \
     SC_NBINS + (SC_NGROUP                                                      \
-        * (CCACHE_LG_MAXCLASS_LIMIT - TCACHE_LG_MAXCLASS_LIMIT + 1))
+        * (CCACHE_LG_MAXCLASS_LIMIT - SC_LG_LARGE_MINCLASS + 1))
 
   typedef struct ccache_bin_s ccache_bin_t;
   struct ccache_bin_s {

--- a/include/jemalloc/internal/ccache_types.h
+++ b/include/jemalloc/internal/ccache_types.h
@@ -1,0 +1,57 @@
+#ifndef JEMALLOC_INTERNAL_CCACHE_TYPES_H
+#define JEMALLOC_INTERNAL_CCACHE_TYPES_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include "jemalloc/internal/tcache_types.h"
+#include "jemalloc/internal/atomic.h"
+
+#ifdef JEMALLOC_CPU_CACHE
+  #include <linux/rseq.h>
+  typedef struct rseq rseq_t;
+
+  #define CCACHE_TDATA_ZERO_INITIALIZER {0}
+#else
+  #define CCACHE_TDATA_ZERO_INITIALIZER {}
+#endif
+
+#define CCACHE_BIN_ELEMENTS ((PAGE - sizeof(void **)) / sizeof(void *))
+#define CCACHE_NCLASSES 16
+
+typedef struct ccache_bin_s ccache_bin_t;
+struct ccache_bin_s {
+	void *ccache_bin_entry[CCACHE_BIN_ELEMENTS];
+	void **head;
+};
+
+typedef struct ccache_stats_s ccache_stats_t;
+struct ccache_stats_s {
+	atomic_u32_t nfills;
+	atomic_u32_t nflushes;
+};
+
+typedef struct ccache_s ccache_t;
+struct ccache_s {
+	/* TODO: make ccache_nclasses a runtime option */
+	ccache_bin_t bins[CCACHE_NCLASSES];
+	ccache_stats_t stats;
+};
+
+/*
+ * This is some ccache-specific metadata, which is stored in thread local
+ * storage rather than per-CPU
+ */
+typedef struct ccache_tdata_s ccache_tdata_t;
+struct ccache_tdata_s {
+#ifdef JEMALLOC_CPU_CACHE
+	/*
+	 * When Ccache serves a request, it still needs to maintain the correct
+	 * nrequests arena bin level metric. This data is cached in TSD and
+	 * flushed periodically to the arenas, to avoid taking lock for every
+	 * request.
+	 */
+	cache_bin_stats_t ccache_stats[CCACHE_NCLASSES];
+	rseq_t rseq_abi;
+#endif
+};
+#endif /* JEMALLOC_INTERNAL_CCACHE_TYPES_H */

--- a/include/jemalloc/internal/ccache_types.h
+++ b/include/jemalloc/internal/ccache_types.h
@@ -9,12 +9,9 @@
 #ifdef JEMALLOC_CPU_CACHE
   #include <linux/rseq.h>
   typedef struct rseq rseq_t;
-
-  #define CCACHE_TDATA_ZERO_INITIALIZER {0}
-#else
-  #define CCACHE_TDATA_ZERO_INITIALIZER {}
 #endif
 
+#define CCACHE_TDATA_ZERO_INITIALIZER {0}
 #define CCACHE_BIN_ELEMENTS ((PAGE - sizeof(void **)) / sizeof(void *))
 #define CCACHE_NCLASSES 16
 
@@ -52,6 +49,9 @@ struct ccache_tdata_s {
 	 */
 	cache_bin_stats_t ccache_stats[CCACHE_NCLASSES];
 	rseq_t rseq_abi;
+#else
+	/* C standard doesn't allow empty structs */
+	char dummy_;
 #endif
 };
 #endif /* JEMALLOC_INTERNAL_CCACHE_TYPES_H */

--- a/include/jemalloc/internal/ccache_types.h
+++ b/include/jemalloc/internal/ccache_types.h
@@ -13,7 +13,14 @@
 
 #define CCACHE_TDATA_ZERO_INITIALIZER {0}
 
-#define CCACHE_BIN_ELEMENTS ((CACHELINE * 5 - sizeof(void **)) / sizeof(void *))
+#define CCACHE_BIN_DESIRED_ELEMENTS 200
+
+/* Round up bin size to CACHELINE multiple */
+#define CCACHE_BIN_ELEMENTS                                                    \
+    ((((CCACHE_BIN_DESIRED_ELEMENTS * sizeof(void *) + CACHELINE)              \
+        & ~(CACHELINE - 1))                                                    \
+       - sizeof(void **))                                                      \
+      / sizeof(void *))
 #define CCACHE_LG_MAXCLASS_LIMIT 23 /* 8 MiB */
 #define CCACHE_MAXCLASS_LIMIT ((size_t)1 << CCACHE_LG_MAXCLASS_LIMIT)
 #define CCACHE_NBINS_LIMIT                                                     \

--- a/include/jemalloc/internal/ccache_types.h
+++ b/include/jemalloc/internal/ccache_types.h
@@ -20,8 +20,8 @@
     SC_NBINS + (SC_NGROUP                                                      \
         * (CCACHE_LG_MAXCLASS_LIMIT - SC_LG_LARGE_MINCLASS + 1))
 
-  typedef struct ccache_bin_s ccache_bin_t;
-  struct ccache_bin_s {
+typedef struct ccache_bin_s ccache_bin_t;
+struct ccache_bin_s {
       void *ccache_bin_entry[CCACHE_BIN_ELEMENTS];
       void **head;
 };

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -424,4 +424,7 @@
 /* If defined, realloc(ptr, 0) defaults to "free" instead of "alloc". */
 #undef JEMALLOC_ZERO_REALLOC_DEFAULT_FREE
 
+/* Is jemalloc built with CPU cache support? */
+#undef JEMALLOC_CPU_CACHE
+
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -260,4 +260,12 @@ static const bool have_memcntl =
 #endif
     ;
 
+static const bool config_cpu_cache =
+#ifdef JEMALLOC_CPU_CACHE
+    true
+#else
+    false
+#endif
+    ;
+
 #endif /* JEMALLOC_PREAMBLE_H */

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -68,7 +68,7 @@ tcache_alloc_small(tsd_t *tsd, arena_t *arena, tcache_t *tcache,
 				return NULL;
 			}
 		} else if (config_cpu_cache &&
-		    likely(size < ccache_maxclass && arena_is_auto(arena))) {
+		    likely(binind < ccache_maxind && arena_is_auto(arena))) {
 			/* stats and zero and handled by ccache */
 			return ccache_alloc(tsd, arena, size, binind, zero,
 			    true);

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -154,7 +154,7 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	}
 
 	if (unlikely(tcache_small_bin_disabled(binind, bin))) {
-		if (!config_cpu_cache || binind >= ccache_maxclass ||
+		if (!config_cpu_cache || binind >= ccache_maxind ||
 		    ccache_free(tsd, ptr, binind, /* small= */ true)) {
 			arena_dalloc_small(tsd_tsdn(tsd), ptr);
 		}

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -154,7 +154,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	}
 
 	if (unlikely(tcache_small_bin_disabled(binind, bin))) {
-		if (!config_cpu_cache || !ccache_free(tsd, ptr, binind, true)) {
+		if (!(config_cpu_cache && binind < ccache_maxclass &&
+		    ccache_free(tsd, ptr, binind, /* small */ true))) {
 			arena_dalloc_small(tsd_tsdn(tsd), ptr);
 		}
 	} else if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -154,8 +154,8 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	}
 
 	if (unlikely(tcache_small_bin_disabled(binind, bin))) {
-		if (!(config_cpu_cache && binind < ccache_maxclass &&
-		    ccache_free(tsd, ptr, binind, /* small */ true))) {
+		if (!config_cpu_cache || binind >= ccache_maxclass ||
+		    ccache_free(tsd, ptr, binind, /* small= */ true)) {
 			arena_dalloc_small(tsd_tsdn(tsd), ptr);
 		}
 	} else if (unlikely(!cache_bin_dalloc_easy(bin, ptr))) {

--- a/include/jemalloc/internal/tsd.h
+++ b/include/jemalloc/internal/tsd.h
@@ -14,6 +14,7 @@
 #include "jemalloc/internal/tcache_structs.h"
 #include "jemalloc/internal/util.h"
 #include "jemalloc/internal/witness.h"
+#include "jemalloc/internal/ccache_types.h"
 
 /*
  * Thread-Specific-Data layout
@@ -86,7 +87,8 @@ typedef ql_elm(tsd_t) tsd_link_t;
     O(activity_callback_thunk,	activity_callback_thunk_t,		\
 	activity_callback_thunk_t)					\
     O(tcache_slow,		tcache_slow_t,		tcache_slow_t)	\
-    O(rtree_ctx,		rtree_ctx_t,		rtree_ctx_t)
+    O(rtree_ctx,		rtree_ctx_t,		rtree_ctx_t)    \
+    O(ccache_tdata,		ccache_tdata_t,		ccache_tdata_t)
 
 #define TSD_DATA_SLOW_INITIALIZER					\
     /* tcache_enabled */	TCACHE_ENABLED_ZERO_INITIALIZER,	\
@@ -119,7 +121,8 @@ typedef ql_elm(tsd_t) tsd_link_t;
     /* activity_callback_thunk */					\
 	ACTIVITY_CALLBACK_THUNK_INITIALIZER,				\
     /* tcache_slow */		TCACHE_SLOW_ZERO_INITIALIZER,		\
-    /* rtree_ctx */		RTREE_CTX_INITIALIZER,
+    /* rtree_ctx */		RTREE_CTX_INITIALIZER,			\
+    /* ccache_tdata_t */	CCACHE_TDATA_ZERO_INITIALIZER,
 
 /*  O(name,			type,			nullable type) */
 #define TSD_DATA_FAST							\

--- a/src/arena.c
+++ b/src/arena.c
@@ -924,17 +924,9 @@ arena_bin_choose(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 	return arena_get_bin(arena, binind, binshard);
 }
 
-void
-arena_cache_bin_fill_small(tsdn_t *tsdn, arena_t *arena,
-    cache_bin_t *cache_bin, cache_bin_info_t *cache_bin_info, szind_t binind,
-    const unsigned nfill) {
-	assert(cache_bin_ncached_get_local(cache_bin, cache_bin_info) == 0);
-
-	const bin_info_t *bin_info = &bin_infos[binind];
-
-	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nfill);
-	cache_bin_init_ptr_array_for_fill(cache_bin, cache_bin_info, &ptrs,
-	    nfill);
+unsigned
+arena_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind, void **ptrs,
+    const unsigned nfill, cache_bin_stats_t *stats) {
 	/*
 	 * Bin-local resources are used first: 1) bin->slabcur, and 2) nonfull
 	 * slabs.  After both are exhausted, new slabs will be allocated through
@@ -961,13 +953,14 @@ arena_cache_bin_fill_small(tsdn_t *tsdn, arena_t *arena,
 	 * local exhausted, b) unlock and slab_alloc returns null, c) re-lock
 	 * and bin local fails again.
 	 */
+	const bin_info_t *bin_info = &bin_infos[binind];
+
 	bool made_progress = true;
 	edata_t *fresh_slab = NULL;
 	bool alloc_and_retry = false;
 	unsigned filled = 0;
 	unsigned binshard;
 	bin_t *bin = arena_bin_choose(tsdn, arena, binind, &binshard);
-
 label_refill:
 	malloc_mutex_lock(tsdn, &bin->lock);
 
@@ -980,7 +973,7 @@ label_refill:
 			unsigned cnt = tofill < nfree ? tofill : nfree;
 
 			arena_slab_reg_alloc_batch(slabcur, bin_info, cnt,
-			    &ptrs.ptr[filled]);
+			    &ptrs[filled]);
 			made_progress = true;
 			filled += cnt;
 			continue;
@@ -1018,10 +1011,16 @@ label_refill:
 
 	if (config_stats && !alloc_and_retry) {
 		bin->stats.nmalloc += filled;
-		bin->stats.nrequests += cache_bin->tstats.nrequests;
 		bin->stats.curregs += filled;
 		bin->stats.nfills++;
-		cache_bin->tstats.nrequests = 0;
+		/* We do not flush stats from ccache
+		 * TODO: create a verbose argument to distinguish a call from
+		 * ccache
+		 */
+		if (stats != NULL) {
+			bin->stats.nrequests += stats->nrequests;
+			stats->nrequests = 0;
+		}
 	}
 
 	malloc_mutex_unlock(tsdn, &bin->lock);
@@ -1047,9 +1046,270 @@ label_refill:
 		arena_slab_dalloc(tsdn, arena, fresh_slab);
 		fresh_slab = NULL;
 	}
-
-	cache_bin_finish_fill(cache_bin, cache_bin_info, &ptrs, filled);
 	arena_decay_tick(tsdn, arena);
+	return filled;
+}
+
+static const void *
+tcache_bin_flush_ptr_getter(void *arr_ctx, size_t ind) {
+	cache_bin_ptr_array_t *arr = (cache_bin_ptr_array_t *)arr_ctx;
+	return arr->ptr[ind];
+}
+
+static void
+tcache_bin_flush_metadata_visitor(void *szind_sum_ctx,
+    emap_full_alloc_ctx_t *alloc_ctx) {
+	size_t *szind_sum = (size_t *)szind_sum_ctx;
+	*szind_sum -= alloc_ctx->szind;
+	util_prefetch_write_range(alloc_ctx->edata, sizeof(edata_t));
+}
+
+JEMALLOC_NOINLINE static void
+tcache_bin_flush_size_check_fail(cache_bin_ptr_array_t *arr, szind_t szind,
+    size_t nptrs, emap_batch_lookup_result_t *edatas) {
+	bool found_mismatch = false;
+	for (size_t i = 0; i < nptrs; i++) {
+		szind_t true_szind = edata_szind_get(edatas[i].edata);
+		if (true_szind != szind) {
+			found_mismatch = true;
+			safety_check_fail_sized_dealloc(
+			    /* current_dealloc */ false,
+			    /* ptr */ tcache_bin_flush_ptr_getter(arr, i),
+			    /* true_size */ sz_index2size(true_szind),
+			    /* input_size */ sz_index2size(szind));
+		}
+	}
+	assert(found_mismatch);
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+tcache_bin_flush_match(edata_t *edata, unsigned cur_arena_ind,
+    unsigned cur_binshard, bool small) {
+	if (small) {
+		return edata_arena_ind_get(edata) == cur_arena_ind
+		    && edata_binshard_get(edata) == cur_binshard;
+	} else {
+		return edata_arena_ind_get(edata) == cur_arena_ind;
+	}
+}
+
+static void
+tcache_bin_flush_edatas_lookup(tsd_t *tsd, cache_bin_ptr_array_t *arr,
+    szind_t binind, size_t nflush, emap_batch_lookup_result_t *edatas) {
+
+	/*
+	 * This gets compiled away when config_opt_safety_checks is false.
+	 * Checks for sized deallocation bugs, failing early rather than
+	 * corrupting metadata.
+	 */
+	size_t szind_sum = binind * nflush;
+	emap_edata_lookup_batch(tsd, &arena_emap_global, nflush,
+	    &tcache_bin_flush_ptr_getter, (void *)arr,
+	    &tcache_bin_flush_metadata_visitor, (void *)&szind_sum,
+	    edatas);
+	if (config_opt_safety_checks && unlikely(szind_sum != 0)) {
+		tcache_bin_flush_size_check_fail(arr, binind, nflush, edatas);
+	}
+}
+
+void
+arena_flush(tsd_t *tsd, arena_t *arena, cache_bin_ptr_array_t *ptrs,
+    szind_t binind, unsigned nflush, cache_bin_stats_t *stats, bool small,
+    bool ccache) {
+	/* Arena is the one where we'll merge our stats */
+	assert(arena != NULL);
+	/*
+	 * A couple lookup calls take tsdn; declare it once for convenience
+	 * instead of calling tsd_tsdn(tsd) all the time.
+	 */
+	tsdn_t *tsdn = tsd_tsdn(tsd);
+
+	if (small) {
+		assert(binind < SC_NBINS);
+	} else {
+		assert(binind < nhbins || (ccache && binind <= ccache_maxind));
+	}
+
+	/*
+	 * Variable length array must have > 0 length; the last element is never
+	 * touched (it's just included to satisfy the no-zero-length rule).
+	 */
+	VARIABLE_ARRAY(emap_batch_lookup_result_t, item_edata, nflush + 1);
+	tcache_bin_flush_edatas_lookup(tsd, ptrs, binind, nflush, item_edata);
+
+	/*
+	 * The slabs where we freed the last remaining object in the slab (and
+	 * so need to free the slab itself).
+	 * Used only if small == true.
+	 */
+	unsigned dalloc_count = 0;
+	VARIABLE_ARRAY(edata_t *, dalloc_slabs, nflush + 1);
+
+	/*
+	 * We're about to grab a bunch of locks.  If one of them happens to be
+	 * the one guarding the arena-level stats counters we flush our
+	 * thread-local ones to, we do so under one critical section.
+	 */
+	bool merged_stats = false;
+	while (nflush > 0) {
+		/* Lock the arena, or bin, associated with the first object. */
+		edata_t *edata = item_edata[0].edata;
+		unsigned cur_arena_ind = edata_arena_ind_get(edata);
+		arena_t *cur_arena = arena_get(tsdn, cur_arena_ind, false);
+
+		/*
+		 * These assignments are always overwritten when small is true,
+		 * and their values are always ignored when small is false, but
+		 * to avoid the technical UB when we pass them as parameters, we
+		 * need to intialize them.
+		 */
+		unsigned cur_binshard = 0;
+		bin_t *cur_bin = NULL;
+		if (small) {
+			cur_binshard = edata_binshard_get(edata);
+			cur_bin = arena_get_bin(cur_arena, binind,
+			    cur_binshard);
+			assert(cur_binshard < bin_infos[binind].n_shards);
+			/*
+			 * If you're looking at profiles, you might think this
+			 * is a good place to prefetch the bin stats, which are
+			 * often a cache miss.  This turns out not to be
+			 * helpful on the workloads we've looked at, with moving
+			 * the bin stats next to the lock seeming to do better.
+			 */
+		}
+
+		if (small) {
+			malloc_mutex_lock(tsdn, &cur_bin->lock);
+		}
+		if (!small && !arena_is_auto(cur_arena)) {
+			malloc_mutex_lock(tsdn, &cur_arena->large_mtx);
+		}
+
+		/*
+		 * If we acquired the right lock and have some stats to flush,
+		 * flush them.
+		 */
+		if (config_stats && arena == cur_arena && !merged_stats) {
+			merged_stats = true;
+			/* TODO: refactor !ccache case */
+			if (small) {
+				cur_bin->stats.nflushes++;
+				if (!ccache) {
+					cur_bin->stats.nrequests += stats->nrequests;
+				}
+			} else {
+				arena_stats_large_flush_update_stats(tsdn,
+				    &arena->stats, binind, stats, !ccache);
+			}
+			if (!ccache) {
+				stats->nrequests = 0;
+			}
+		}
+
+		/*
+		 * Large allocations need special prep done.  Afterwards, we can
+		 * drop the large lock.
+		 */
+		if (!small) {
+			for (unsigned i = 0; i < nflush; i++) {
+				void *ptr = ptrs->ptr[i];
+				edata = item_edata[i].edata;
+				assert(ptr != NULL && edata != NULL);
+
+				if (tcache_bin_flush_match(edata, cur_arena_ind,
+				    cur_binshard, small)) {
+					large_dalloc_prep_locked(tsdn,
+					    edata);
+				}
+			}
+		}
+		if (!small && !arena_is_auto(cur_arena)) {
+			malloc_mutex_unlock(tsdn, &cur_arena->large_mtx);
+		}
+
+		/* Deallocate whatever we can. */
+		unsigned ndeferred = 0;
+		/* Init only to avoid used-uninitialized warning. */
+		arena_dalloc_bin_locked_info_t dalloc_bin_info = {0};
+		if (small) {
+			arena_dalloc_bin_locked_begin(&dalloc_bin_info, binind);
+		}
+		for (unsigned i = 0; i < nflush; i++) {
+			void *ptr = ptrs->ptr[i];
+			edata = item_edata[i].edata;
+			assert(ptr != NULL && edata != NULL);
+			if (!tcache_bin_flush_match(edata, cur_arena_ind,
+			    cur_binshard, small)) {
+				/*
+				 * The object was allocated either via a
+				 * different arena, or a different bin in this
+				 * arena.  Either way, stash the object so that
+				 * it can be handled in a future pass.
+				 */
+				ptrs->ptr[ndeferred] = ptr;
+				item_edata[ndeferred].edata = edata;
+				ndeferred++;
+				continue;
+			}
+			if (small) {
+				if (arena_dalloc_bin_locked_step(tsdn,
+				    cur_arena, cur_bin, &dalloc_bin_info,
+				    binind, edata, ptr)) {
+					dalloc_slabs[dalloc_count] = edata;
+					dalloc_count++;
+				}
+			} else {
+				if (large_dalloc_safety_checks(edata, ptr,
+				    binind)) {
+					/* See the comment in isfree. */
+					continue;
+				}
+				large_dalloc_finish(tsdn, edata);
+			}
+		}
+
+		if (small) {
+			arena_dalloc_bin_locked_finish(tsdn, cur_arena, cur_bin,
+			    &dalloc_bin_info);
+			malloc_mutex_unlock(tsdn, &cur_bin->lock);
+		}
+		arena_decay_ticks(tsdn, cur_arena, nflush - ndeferred);
+		nflush = ndeferred;
+	}
+
+	/* Handle all deferred slab dalloc. */
+	assert(small || dalloc_count == 0);
+	for (unsigned i = 0; i < dalloc_count; i++) {
+		edata_t *slab = dalloc_slabs[i];
+		arena_slab_dalloc(tsdn, arena_get_from_edata(slab), slab);
+
+	}
+
+	if (config_stats && !merged_stats) {
+		/*
+		 * The flush loop didn't happen to flush to this
+		 * thread's arena, so the stats didn't get merged.
+		 * Manually do so now.
+		 */
+		if (small) {
+			bin_t *bin = arena_bin_choose(tsdn, arena,
+			    binind, NULL);
+			malloc_mutex_lock(tsdn, &bin->lock);
+			bin->stats.nflushes++;
+			if (!ccache) {
+				bin->stats.nrequests += stats->nrequests;
+			}
+			malloc_mutex_unlock(tsdn, &bin->lock);
+		} else {
+			arena_stats_large_flush_update_stats(tsdn,
+			    &arena->stats, binind, stats, !ccache);
+		}
+		if (!ccache) {
+			stats->nrequests = 0;
+		}
+	}
+
 }
 
 size_t
@@ -1286,6 +1546,10 @@ arena_dalloc_promoted(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	if (bumped_usize <= tcache_maxclass && tcache != NULL) {
 		tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr,
 		    sz_size2index(bumped_usize), slow_path);
+	} else if (config_cpu_cache && bumped_usize <= ccache_maxclass
+	    && tcache != NULL) {
+		ccache_free(tsdn_tsd(tsdn), ptr, sz_size2index(bumped_usize),
+		    /* small= */ false);
 	} else {
 		large_dalloc(tsdn, edata);
 	}

--- a/src/arena.c
+++ b/src/arena.c
@@ -1127,7 +1127,7 @@ arena_flush(tsd_t *tsd, arena_t *arena, cache_bin_ptr_array_t *ptrs,
 	if (small) {
 		assert(binind < SC_NBINS);
 	} else {
-		assert(binind < nhbins || (ccache && binind <= ccache_maxind));
+		assert(binind < nhbins || (ccache && binind < ccache_maxind));
 	}
 
 	/*
@@ -1546,7 +1546,7 @@ arena_dalloc_promoted(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	if (bumped_usize <= tcache_maxclass && tcache != NULL) {
 		tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr,
 		    sz_size2index(bumped_usize), slow_path);
-	} else if (config_cpu_cache && bumped_usize <= ccache_maxclass
+	} else if (config_cpu_cache && bumped_usize < ccache_maxclass
 	    && tcache != NULL) {
 		ccache_free(tsdn_tsd(tsdn), ptr, sz_size2index(bumped_usize),
 		    /* small= */ false);

--- a/src/arena.c
+++ b/src/arena.c
@@ -1546,10 +1546,12 @@ arena_dalloc_promoted(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	if (bumped_usize <= tcache_maxclass && tcache != NULL) {
 		tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr,
 		    sz_size2index(bumped_usize), slow_path);
-	} else if (config_cpu_cache && bumped_usize < ccache_maxclass
+	} else if (config_cpu_cache && bumped_usize <= ccache_maxclass
 	    && tcache != NULL) {
-		ccache_free(tsdn_tsd(tsdn), ptr, sz_size2index(bumped_usize),
-		    /* small= */ false);
+		if (ccache_free(tsdn_tsd(tsdn), ptr,
+		    sz_size2index(bumped_usize), /* small= */ false)) {
+			large_dalloc(tsdn, edata);
+		}
 	} else {
 		large_dalloc(tsdn, edata);
 	}

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -215,11 +215,17 @@ ccache_alloc(tsd_t *tsd, arena_t *arena, size_t size, szind_t ind,
     bool zero, bool small) {
 	assert(opt_ccache);
 	assert(ccache_handles_szind(ind));
+
+	arena = arena_choose(tsd, arena);
 	/*
 	 * Ccache is disabled for manual arenas due to difficulties handling
 	 * arena reset.
 	 */
 	assert(arena_is_auto(arena));
+
+	if (unlikely(arena == NULL)) {
+		return NULL;
+	}
 
 	void *ret = NULL;
 	volatile rseq_t *rseq_abi = &tsd_ccache_tdatap_get(tsd)->rseq_abi;

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -1,0 +1,593 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/ccache.h"
+
+#include "jemalloc/internal/base.h"
+#include "jemalloc/internal/arena_externs.h"
+#include "jemalloc/internal/cache_bin.h"
+
+#include <linux/rseq.h>
+
+#define JEMALLOC_RSEQ_SIG 0x80088008
+
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
+
+/* TODO: Change to configure option */
+static const size_t ccached_nclasses = CCACHE_NCLASSES;
+
+/* Beware of the init order, it must be assigned before ccache_init call */
+extern unsigned ncpus;
+
+szind_t ccache_minind;
+szind_t ccache_maxind;
+
+size_t ccache_maxclass;
+
+static size_t ccache_bin_size;
+static size_t ccache_size;
+
+static ccache_t *ccache_base;
+
+static bool
+ccache_handles_szind(szind_t ind) {
+	return ccache_minind <= ind && ind <= ccache_maxind;
+}
+
+static unsigned
+ccache_bin_capacity() {
+	return CCACHE_BIN_ELEMENTS;
+}
+
+static bool
+ccache_bin_empty(ccache_bin_t *bin) {
+	return bin->head == (void**)&bin->head;
+}
+
+static bool
+ccache_bin_locked(ccache_bin_t *bin) {
+	return bin->head == NULL;
+}
+
+static unsigned
+ccache_bin_ncached_elements(ccache_bin_t *bin) {
+	unsigned res = (unsigned)((uintptr_t)(&bin->head) -
+	    (uintptr_t)(bin->head)) / sizeof(void*);
+	assert(res <= ccache_bin_capacity());
+	return res;
+}
+
+static ccache_t *
+ccache_get(int cpu) {
+	return &ccache_base[cpu];
+}
+
+static ccache_bin_t *
+ccache_bin_get(ccache_t *c, szind_t ind) {
+	assert(ccache_handles_szind(ind));
+	return &c->bins[ind - ccache_minind];
+}
+
+static void *
+ccache_bin_finish_fill(ccache_bin_t *bin, cache_bin_ptr_array_t *arr,
+    cache_bin_sz_t nfilled) {
+	unsigned dest_index = arr->n - nfilled;
+	if (nfilled < arr->n) {
+		memmove(arr->ptr + dest_index, arr->ptr,
+		    nfilled * sizeof(void *));
+	}
+	void *allocated = arr->ptr[dest_index];
+	__asm__ __volatile__ ("" ::: "memory" );
+	bin->head = &arr->ptr[dest_index + 1];
+	return allocated;
+}
+
+/* Refills half of the bin */
+static void *
+ccache_bin_refill(tsd_t *tsd, ccache_t *ccache, ccache_bin_t *bin,
+    arena_t *arena, szind_t binind, bool small) {
+	const unsigned nfill = CCACHE_BIN_ELEMENTS / 2 + 1;
+	assert(ccache_bin_locked(bin));
+	assert(small);
+	/*
+	 * Here we can already be on a different CPU, i.e. rseq_abi->cpu might
+	 * be different from 'cpu' argument. But there's no race, as the
+	 * critical section assigns 0 to head, making all following allocations
+	 * on the same CPU go down the slow path.
+	 */
+
+	atomic_fetch_add_u32(&ccache->stats.nfills, 1,
+	    atomic_memory_order_relaxed);
+
+	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nfill);
+	ptrs.ptr = &bin->ccache_bin_entry[CCACHE_BIN_ELEMENTS - nfill];
+
+	unsigned nfilled = arena_fill_small(tsd_tsdn(tsd), arena, binind,
+	    ptrs.ptr, nfill, NULL);
+	return ccache_bin_finish_fill(bin, &ptrs, nfilled);
+}
+
+/* Flushes half of the bin */
+static bool
+ccache_bin_flush(tsd_t *tsd, ccache_t *ccache, ccache_bin_t *bin,
+    arena_t *arena, szind_t binind, void *ptr, bool small) {
+	const unsigned nflush = CCACHE_BIN_ELEMENTS / 2;
+	assert(ccache_bin_locked(bin));
+
+	atomic_fetch_add_u32(&ccache->stats.nflushes, 1,
+	    atomic_memory_order_relaxed);
+
+	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nflush);
+	/* 
+	 * TODO: tcache is flushed differently - 'oldest' ptrs are flushed and
+	 * the rest is memmoved to the beginning of the bin. It helps first fit,
+	 * apparently. Here I pick the easiest way - flush the 'top' half
+	 * (leftmost in the address space). Other policies should be tested as
+	 * well.
+	 */
+	ptrs.ptr = bin->ccache_bin_entry;
+
+	arena_flush(tsd, arena, &ptrs, binind, nflush, NULL, small,
+	    /* ccache = */ true);
+
+	bin->ccache_bin_entry[nflush - 1] = ptr;
+	__asm__ __volatile__ ("" ::: "memory" );
+	bin->head = &bin->ccache_bin_entry[nflush - 1];
+
+	/* TODO: re-consider return true or false on success. This caused a bug
+	 * becuase the return value was forwarded by ccache_free, which should
+	 * return true on success, but this was returning 'false'
+	 */
+	return true;
+}
+
+static void
+ccache_bin_full_flush_unsafe(tsd_t *tsd, ccache_bin_t *bin, szind_t binind,
+    bool small) {
+	const unsigned nflush = ccache_bin_ncached_elements(bin);
+
+	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nflush);
+	ptrs.ptr = &bin->ccache_bin_entry[CCACHE_BIN_ELEMENTS - nflush];
+
+	arena_flush(tsd, *tsd_arenap_get(tsd), &ptrs, binind, nflush, NULL,
+	    small, true);
+
+	bin->head = (void *)&bin->head;
+}
+
+static inline cache_bin_stats_t *
+ccache_bin_tstats_get(tsd_t *tsd, szind_t binind) {
+	assert(binind >= ccache_minind);
+	return &tsd_ccache_tdatap_get(tsd)->ccache_stats[binind - ccache_minind];
+}
+
+static void
+ccache_bump_tstats(tsd_t *tsd, szind_t binind) {
+	cache_bin_stats_t *stats = ccache_bin_tstats_get(tsd, binind);
+	++stats->nrequests;
+}
+
+/* Depends on booted tcache */
+bool
+ccache_init(tsdn_t *tsdn, base_t *base) {
+	assert(ncpus > 0);
+
+	ccache_minind = sz_size2index(tcache_maxclass) + 1;
+	ccache_maxind = ccache_minind + ccached_nclasses - 1;
+	ccache_maxclass = sz_index2size(ccache_maxind);
+	ccache_bin_size = PAGE;
+	ccache_size = sizeof(ccache_t) * ncpus;
+	ccache_base = (ccache_t*)base_alloc(tsdn, base, ccache_size,
+	    PAGE);
+	if (ccache_base == NULL) {
+		return true;
+	}
+	for (unsigned i = 0; i < ncpus; ++i) {
+		ccache_t *ith_cache = &ccache_base[i];
+		for (unsigned j = 0; j < ccached_nclasses; ++j) {
+			ccache_bin_t *bin = &ith_cache->bins[j];
+			bin->head = (void **)&bin->head;
+		}
+	}
+
+	return false;
+}
+
+void*
+ccache_alloc(tsd_t *tsd, arena_t *arena, size_t size, szind_t ind,
+    bool zero, bool small) {
+	/*
+	 * Ccache is disabled for manual arenas due to difficulties handling
+	 * arena reset.
+	 */
+	assert(arena_is_auto(arena));
+
+	void *ret = NULL;
+	volatile rseq_t *rseq_abi = &tsd_ccache_tdatap_get(tsd)->rseq_abi;
+	ccache_t *ccache;
+	ccache_bin_t *bin;
+	/*
+	 * No need to zero initialize these flags.
+	 * If fallback, sete will set 'fallback_flag' to 1, 'refill_flag' is
+	 * never read.
+	 * If refill, sete will set 'fallback_flag' to 0, and setne will set
+	 * 'refill_flag' to 1.
+	 */
+	bool fallback_flag, refill_flag;
+#ifdef JEMALLOC_DEBUG
+	int cpu;
+	int spins = 0;
+#endif
+
+	size_t bin_offset = (ind - ccache_minind) * sizeof(ccache_bin_t);
+
+	__asm__ __volatile__(
+	    /* aw == Allocatable and writable section */
+	    ".pushsection __rseq_table, \"aw\"\n\t"
+	    ".balign 32\n\t"
+	    "cs_obj_ccache_alloc:\n\t"
+	    /* rseq_cs.version rseq_cs.flags */
+	    ".long 0, 0\n\t"
+	    /* rseq_cs.start_ip rseq_cs.post_commit_offset rseq_cs.abort_ip */
+	    ".quad rseq_cs_start%=, rseq_cs_postcommit%= - rseq_cs_start%=, rseq_cs_abort%=\n\t"
+	    ".popsection\n\t"
+
+	    "restart%=:\n\t"
+#ifdef JEMALLOC_DEBUG
+	    "incl %[spins]\n\t"
+#endif
+	    /* Set the critical section pointer */
+	    "leaq cs_obj_ccache_alloc(%%rip), %%rax\n\t"
+	    "movq %%rax, %c[rseq_cs_offset](%[rseq_abi])\n\t"
+
+	    /* -------------------- Begin ------------------- */
+	    "rseq_cs_start%=:\n\t"
+	    /* Get CPU id, ccache and bin pointers */
+	    "movl %c[cpuid_offset](%[rseq_abi]), %%eax\n\t"
+#ifdef JEMALLOC_DEBUG
+	    "movl %%eax, %[cpu]\n\t"
+#endif
+	    "imulq $%c[sizeof_ccache_t], %%rax, %%rax\n\t"
+	    "addq %[ccache_base], %%rax\n\t"
+	    "movq %%rax, %[ccache]\n\t"
+	    "leaq (%%rax, %[bin_offset]), %[bin]\n\t"
+
+	    /* Read head value, decide between fallback, refill or alloc */
+	    "movq %c[head_offset](%[bin]), %%rax\n\t"
+	    /*
+	     * If head == 0, another thread has put the bin into fallback mode.
+	     * Set fallback flag and leave the critical section
+	     */
+	    "testq %%rax, %%rax\n\t"
+	    "sete %[fallback_flag]\n\t"
+	    "je rseq_cs_postcommit%=\n\t"
+
+	    /* If the bin is empty, then put into fallback mode and refill */
+	    "cmpq %%rax, (%%rax)\n\t"
+	    "sete %[refill_flag]\n\t"
+	    "je refill_needed%=\n\t"
+	    /* Store allocation in ret and preapare head++ */
+	    "movq (%%rax), %[ret]\n\t"
+	    "addq $8, %%rax\n\t"
+	    "jmp commit%=\n\t"
+
+	    "refill_needed%=:\n\t"
+	    /* Prepare head = 0 */
+	    "xorl %%eax, %%eax\n\t"
+
+	    /* Commit head++ or head = 0 and exit CS */
+	    "commit%=:\n\t"
+	    "movq %%rax, %c[head_offset](%[bin])\n\t"
+
+	    /* ------------------- End ------------------- */
+	    "rseq_cs_postcommit%=:\n\t"
+
+	    /* ax == Allocatable and executable section */
+	    ".pushsection __rseq_abort, \"ax\"\n\t"
+	    ".byte 0x0f, 0x1f, 0x05\n\t"
+	    ".long "STRINGIFY(JEMALLOC_RSEQ_SIG)"\n\t"
+	    "rseq_cs_abort%=:\n\t"
+	    /*
+	     * Spin in case of abort - re-fetch per-cpu cache for the updated
+	     * CPU value in rseq_abi and retry.
+	     */
+	    "jmp restart%=\n\t"
+	    ".popsection\n\t"
+
+	    : [ret] "=&r" (ret),
+	      [fallback_flag] "=&r" (fallback_flag),
+	      [refill_flag] "=&r" (refill_flag),
+	      [bin] "=&r" (bin),
+	      [ccache] "=&r" (ccache)
+#ifdef JEMALLOC_DEBUG
+	      , [cpu] "=m" (cpu),
+	      [spins] "=m" (spins)
+#endif
+	    : [bin_offset] "r" (bin_offset),
+	      [head_offset] "i" (offsetof(ccache_bin_t, head)),
+	      [cpuid_offset] "i" (offsetof(rseq_t, cpu_id)),
+	      [rseq_cs_offset] "i" (offsetof(rseq_t, rseq_cs)),
+	      [sizeof_ccache_t] "i" (sizeof(ccache_t)),
+	      [rseq_abi] "r" (rseq_abi),
+	      [ccache_base] "rm" (ccache_base)
+	    : "rax", "cc", "memory"
+	);
+#ifdef JEMALLOC_DEBUG
+	assert(spins > 0);
+	assert(ccache_get(cpu) == ccache);
+	assert(ccache_bin_get(ccache_get(cpu), ind) == bin);
+#endif
+	if (unlikely(fallback_flag)) {
+		goto fallback;
+	}
+	if (unlikely(refill_flag)) {
+		assert(bin->head == NULL);
+		/*
+		 * At this point, we're in the refill/flush mode. This thread is
+		 * the owner of the refill, other threads willing to draw values
+		 * from 'cpu' will jump to fallback label and return NULL.
+		 */
+		if (small) {
+			ret =
+			    ccache_bin_refill(tsd, ccache, bin, arena,
+				ind, small);
+		} else {
+			/*
+			 * Do not refill if large size class; transfer to the 
+			 * empty state. Arena will handle zero and stats.
+			 */
+			bin->head = (void **)&bin->head;
+fallback:
+			return arena_malloc_hard(tsd_tsdn(tsd), arena, size,
+			    ind, zero);
+		}
+	}
+	assert(ret != NULL);
+	if (unlikely(zero)) {
+		size_t usize = sz_index2size(ind);
+		assert(tcache_salloc(tsd_tsdn(tsd), ret) == usize);
+		memset(ret, 0, usize);
+	}
+	ccache_bump_tstats(tsd, ind);
+
+	return ret;
+}
+
+bool
+ccache_free(tsd_t *tsd, void *ptr, szind_t ind, bool small) {
+	if (!ccache_handles_szind(ind)) {
+		return false;
+	}
+	edata_t *edata = emap_edata_lookup(tsd_tsdn(tsd),
+	    &arena_emap_global, ptr);
+	arena_t *origin_arena = arena_get_from_edata(edata);
+	if (!arena_is_auto(origin_arena)) {
+		return false;
+	}
+	volatile rseq_t *rseq_abi = &tsd_ccache_tdatap_get(tsd)->rseq_abi;
+	ccache_t *ccache;
+	ccache_bin_t *bin;
+#ifdef JEMALLOC_DEBUG
+	int cpu;
+	int spins = 0;
+#endif
+	bool fallback_flag, flush_flag;
+
+	size_t bin_offset = (ind - ccache_minind) * sizeof(ccache_bin_t);
+
+	__asm__ __volatile__(
+	    /* aw == Allocatable and writable section */
+	    ".pushsection __rseq_table, \"aw\"\n\t"
+	    ".balign 32\n\t"
+	    "cs_obj_ccache_free:\n\t"
+	    /* rseq_cs.version rseq_cs.flags */
+	    ".long 0, 0\n\t"
+	    /* rseq_cs.start_ip rseq_cs.post_commit_offset rseq_cs.abort_ip */
+	    ".quad rseq_cs_start%=, rseq_cs_postcommit%= - rseq_cs_start%=, rseq_cs_abort%=\n\t"
+	    ".popsection\n\t"
+
+	    "restart%=:\n\t"
+#ifdef JEMALLOC_DEBUG
+	    "incl %[spins]\n\t"
+#endif
+	    /* Set the critical section pointer */
+	    "leaq cs_obj_ccache_free(%%rip), %%rax\n\t"
+	    "movq %%rax, %c[rseq_cs_offset](%[rseq_abi])\n\t"
+
+	    /* -------------------- Begin ------------------- */
+	    "rseq_cs_start%=:\n\t"
+	    /* Get CPU id, ccache and bin pointers */
+	    "movl %c[cpuid_offset](%[rseq_abi]), %%eax\n\t"
+#ifdef JEMALLOC_DEBUG
+	    "movl %%eax, %[cpu]\n\t"
+#endif
+	    "imulq $%c[sizeof_ccache_t], %%rax, %%rax\n\t"
+	    "addq %[ccache_base], %%rax\n\t"
+	    "movq %%rax, %[ccache]\n\t"
+	    "leaq (%%rax, %[bin_offset]), %[bin]\n\t"
+
+	    /* rax = head */
+	    "movq %c[head_offset](%[bin]), %%rax\n\t"
+	    /* Check if in fallback mode, then fallback */
+	    "testq %%rax, %%rax\n\t"
+	    "sete %[fallback_flag]\n\t"
+	    "je rseq_cs_postcommit%=\n\t"
+	    /* Check if the bin is full, then flush  */
+	    "cmpq %%rax, %[bin]\n\t"
+	    "sete %[flush_flag]\n\t"
+	    "je flush_needed%=\n\t"
+	    /* Prepare head-- */
+	    "subq $8, %%rax\n\t"
+	    "movq %[ptr], (%%rax)\n\t"
+	    "jmp commit%=\n\t"
+
+	    "flush_needed%=:\n\t"
+	    /* Prepare head = 0 */
+	    "xorl %%eax, %%eax\n\t"
+	    /* Commit either head-- or head = 0 */
+	    "commit%=:\n\t"
+	    "movq %%rax, %c[head_offset](%[bin])\n\t"
+
+	    /* ------------------- End ------------------- */
+	    "rseq_cs_postcommit%=:\n\t"
+
+	    /* ax == Allocatable and executable section */
+	    ".pushsection __rseq_abort, \"ax\"\n\t"
+	    ".byte 0x0f, 0x1f, 0x05\n\t"
+	    ".long "STRINGIFY(JEMALLOC_RSEQ_SIG)"\n\t"
+	    "rseq_cs_abort%=:\n\t"
+	    "jmp restart%=\n\t"
+	    ".popsection\n\t"
+	    : [fallback_flag] "=&r" (fallback_flag),
+	      [flush_flag] "=&r" (flush_flag),
+	      [bin] "=&r" (bin),
+	      [ccache] "=&r" (ccache)
+#ifdef JEMALLOC_DEBUG
+	      , [cpu] "=m" (cpu),
+	      [spins] "=m" (spins)
+#endif
+	    : [bin_offset] "r" (bin_offset),
+	      [head_offset] "i" (offsetof(ccache_bin_t, head)),
+	      [cpuid_offset] "i" (offsetof(rseq_t, cpu_id)),
+	      [rseq_cs_offset] "i" (offsetof(rseq_t, rseq_cs)),
+	      [sizeof_ccache_t] "i" (sizeof(ccache_t)),
+	      [rseq_abi] "r" (rseq_abi),
+	      [ccache_base] "rm" (ccache_base),
+	      [ptr] "r" (ptr)
+	    : "rax", "cc", "memory"
+	 );
+#ifdef JEMALLOC_DEBUG
+	assert(spins > 0);
+	assert(ccache_get(cpu) == ccache);
+	assert(ccache_bin_get(ccache_get(cpu), ind) == bin);
+#endif
+	if (unlikely(fallback_flag)) {
+		return false;
+	}
+	if (unlikely(flush_flag)) {
+		assert(bin->head == NULL);
+		return ccache_bin_flush(tsd, ccache, bin, tsd_arena_get(tsd),
+		    ind, ptr, small);
+	}
+	return true;
+}
+
+uint32_t
+ccache_nflushes_get() {
+	assert(ncpus > 0);
+
+	uint32_t res = 0;
+	for (unsigned cpu = 0; cpu < ncpus; ++cpu) {
+		ccache_t *ccache = ccache_get(cpu);
+		res += atomic_load_u32(&ccache->stats.nflushes,
+		    atomic_memory_order_relaxed);
+	}
+	return res;
+}
+
+uint32_t
+ccache_nfills_get() {
+	assert(ncpus > 0);
+
+	uint32_t res = 0;
+	for (unsigned cpu = 0; cpu < ncpus; ++cpu) {
+		ccache_t *ccache = ccache_get(cpu);
+		res += atomic_load_u32(&ccache->stats.nfills,
+		    atomic_memory_order_relaxed);
+	}
+	return res;
+}
+
+typedef void (* ccache_bin_visitor)(ccache_bin_t *bin, int cpu, szind_t ind,
+    void *ctx);
+
+void
+ccache_visit_bins(ccache_bin_visitor visitor, void *ctx) {
+	assert(ncpus > 0);
+
+	for (unsigned cpu = 0; cpu < ncpus; ++cpu) {
+		ccache_t *ccache = ccache_get(cpu);
+		for (szind_t ind = ccache_minind; ind <= ccache_maxind; ++ind) {
+			ccache_bin_t *bin = ccache_bin_get(ccache, ind);
+			visitor(bin, cpu, ind, ctx);
+		}
+	}
+}
+
+static void
+ccache_bin_flush_visitor(ccache_bin_t *bin, int cpu, szind_t ind, void *aux) {
+	ccache_bin_full_flush_unsafe(tsd_fetch(), bin, ind, ind < SC_NBINS);
+}
+
+void
+ccache_full_flush_unsafe() {
+	ccache_visit_bins(ccache_bin_flush_visitor, NULL);
+}
+
+static void
+ccache_bin_is_empty_visitor(ccache_bin_t *bin, int cpu, szind_t ind,
+    void *res) {
+	if (!ccache_bin_empty(bin)) {
+		*((bool *)res) = false;
+	}
+}
+
+bool
+ccache_is_empty_unsafe() {
+	bool is_empty = true;
+	ccache_visit_bins(ccache_bin_is_empty_visitor, &is_empty);
+	return is_empty;
+}
+
+static void
+ccache_ncached_visitor(ccache_bin_t *bin, int cpu, szind_t ind, void *res) {
+	*((int *)res) += ccache_bin_ncached_elements(bin);
+}
+
+int
+ccache_ncached_elements_unsafe() {
+	int result = 0;
+	ccache_visit_bins(ccache_ncached_visitor, &result);
+	return result;
+}
+
+void
+tsd_ccache_init(tsd_t *tsd) {
+	rseq_t *rseq_abi = &tsd_ccache_tdatap_get(tsd)->rseq_abi;
+	long rc = syscall(__NR_rseq, rseq_abi, sizeof(rseq_t), 0,
+	    JEMALLOC_RSEQ_SIG);
+	if (rc) {
+		/* TODO: handle failure here */
+	}
+}
+
+void
+ccache_merge_tstats(tsdn_t *tsdn) {
+	cassert(config_stats);
+
+	arena_t *arena = tsd_arena_get(tsdn_tsd(tsdn));
+	if (arena == NULL) {
+		return;
+	}
+	for (szind_t binind = ccache_minind; binind <= ccache_maxind; ++binind) {
+		cache_bin_stats_t *stats = ccache_bin_tstats_get(tsdn_tsd(tsdn), binind);
+		assert(stats);
+
+		if (stats->nrequests == 0) {
+			continue;
+		}
+
+		/* TODO: remove duplication with tcache_stats_merge */
+		if (binind < SC_NBINS) {
+			bin_t *bin = arena_bin_choose(tsdn, arena, binind, NULL);
+			malloc_mutex_lock(tsdn, &bin->lock);
+			bin->stats.nrequests += stats->nrequests;
+			malloc_mutex_unlock(tsdn, &bin->lock);
+		} else {
+			arena_stats_large_nrequests_add(tsdn,
+			    &arena->stats, binind, stats->nrequests);
+		}
+		stats->nrequests = 0;
+	}
+}

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -363,7 +363,7 @@ fallback:
 	assert(ret != NULL);
 	if (unlikely(zero)) {
 		size_t usize = sz_index2size(ind);
-		assert(tcache_salloc(tsd_tsdn(tsd), ret) == usize);
+		assert(arena_salloc(tsd_tsdn(tsd), ret) == usize);
 		memset(ret, 0, usize);
 	}
 	ccache_bump_tstats(tsd, ind);

--- a/src/ccache.c
+++ b/src/ccache.c
@@ -105,8 +105,10 @@ ccache_bin_refill(tsd_t *tsd, ccache_t *ccache, ccache_bin_t *bin,
 	 * on the same CPU go down the slow path.
 	 */
 
-	atomic_fetch_add_u32(&ccache->stats.nfills, 1,
-	    atomic_memory_order_relaxed);
+	if (config_stats) {
+		atomic_fetch_add_u32(&ccache->stats.nfills, 1,
+		    atomic_memory_order_relaxed);
+	}
 
 	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nfill);
 	ptrs.ptr = &bin->ccache_bin_entry[CCACHE_BIN_ELEMENTS - nfill];
@@ -123,8 +125,10 @@ ccache_bin_flush(tsd_t *tsd, ccache_t *ccache, ccache_bin_t *bin,
 	const unsigned nflush = CCACHE_BIN_ELEMENTS / 2;
 	assert(ccache_bin_locked(bin));
 
-	atomic_fetch_add_u32(&ccache->stats.nflushes, 1,
-	    atomic_memory_order_relaxed);
+	if (config_stats) {
+		atomic_fetch_add_u32(&ccache->stats.nflushes, 1,
+		    atomic_memory_order_relaxed);
+	}
 
 	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nflush);
 	/* 
@@ -225,7 +229,7 @@ ccache_alloc(tsd_t *tsd, arena_t *arena, size_t size, szind_t ind,
 	 * No need to zero initialize these flags.
 	 * If fallback, sete will set 'fallback_flag' to 1, 'refill_flag' is
 	 * never read.
-	 * If refill, sete will set 'fallback_flag' to 0, and setne will set
+	 * If refill, sete will set 'fallback_flag' to 0, and sete will set
 	 * 'refill_flag' to 1.
 	 */
 	bool fallback_flag, refill_flag;

--- a/src/ccache_dummy.c
+++ b/src/ccache_dummy.c
@@ -1,0 +1,70 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/ccache.h"
+
+szind_t ccache_maxind = 0;
+szind_t ccache_minind = 0;
+size_t ccache_maxclass = 0;
+
+static inline void
+assert_unused() {
+	assert(!config_cpu_cache);
+	not_reached();
+}
+
+bool
+ccache_init(tsdn_t *tsdn, base_t *base) {
+	assert_unused();
+	return false;
+}
+
+void*
+ccache_alloc(tsd_t *tsd, arena_t *arena,
+    size_t size, szind_t ind, bool zero, bool small) {
+	assert_unused();
+	return NULL;
+}
+
+bool
+ccache_free(tsd_t *tsd, void *ptr, szind_t ind, bool small) {
+	assert_unused();
+	return true;
+}
+
+uint32_t
+ccache_nflushes_get() {
+	assert_unused();
+	return 0;
+}
+uint32_t
+ccache_nfills_get() {
+	assert_unused();
+	return 0;
+}
+
+void
+tsd_ccache_init(tsd_t *tsd) {
+	assert_unused();
+}
+void ccache_merge_tstats(tsdn_t *tsdn) {
+	assert_unused();
+}
+
+/* Non thread-safe functions, use only without contention, e.g. in tests */
+void
+ccache_full_flush_unsafe() {
+	assert_unused();
+}
+
+bool
+ccache_is_empty_unsafe() {
+	assert_unused();
+	return false;
+}
+
+int
+ccache_ncached_elements_unsafe() {
+	assert_unused();
+	return 0;
+}

--- a/src/ccache_dummy.c
+++ b/src/ccache_dummy.c
@@ -46,9 +46,15 @@ ccache_nfills_get() {
 	return 0;
 }
 
-void
+bool
 tsd_ccache_init(tsd_t *tsd) {
 	assert_unused();
+	return false;
+}
+bool
+ccache_cleanup(tsd_t *tsd) {
+	assert_unused();
+	return false;
 }
 void ccache_merge_tstats(tsdn_t *tsdn) {
 	assert_unused();

--- a/src/ccache_dummy.c
+++ b/src/ccache_dummy.c
@@ -3,6 +3,9 @@
 
 #include "jemalloc/internal/ccache.h"
 
+bool opt_ccache = false;
+size_t opt_ccache_max = 0;
+
 szind_t ccache_maxind = 0;
 szind_t ccache_minind = 0;
 size_t ccache_maxclass = 0;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -135,6 +135,8 @@ CTL_PROTO(opt_tcache_gc_incr_bytes)
 CTL_PROTO(opt_tcache_gc_delay_bytes)
 CTL_PROTO(opt_lg_tcache_flush_small_div)
 CTL_PROTO(opt_lg_tcache_flush_large_div)
+CTL_PROTO(opt_ccache)
+CTL_PROTO(opt_ccache_max)
 CTL_PROTO(opt_thp)
 CTL_PROTO(opt_lg_extent_max_active_fit)
 CTL_PROTO(opt_prof)
@@ -457,6 +459,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("lg_tcache_nslots_mul"),	CTL(opt_lg_tcache_nslots_mul)},
 	{NAME("tcache_gc_incr_bytes"),	CTL(opt_tcache_gc_incr_bytes)},
 	{NAME("tcache_gc_delay_bytes"),	CTL(opt_tcache_gc_delay_bytes)},
+	{NAME("ccache"),	CTL(opt_ccache)},
+	{NAME("ccache_max"),	CTL(opt_ccache_max)},
 	{NAME("lg_tcache_flush_small_div"),
 		CTL(opt_lg_tcache_flush_small_div)},
 	{NAME("lg_tcache_flush_large_div"),
@@ -2192,6 +2196,8 @@ CTL_RO_NL_GEN(opt_lg_tcache_flush_small_div, opt_lg_tcache_flush_small_div,
     unsigned)
 CTL_RO_NL_GEN(opt_lg_tcache_flush_large_div, opt_lg_tcache_flush_large_div,
     unsigned)
+CTL_RO_NL_GEN(opt_ccache, opt_ccache, bool)
+CTL_RO_NL_GEN(opt_ccache_max, opt_ccache_max, size_t)
 CTL_RO_NL_GEN(opt_thp, thp_mode_names[opt_thp], const char *)
 CTL_RO_NL_GEN(opt_lg_extent_max_active_fit, opt_lg_extent_max_active_fit,
     size_t)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -662,6 +662,7 @@ stats_print_atexit(void) {
 				    &arena->tcache_ql_mtx);
 			}
 		}
+		ccache_merge_tstats(tsdn);
 	}
 	je_malloc_stats_print(NULL, NULL, opt_stats_print_opts);
 }
@@ -2165,6 +2166,11 @@ malloc_init_hard(void) {
 	malloc_tsd_boot1();
 	/* Update TSD after tsd_boot1. */
 	tsd = tsd_fetch();
+	if (config_cpu_cache) {
+		if (ccache_init(TSDN_NULL, b0get())) {
+			return true;
+		}
+	}
 	if (opt_background_thread) {
 		assert(have_background_thread);
 		/*
@@ -4128,6 +4134,7 @@ batch_alloc_prof_sample_assert(tsd_t *tsd, size_t batch, size_t usize) {
 	assert(surplus < usize);
 }
 
+/* TODO: check if percpu cache affects it */
 size_t
 batch_alloc(void **ptrs, size_t num, size_t size, int flags) {
 	LOG("core.batch_alloc.entry",

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1741,9 +1741,15 @@ malloc_conf_init_check_deps(void) {
 		    "prof_final.\n");
 		return true;
 	}
+	if (opt_ccache && !config_cpu_cache) {
+		malloc_printf("<jemalloc>: opt_ccache is set while cpu cache "
+		    "is not configured. Ignoring.\n");
+		opt_ccache = false;
+	}
 	if (opt_ccache && !opt_tcache) {
 		malloc_printf("<jemalloc>: opt_ccache is set w/o opt_tcache. "
 		    "Ignoring.\n");
+		opt_ccache = false;
 		return true;
 	}
 	if (opt_ccache && opt_tcache && opt_ccache_max < opt_tcache_max) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -1518,6 +1518,8 @@ stats_general_print(emitter_t *emitter) {
 	OPT_WRITE_SIZE_T("tcache_gc_delay_bytes")
 	OPT_WRITE_UNSIGNED("lg_tcache_flush_small_div")
 	OPT_WRITE_UNSIGNED("lg_tcache_flush_large_div")
+	OPT_WRITE_BOOL("ccache")
+	OPT_WRITE_SIZE_T("ccache_max")
 	OPT_WRITE_CHAR_P("thp")
 	OPT_WRITE_BOOL("prof")
 	OPT_WRITE_CHAR_P("prof_prefix")

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -241,7 +241,7 @@ tcache_bin_fill_small(tsdn_t *tsdn, arena_t *arena,
 	    nfill);
 
 	unsigned nfilled = arena_fill_small(tsdn, arena, binind, ptrs.ptr,
-	    nfill, &cache_bin->tstats);
+	    nfill, &cache_bin->tstats, /* ccache= */ false);
 
 	cache_bin_finish_fill(cache_bin, cache_bin_info, &ptrs, nfilled);
 	/* TODO: remove this duplication with ccache's version */

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -211,6 +211,11 @@ tcache_event(tsd_t *tsd) {
 	if (tcache_slow->next_gc_bin == nhbins) {
 		tcache_slow->next_gc_bin = 0;
 	}
+
+	/* TODO: create a separate event type for it */
+	if (config_cpu_cache) {
+		ccache_merge_tstats(tsd_tsdn(tsd));
+	}
 }
 
 void
@@ -225,6 +230,24 @@ tcache_gc_dalloc_event_handler(tsd_t *tsd, uint64_t elapsed) {
 	tcache_event(tsd);
 }
 
+static void
+tcache_bin_fill_small(tsdn_t *tsdn, arena_t *arena,
+    cache_bin_t *cache_bin, cache_bin_info_t *cache_bin_info, szind_t binind,
+    const unsigned nfill) {
+	assert(cache_bin_ncached_get_local(cache_bin, cache_bin_info) == 0);
+
+	CACHE_BIN_PTR_ARRAY_DECLARE(ptrs, nfill);
+	cache_bin_init_ptr_array_for_fill(cache_bin, cache_bin_info, &ptrs,
+	    nfill);
+
+	unsigned nfilled = arena_fill_small(tsdn, arena, binind, ptrs.ptr,
+	    nfill, &cache_bin->tstats);
+
+	cache_bin_finish_fill(cache_bin, cache_bin_info, &ptrs, nfilled);
+	/* TODO: remove this duplication with ccache's version */
+	arena_decay_tick(tsdn, arena);
+}
+
 void *
 tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena,
     tcache_t *tcache, cache_bin_t *cache_bin, szind_t binind,
@@ -235,7 +258,7 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena,
 	assert(tcache_slow->arena != NULL);
 	unsigned nfill = cache_bin_info_ncached_max(&tcache_bin_info[binind])
 	    >> tcache_slow->lg_fill_div[binind];
-	arena_cache_bin_fill_small(tsdn, arena, cache_bin,
+	tcache_bin_fill_small(tsdn, arena, cache_bin,
 	    &tcache_bin_info[binind], binind, nfill);
 	tcache_slow->bin_refilled[binind] = true;
 	ret = cache_bin_alloc(cache_bin, tcache_success);
@@ -243,263 +266,13 @@ tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena,
 	return ret;
 }
 
-static const void *
-tcache_bin_flush_ptr_getter(void *arr_ctx, size_t ind) {
-	cache_bin_ptr_array_t *arr = (cache_bin_ptr_array_t *)arr_ctx;
-	return arr->ptr[ind];
-}
-
 static void
-tcache_bin_flush_metadata_visitor(void *szind_sum_ctx,
-    emap_full_alloc_ctx_t *alloc_ctx) {
-	size_t *szind_sum = (size_t *)szind_sum_ctx;
-	*szind_sum -= alloc_ctx->szind;
-	util_prefetch_write_range(alloc_ctx->edata, sizeof(edata_t));
-}
-
-JEMALLOC_NOINLINE static void
-tcache_bin_flush_size_check_fail(cache_bin_ptr_array_t *arr, szind_t szind,
-    size_t nptrs, emap_batch_lookup_result_t *edatas) {
-	bool found_mismatch = false;
-	for (size_t i = 0; i < nptrs; i++) {
-		szind_t true_szind = edata_szind_get(edatas[i].edata);
-		if (true_szind != szind) {
-			found_mismatch = true;
-			safety_check_fail_sized_dealloc(
-			    /* current_dealloc */ false,
-			    /* ptr */ tcache_bin_flush_ptr_getter(arr, i),
-			    /* true_size */ sz_index2size(true_szind),
-			    /* input_size */ sz_index2size(szind));
-		}
-	}
-	assert(found_mismatch);
-}
-
-static void
-tcache_bin_flush_edatas_lookup(tsd_t *tsd, cache_bin_ptr_array_t *arr,
-    szind_t binind, size_t nflush, emap_batch_lookup_result_t *edatas) {
-
-	/*
-	 * This gets compiled away when config_opt_safety_checks is false.
-	 * Checks for sized deallocation bugs, failing early rather than
-	 * corrupting metadata.
-	 */
-	size_t szind_sum = binind * nflush;
-	emap_edata_lookup_batch(tsd, &arena_emap_global, nflush,
-	    &tcache_bin_flush_ptr_getter, (void *)arr,
-	    &tcache_bin_flush_metadata_visitor, (void *)&szind_sum,
-	    edatas);
-	if (config_opt_safety_checks && unlikely(szind_sum != 0)) {
-		tcache_bin_flush_size_check_fail(arr, binind, nflush, edatas);
-	}
-}
-
-JEMALLOC_ALWAYS_INLINE bool
-tcache_bin_flush_match(edata_t *edata, unsigned cur_arena_ind,
-    unsigned cur_binshard, bool small) {
-	if (small) {
-		return edata_arena_ind_get(edata) == cur_arena_ind
-		    && edata_binshard_get(edata) == cur_binshard;
-	} else {
-		return edata_arena_ind_get(edata) == cur_arena_ind;
-	}
-}
-
-JEMALLOC_ALWAYS_INLINE void
 tcache_bin_flush_impl(tsd_t *tsd, tcache_t *tcache, cache_bin_t *cache_bin,
     szind_t binind, cache_bin_ptr_array_t *ptrs, unsigned nflush, bool small) {
 	tcache_slow_t *tcache_slow = tcache->tcache_slow;
-	/*
-	 * A couple lookup calls take tsdn; declare it once for convenience
-	 * instead of calling tsd_tsdn(tsd) all the time.
-	 */
-	tsdn_t *tsdn = tsd_tsdn(tsd);
-
-	if (small) {
-		assert(binind < SC_NBINS);
-	} else {
-		assert(binind < nhbins);
-	}
-	arena_t *tcache_arena = tcache_slow->arena;
-	assert(tcache_arena != NULL);
-
-	/*
-	 * Variable length array must have > 0 length; the last element is never
-	 * touched (it's just included to satisfy the no-zero-length rule).
-	 */
-	VARIABLE_ARRAY(emap_batch_lookup_result_t, item_edata, nflush + 1);
-	tcache_bin_flush_edatas_lookup(tsd, ptrs, binind, nflush, item_edata);
-
-	/*
-	 * The slabs where we freed the last remaining object in the slab (and
-	 * so need to free the slab itself).
-	 * Used only if small == true.
-	 */
-	unsigned dalloc_count = 0;
-	VARIABLE_ARRAY(edata_t *, dalloc_slabs, nflush + 1);
-
-	/*
-	 * We're about to grab a bunch of locks.  If one of them happens to be
-	 * the one guarding the arena-level stats counters we flush our
-	 * thread-local ones to, we do so under one critical section.
-	 */
-	bool merged_stats = false;
-	while (nflush > 0) {
-		/* Lock the arena, or bin, associated with the first object. */
-		edata_t *edata = item_edata[0].edata;
-		unsigned cur_arena_ind = edata_arena_ind_get(edata);
-		arena_t *cur_arena = arena_get(tsdn, cur_arena_ind, false);
-
-		/*
-		 * These assignments are always overwritten when small is true,
-		 * and their values are always ignored when small is false, but
-		 * to avoid the technical UB when we pass them as parameters, we
-		 * need to intialize them.
-		 */
-		unsigned cur_binshard = 0;
-		bin_t *cur_bin = NULL;
-		if (small) {
-			cur_binshard = edata_binshard_get(edata);
-			cur_bin = arena_get_bin(cur_arena, binind,
-			    cur_binshard);
-			assert(cur_binshard < bin_infos[binind].n_shards);
-			/*
-			 * If you're looking at profiles, you might think this
-			 * is a good place to prefetch the bin stats, which are
-			 * often a cache miss.  This turns out not to be
-			 * helpful on the workloads we've looked at, with moving
-			 * the bin stats next to the lock seeming to do better.
-			 */
-		}
-
-		if (small) {
-			malloc_mutex_lock(tsdn, &cur_bin->lock);
-		}
-		if (!small && !arena_is_auto(cur_arena)) {
-			malloc_mutex_lock(tsdn, &cur_arena->large_mtx);
-		}
-
-		/*
-		 * If we acquired the right lock and have some stats to flush,
-		 * flush them.
-		 */
-		if (config_stats && tcache_arena == cur_arena
-		    && !merged_stats) {
-			merged_stats = true;
-			if (small) {
-				cur_bin->stats.nflushes++;
-				cur_bin->stats.nrequests +=
-				    cache_bin->tstats.nrequests;
-				cache_bin->tstats.nrequests = 0;
-			} else {
-				arena_stats_large_flush_nrequests_add(tsdn,
-				    &tcache_arena->stats, binind,
-				    cache_bin->tstats.nrequests);
-				cache_bin->tstats.nrequests = 0;
-			}
-		}
-
-		/*
-		 * Large allocations need special prep done.  Afterwards, we can
-		 * drop the large lock.
-		 */
-		if (!small) {
-			for (unsigned i = 0; i < nflush; i++) {
-				void *ptr = ptrs->ptr[i];
-				edata = item_edata[i].edata;
-				assert(ptr != NULL && edata != NULL);
-
-				if (tcache_bin_flush_match(edata, cur_arena_ind,
-				    cur_binshard, small)) {
-					large_dalloc_prep_locked(tsdn,
-					    edata);
-				}
-			}
-		}
-		if (!small && !arena_is_auto(cur_arena)) {
-			malloc_mutex_unlock(tsdn, &cur_arena->large_mtx);
-		}
-
-		/* Deallocate whatever we can. */
-		unsigned ndeferred = 0;
-		/* Init only to avoid used-uninitialized warning. */
-		arena_dalloc_bin_locked_info_t dalloc_bin_info = {0};
-		if (small) {
-			arena_dalloc_bin_locked_begin(&dalloc_bin_info, binind);
-		}
-		for (unsigned i = 0; i < nflush; i++) {
-			void *ptr = ptrs->ptr[i];
-			edata = item_edata[i].edata;
-			assert(ptr != NULL && edata != NULL);
-			if (!tcache_bin_flush_match(edata, cur_arena_ind,
-			    cur_binshard, small)) {
-				/*
-				 * The object was allocated either via a
-				 * different arena, or a different bin in this
-				 * arena.  Either way, stash the object so that
-				 * it can be handled in a future pass.
-				 */
-				ptrs->ptr[ndeferred] = ptr;
-				item_edata[ndeferred].edata = edata;
-				ndeferred++;
-				continue;
-			}
-			if (small) {
-				if (arena_dalloc_bin_locked_step(tsdn,
-				    cur_arena, cur_bin, &dalloc_bin_info,
-				    binind, edata, ptr)) {
-					dalloc_slabs[dalloc_count] = edata;
-					dalloc_count++;
-				}
-			} else {
-				if (large_dalloc_safety_checks(edata, ptr,
-				    binind)) {
-					/* See the comment in isfree. */
-					continue;
-				}
-				large_dalloc_finish(tsdn, edata);
-			}
-		}
-
-		if (small) {
-			arena_dalloc_bin_locked_finish(tsdn, cur_arena, cur_bin,
-			    &dalloc_bin_info);
-			malloc_mutex_unlock(tsdn, &cur_bin->lock);
-		}
-		arena_decay_ticks(tsdn, cur_arena, nflush - ndeferred);
-		nflush = ndeferred;
-	}
-
-	/* Handle all deferred slab dalloc. */
-	assert(small || dalloc_count == 0);
-	for (unsigned i = 0; i < dalloc_count; i++) {
-		edata_t *slab = dalloc_slabs[i];
-		arena_slab_dalloc(tsdn, arena_get_from_edata(slab), slab);
-
-	}
-
-	if (config_stats && !merged_stats) {
-		if (small) {
-			/*
-			 * The flush loop didn't happen to flush to this
-			 * thread's arena, so the stats didn't get merged.
-			 * Manually do so now.
-			 */
-			bin_t *bin = arena_bin_choose(tsdn, tcache_arena,
-			    binind, NULL);
-			malloc_mutex_lock(tsdn, &bin->lock);
-			bin->stats.nflushes++;
-			bin->stats.nrequests += cache_bin->tstats.nrequests;
-			cache_bin->tstats.nrequests = 0;
-			malloc_mutex_unlock(tsdn, &bin->lock);
-		} else {
-			arena_stats_large_flush_nrequests_add(tsdn,
-			    &tcache_arena->stats, binind,
-			    cache_bin->tstats.nrequests);
-			cache_bin->tstats.nrequests = 0;
-		}
-	}
-
+	assert(tcache_slow != NULL);
+	arena_flush(tsd, tcache_slow->arena, ptrs, binind, nflush,
+	    &cache_bin->tstats, small, /* ccache = */ false);
 }
 
 JEMALLOC_ALWAYS_INLINE void
@@ -872,7 +645,7 @@ tcache_stats_merge(tsdn_t *tsdn, tcache_t *tcache, arena_t *arena) {
 			bin->stats.nrequests += cache_bin->tstats.nrequests;
 			malloc_mutex_unlock(tsdn, &bin->lock);
 		} else {
-			arena_stats_large_flush_nrequests_add(tsdn,
+			arena_stats_large_nrequests_add(tsdn,
 			    &arena->stats, i, cache_bin->tstats.nrequests);
 		}
 		cache_bin->tstats.nrequests = 0;

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -213,7 +213,7 @@ tcache_event(tsd_t *tsd) {
 	}
 
 	/* TODO: create a separate event type for it */
-	if (config_cpu_cache) {
+	if (config_stats && config_cpu_cache) {
 		ccache_merge_tstats(tsd_tsdn(tsd));
 	}
 }

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -241,6 +241,9 @@ tsd_data_init(tsd_t *tsd) {
 	tsd_prng_state_init(tsd);
 	tsd_te_init(tsd); /* event_init may use the prng state above. */
 	tsd_san_init(tsd);
+	if (config_cpu_cache) {
+		tsd_ccache_init(tsd);
+	}
 	return tsd_tcache_enabled_data_init(tsd);
 }
 

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -241,8 +241,8 @@ tsd_data_init(tsd_t *tsd) {
 	tsd_prng_state_init(tsd);
 	tsd_te_init(tsd); /* event_init may use the prng state above. */
 	tsd_san_init(tsd);
-	if (config_cpu_cache) {
-		tsd_ccache_init(tsd);
+	if (config_cpu_cache && tsd_ccache_init(tsd)) {
+		return true;
 	}
 	return tsd_tcache_enabled_data_init(tsd);
 }
@@ -383,6 +383,9 @@ tsd_do_data_cleanup(tsd_t *tsd) {
 	iarena_cleanup(tsd);
 	arena_cleanup(tsd);
 	tcache_cleanup(tsd);
+	if (config_cpu_cache) {
+		ccache_cleanup(tsd);
+	}
 	witnesses_cleanup(tsd_witness_tsdp_get_unsafe(tsd));
 	*tsd_reentrancy_levelp_get(tsd) = 1;
 }

--- a/test/integration/aligned_alloc.c
+++ b/test/integration/aligned_alloc.c
@@ -15,7 +15,7 @@ purge(void) {
 
 TEST_BEGIN(test_alignment_errors) {
 	size_t alignment;
-	void *p;
+	volatile void *p;
 
 	alignment = 0;
 	set_errno(0);
@@ -47,7 +47,7 @@ JEMALLOC_DIAGNOSTIC_IGNORE_ALLOC_SIZE_LARGER_THAN
 
 TEST_BEGIN(test_oom_errors) {
 	size_t alignment, size;
-	void *p;
+	volatile void *p;
 
 #if LG_SIZEOF_PTR == 3
 	alignment = UINT64_C(0x8000000000000000);

--- a/test/unit/arena_decay.c
+++ b/test/unit/arena_decay.c
@@ -36,16 +36,7 @@ TEST_BEGIN(test_decay_ticks) {
 	expect_d_eq(mallctl("arenas.lextent.0.size", (void *)&large0, &sz, NULL,
 	    0), 0, "Unexpected mallctl failure");
 
-	if (config_cpu_cache) {
-		arena_served_sz = sz_index2size(ccache_maxind + 1);
-	} else {
-		/*
-		 * Large0 is served by arena, because MALLOC_CONF for this test
-		 * limits tcache to 4096 size class.
-		 */
-		arena_served_sz = large0;
-	}
-
+	arena_served_sz = large0;
 	/* Set up a manually managed arena for test. */
 	arena_ind = do_arena_create(0, 0);
 

--- a/test/unit/arena_decay.c
+++ b/test/unit/arena_decay.c
@@ -66,8 +66,6 @@ TEST_BEGIN(test_decay_ticks) {
 	tick0 = ticker_geom_read(decay_ticker);
 	free(p);
 	tick1 = ticker_geom_read(decay_ticker);
-	/* TODO: change the expectation, because these allocs are not handled by
-	 * the arena anymore */
 	expect_u32_ne(tick1, tick0, "Expected ticker to tick during free()");
 
 	/* calloc(). */

--- a/test/unit/ccache.c
+++ b/test/unit/ccache.c
@@ -1,0 +1,261 @@
+#include "test/jemalloc_test.h"
+#include "test/arena_util.h"
+
+#include "jemalloc/internal/ccache.h"
+
+static void
+assert_preconditions() {
+	assert_true(ccache_is_empty_unsafe(),
+	    "Empty ccache precondition failed");
+}
+
+static void
+flush_ccache() {
+	ccache_full_flush_unsafe();
+	assert_true(ccache_is_empty_unsafe(),
+	    "Non-empty ccache after flushing");
+}
+
+TEST_BEGIN(test_ccache_alloc_free_noflush) {
+	test_skip_if(!config_cpu_cache);
+
+	assert_preconditions();
+
+	size_t alloc_size = sz_index2size(ccache_minind);
+	void *initial_ptr = mallocx(alloc_size, MALLOCX_TCACHE_NONE);
+
+	assert_true(ccache_is_empty_unsafe(),
+	    "Ccache refilled after TCACHE_NONE allocation");
+
+	/* Free and alloc one */
+	free(initial_ptr);
+
+	expect_d_eq(ccache_ncached_elements_unsafe(), 1,
+	    "Free didn't put pointer to the ccache");
+
+	void *ptr = malloc(alloc_size);
+	expect_ptr_eq(ptr, initial_ptr,
+	    "Allocated pointer is different from the cached one");
+
+	assert_true(ccache_is_empty_unsafe(),
+	    "Allocated pointer wasn't removed from the ccache");
+
+	flush_ccache();
+}
+TEST_END
+
+TEST_BEGIN(test_ccache_alloc_free_flush) {
+	test_skip_if(!config_cpu_cache);
+
+	assert_preconditions();
+
+	size_t alloc_size = sz_index2size(ccache_minind);
+	const int nallocs = 10000;
+	void *ptr[nallocs];
+
+	for (int i = 0; i < nallocs; ++i) {
+		ptr[i] = malloc(alloc_size);
+		expect_ptr_not_null(ptr[i],
+		    "Unable to allocate from cpu cache on step %d", i);
+	}
+
+	for (int i = 0; i < nallocs; ++i) {
+		free(ptr[i]);
+	}
+
+	flush_ccache();
+}
+TEST_END
+
+typedef struct {
+	void **ptrs;
+	int first;
+	unsigned n;
+	size_t size;
+	uint64_t accumulated;
+} thread_ctx_t;
+
+static void *
+thd_alloc_write(void *arg) {
+	thread_ctx_t *ctx = (thread_ctx_t *)arg;
+	for (unsigned i = ctx->first; i < ctx->first + ctx->n; ++i) {
+		ctx->ptrs[i] = malloc(ctx->size);
+		*(unsigned *)ctx->ptrs[i] = i;
+	}
+	return NULL;
+}
+
+static void *
+thd_free_accumulate(void *arg) {
+	/* Bootstrap tcache, otherwise 'free' would bypass ccache */
+	void *volatile ptr = malloc(1);
+	free(ptr);
+
+	thread_ctx_t *ctx = (thread_ctx_t *)arg;
+	uint64_t accumulated = 0;
+	for (unsigned i = ctx->first; i < ctx->first + ctx->n; ++i) {
+		accumulated += *(unsigned *)ctx->ptrs[i];
+		free(ctx->ptrs[i]);
+	}
+	ctx->accumulated = accumulated;
+	return NULL;
+}
+
+#define PRNG_SEED 0xEB134AA0BAF956C0LL
+
+static void
+random_shuffle(void **a, unsigned n) {
+	uint64_t prng_state = PRNG_SEED;
+	for (unsigned i = 0; i < n; ++i) {
+		unsigned j = i + (unsigned)prng_range_u64(&prng_state, n - i);
+		assert(j <= n);
+		void *tmp = a[i];
+		a[i] = a[j];
+		a[j] = tmp;
+	}
+}
+
+#undef PRNG_SEED
+
+static uint64_t
+global_stats_active_get() {
+	uint64_t epoch = 1;
+	expect_d_eq(
+	    mallctl("epoch", NULL, NULL, &epoch, sizeof(epoch)), 0,
+	    "Failed to move the epoch");
+
+	uint64_t res;
+	size_t len = sizeof(res);
+	expect_d_eq(
+	    mallctl("stats.active", &res, &len, NULL, 0), 0,
+	    "Failed to get stats.active via mallctl");
+	return res;
+}
+
+/*
+ * Fuzzy tests that makes nthreads allocate concurrently, then shuffles the
+ * resulting array and makes them free concurrently.
+ */
+TEST_BEGIN(test_ccache_fuzzy) {
+	test_skip_if(!config_cpu_cache);
+
+	assert_preconditions();
+
+	const size_t alloc_size = sz_index2size(ccache_minind);
+	const unsigned nthreads = ncpus * 4;
+	const unsigned nptrs = 1000000;
+	const unsigned jobs_per_thread = nptrs / nthreads;
+
+	void **ptrs = (void **)mallocx(nptrs * sizeof(void *),
+	    MALLOCX_TCACHE_NONE);
+	thread_ctx_t *tctx =
+	    (thread_ctx_t *)mallocx(nthreads * sizeof(thread_ctx_t),
+	    MALLOCX_TCACHE_NONE);
+
+	int first_job = 0;
+	for (unsigned i = 0; i < nthreads; ++i) {
+		tctx[i].ptrs = ptrs;
+		tctx[i].size = alloc_size;
+		tctx[i].first = first_job;
+		if (i == nthreads - 1) {
+			tctx[i].n = nptrs - first_job;
+		} else {
+			tctx[i].n = jobs_per_thread;
+		}
+		first_job += jobs_per_thread;
+	}
+	thd_t *thds = (thd_t *)mallocx(nthreads * sizeof(thd_t),
+	    MALLOCX_TCACHE_NONE);
+
+	uint64_t active_before_alloc = global_stats_active_get();
+
+	for (unsigned i = 0; i < nthreads; ++i) {
+		thd_create(&thds[i], thd_alloc_write, (void *)&tctx[i]);
+	}
+	for (unsigned i = 0; i < nthreads; ++i) {
+		thd_join(thds[i], NULL);
+	}
+
+	uint64_t active_after_alloc = global_stats_active_get();
+	expect_u64_gt(active_after_alloc, active_before_alloc,
+	    "Active didn't grow after ccache allocations");
+	expect_u64_ge(active_after_alloc - active_before_alloc,
+	    nptrs * alloc_size,
+	    "Insufficient amount of memory allocated to satisfy the requests");
+
+	uint64_t sum = 0;
+	uint64_t expected = (uint64_t)nptrs * (nptrs - 1) / 2;
+	for (unsigned i = 0; i < nptrs; ++i) {
+		sum += *(unsigned *)ptrs[i];
+	}
+	expect_u64_eq(sum, expected, "Sanity check sum is incorrect");
+
+	random_shuffle(ptrs, nptrs);
+
+	uint64_t flushes_before = ccache_nflushes_get();
+	for (unsigned i = 0; i < nthreads; ++i) {
+		tctx[i].accumulated = 0;
+		thd_create(&thds[i], thd_free_accumulate, (void *)&tctx[i]);
+	}
+
+	sum = 0;
+	expected = (uint64_t)nptrs * (nptrs - 1) / 2;
+	for (unsigned i = 0; i < nthreads; ++i) {
+		thd_join(thds[i], NULL);
+		sum += tctx[i].accumulated;
+	}
+	expect_u64_eq(sum, expected, "The resulting sum is incorrect");
+
+	uint64_t flushes_after = ccache_nflushes_get();
+	expect_u64_gt(flushes_after, flushes_before,
+	    "Never flushed the ccache after the large number of deallocs");
+
+	flush_ccache();
+
+	uint64_t active_after_free = global_stats_active_get();
+	expect_u64_eq(active_after_free, active_before_alloc,
+	    "Active stat did not drop back after deallocations and flushes");
+
+	dallocx(thds, MALLOCX_TCACHE_NONE);
+	dallocx(tctx, MALLOCX_TCACHE_NONE);
+	dallocx(ptrs, MALLOCX_TCACHE_NONE);
+
+}
+TEST_END
+
+TEST_BEGIN(test_ccache_stats) {
+	test_skip_if(!config_cpu_cache);
+
+	assert_preconditions();
+
+	const size_t alloc_size = sz_index2size(ccache_minind);
+	uint64_t fills_before = ccache_nfills_get();
+	void *ptr = malloc(alloc_size);
+	uint64_t fills_after = ccache_nfills_get();
+	expect_u64_eq(fills_after - fills_before, 1,
+	    "Expected one refill after allocating from an empty ccache");
+	free(ptr);
+
+	flush_ccache();
+
+	uint64_t flushes_before = ccache_nflushes_get();
+	for (unsigned i = 0; i < CCACHE_BIN_ELEMENTS + 1; ++i) {
+		void *ptr = mallocx(alloc_size, MALLOCX_TCACHE_NONE);
+		free(ptr);
+	}
+	uint64_t flushes_after = ccache_nflushes_get();
+	expect_u64_eq(flushes_after - flushes_before, 1,
+	    "Expected one flush after overflowing the bin with elements");
+
+	flush_ccache();
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_ccache_alloc_free_noflush,
+	    test_ccache_alloc_free_flush,
+	    test_ccache_fuzzy,
+	    test_ccache_stats);
+}

--- a/test/unit/ccache.c
+++ b/test/unit/ccache.c
@@ -137,7 +137,7 @@ global_stats_active_get() {
  * resulting array and makes them free concurrently.
  */
 TEST_BEGIN(test_ccache_fuzzy) {
-	test_skip_if(!config_cpu_cache);
+	test_skip_if(!config_cpu_cache || !config_stats);
 
 	assert_preconditions();
 
@@ -224,7 +224,7 @@ TEST_BEGIN(test_ccache_fuzzy) {
 TEST_END
 
 TEST_BEGIN(test_ccache_stats) {
-	test_skip_if(!config_cpu_cache);
+	test_skip_if(!config_cpu_cache || !config_stats);
 
 	assert_preconditions();
 

--- a/test/unit/ccache.c
+++ b/test/unit/ccache.c
@@ -275,8 +275,11 @@ TEST_BEGIN(test_ccache_stats) {
 	uint64_t fills_before = ccache_nfills_get();
 	void *ptr = malloc(alloc_size);
 	uint64_t fills_after = ccache_nfills_get();
-	expect_u64_eq(fills_after - fills_before, 1,
-	    "Expected one refill after allocating from an empty ccache");
+	if (!opt_prof) {
+		expect_u64_eq(fills_after - fills_before, 1,
+		    "Expected one refill after allocating from an empty "
+		    "ccache");
+	}
 	free(ptr);
 
 	flush_ccache();

--- a/test/unit/ccache.sh
+++ b/test/unit/ccache.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="lg_tcache_max:12"
+export MALLOC_CONF="tcache_max:4096,ccache:true,ccache_max:32768"

--- a/test/unit/ccache.sh
+++ b/test/unit/ccache.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="tcache_max:4096,ccache:true,ccache_max:32768"
+export MALLOC_CONF="abort_conf:false,tcache_max:4096,ccache:true,ccache_max:32768"

--- a/test/unit/ccache.sh
+++ b/test/unit/ccache.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="lg_tcache_max:12"

--- a/test/unit/ccache.sh
+++ b/test/unit/ccache.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="abort_conf:false,tcache_max:4096,ccache:true,ccache_max:32768"
+export MALLOC_CONF="prof:true,abort_conf:false,tcache_max:4096,ccache:true,ccache_max:32768"

--- a/test/unit/ccache.sh
+++ b/test/unit/ccache.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="prof:true,abort_conf:false,tcache_max:4096,ccache:true,ccache_max:32768"
+export MALLOC_CONF="prof:true,lg_prof_sample:20,abort_conf:false,tcache_max:4096,ccache:true,ccache_max:32768"


### PR DESCRIPTION
An overview of the implementation:
Ccache by itself is very similar to the tcache. It serves size classes on top of tcache_maxclass, there is no overlap in
size classes served by Ccache and Tcache. The maximum size class, served by the ccache is set via `opt_ccache_max`. Ccache can be disabled during the configure time (`--enable-cpu-cache`) or at startup (`opt_ccache`). 

The pointers are stored and allocated out of stack, flush/fill logic is reused from Tcache. Ccache flushes pointers in LIFO order, unlike Tcache. If an allocation overflows/underflows, the thread transfers the Ccache into a 'special state', obtaining the exclusive access to the underlying data structure, and performs refill/flush.