### PR TITLE
Enable retain by default on macOS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -654,6 +654,9 @@ case "${host}" in
 	SOREV="${rev}.${so}"
 	sbrk_deprecated="1"
 	SYM_PREFIX="_"
+	if test "${LG_SIZEOF_PTR}" = "3"; then
+	  default_retain="1"
+	fi
 	;;
   *-*-freebsd*)
 	JE_APPEND_VS(CPPFLAGS, -D_BSD_SOURCE)


### PR DESCRIPTION
@krallin and @brekhus identified that jemalloc w/o retain on macOS will suffer extremely high fork() overhead (can reach tens of seconds), because the cost is quadratic with the number of mappings / VM "holes".  Retain fixes the issue, at a small cost of extra VM space reserved.

cc: @devnexen