### PR TITLE
Make the default option of zero realloc match the system allocator.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -638,6 +638,7 @@ dnl Define cpp macros in CPPFLAGS, rather than doing AC_DEFINE(macro), since the
 dnl definitions need to be seen before any headers are included, which is a pain
 dnl to make happen otherwise.
 default_retain="0"
+zero_realloc_default_free="0"
 maps_coalesce="1"
 DUMP_SYMS="${NM} -a"
 SYM_PREFIX=""
@@ -684,6 +685,7 @@ case "${host}" in
 	if test "${LG_SIZEOF_PTR}" = "3"; then
 	  default_retain="1"
 	fi
+	zero_realloc_default_free="1"
 	;;
   *-*-linux*)
 	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
@@ -698,6 +700,7 @@ case "${host}" in
 	if test "${LG_SIZEOF_PTR}" = "3"; then
 	  default_retain="1"
 	fi
+	zero_realloc_default_free="1"
 	;;
   *-*-kfreebsd*)
 	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
@@ -773,6 +776,7 @@ case "${host}" in
 	if test "${LG_SIZEOF_PTR}" = "3"; then
 	  default_retain="1"
 	fi
+	zero_realloc_default_free="1"
 	;;
   *-*-nto-qnx)
 	abi="elf"
@@ -1393,6 +1397,11 @@ fi
 dnl Indicate whether to retain memory (rather than using munmap()) by default.
 if test "x$default_retain" = "x1" ; then
   AC_DEFINE([JEMALLOC_RETAIN], [ ], [ ])
+fi
+
+dnl Indicate whether realloc(ptr, 0) defaults to the "alloc" behavior.
+if test "x$zero_realloc_default_free" = "x1" ; then
+  AC_DEFINE([JEMALLOC_ZERO_REALLOC_DEFAULT_FREE], [ ], [ ])
 fi
 
 dnl Enable allocation from DSS if supported by the OS.

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1578,13 +1578,14 @@ malloc_conf = "xmalloc:true";]]></programlisting>
           <literal>r-</literal>
         </term>
         <listitem><para> Determines the behavior of
-	<function>realloc()</function> when passed a value of zero for the new
-	size.  <quote>alloc</quote> treats this as an allocation of size zero
-	(and returns a non-null result except in case of resource exhaustion).
-	<quote>free</quote> treats this as a deallocation of the pointer, and
-	returns <constant>NULL</constant> without setting
-	<varname>errno</varname>.  <quote>abort</quote> aborts the process if
-	zero is passed.  The default is <quote>alloc</quote>.</para>
+        <function>realloc()</function> when passed a value of zero for the new
+        size.  <quote>alloc</quote> treats this as an allocation of size zero
+        (and returns a non-null result except in case of resource exhaustion).
+        <quote>free</quote> treats this as a deallocation of the pointer, and
+        returns <constant>NULL</constant> without setting
+        <varname>errno</varname>.  <quote>abort</quote> aborts the process if
+        zero is passed.  The default is <quote>free</quote> on Linux and
+        Windows, and <quote>alloc</quote> elsewhere.</para>
 
 	<para>There is considerable divergence of behaviors across
 	implementations in handling this case. Many have the behavior of

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -421,4 +421,7 @@
 /* Darwin VM_MAKE_TAG support */
 #undef JEMALLOC_HAVE_VM_MAKE_TAG
 
+/* If defined, realloc(ptr, 0) defaults to "free" instead of "alloc". */
+#undef JEMALLOC_ZERO_REALLOC_DEFAULT_FREE
+
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -112,7 +112,12 @@ bool opt_cache_oblivious =
     ;
 
 zero_realloc_action_t opt_zero_realloc_action =
-    zero_realloc_action_alloc;
+#ifdef JEMALLOC_ZERO_REALLOC_DEFAULT_FREE
+    zero_realloc_action_free
+#else
+    zero_realloc_action_alloc
+#endif
+    ;
 
 atomic_zu_t zero_realloc_count = ATOMIC_INIT(0);
 


### PR DESCRIPTION
More context in #2223