### PR TITLE
Enable heap profiling on macOS

### DIFF
--- a/bin/jeprof.in
+++ b/bin/jeprof.in
@@ -4698,7 +4698,7 @@ sub ParseLibraries {
       $offset = HexExtend($3);
       $lib = $4;
       $lib =~ s|\\|/|g;     # turn windows-style paths into unix-style paths
-    } elsif ($l =~ /^\s*($h)-($h):\s*(\S+\.so(\.\d+)*)/) {
+    } elsif ($l =~ /^\s*($h)-($h):\s*(.*$)/) {
       # Cooked line from DumpAddressMap.  Example:
       #   40000000-40015000: /lib/ld-2.3.2.so
       $start = HexExtend($1);

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,17 @@ if test "x$GCC" != "xyes" ; then
                                [je_cv_msvc=no])])
 fi
 
+AC_CACHE_CHECK([whether compiler is clang],
+              [je_cv_clang],
+              [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+                                                  [
+#ifndef __clang__
+  int fail[-1];
+#endif
+])],
+                            [je_cv_clang=yes],
+                            [je_cv_clang=no])])
+
 dnl check if a cray prgenv wrapper compiler is being used
 je_cv_cray_prgenv_wrapper=""
 if test "x${PE_ENV}" != "x" ; then
@@ -1369,7 +1380,7 @@ fi
 if test "x$backtrace_method" = "x" -a "x$enable_prof_libgcc" = "x1" \
      -a "x$GCC" = "xyes" ; then
   AC_CHECK_HEADERS([unwind.h], , [enable_prof_libgcc="0"])
-  if test "x${enable_prof_libgcc}" = "x1" ; then
+  if test "x${enable_prof_libgcc}" = "x1" -a "x${je_cv_clang}" != "xyes" ; then
     AC_CHECK_LIB([gcc], [_Unwind_Backtrace], [JE_APPEND_VS(LIBS, -lgcc)], [enable_prof_libgcc="0"])
   fi
   if test "x${enable_prof_libgcc}" = "x1" ; then

--- a/include/jemalloc/internal/prof_sys.h
+++ b/include/jemalloc/internal/prof_sys.h
@@ -24,7 +24,9 @@ typedef int (prof_dump_open_file_t)(const char *, int);
 extern prof_dump_open_file_t *JET_MUTABLE prof_dump_open_file;
 typedef ssize_t (prof_dump_write_file_t)(int, const void *, size_t);
 extern prof_dump_write_file_t *JET_MUTABLE prof_dump_write_file;
+#ifndef __APPLE__
 typedef int (prof_dump_open_maps_t)();
 extern prof_dump_open_maps_t *JET_MUTABLE prof_dump_open_maps;
+#endif // __APPLE__
 
 #endif /* JEMALLOC_INTERNAL_PROF_SYS_H */

--- a/test/unit/prof_mdump.c
+++ b/test/unit/prof_mdump.c
@@ -128,10 +128,12 @@ TEST_BEGIN(test_mdump_output_error) {
 }
 TEST_END
 
+#ifndef __APPLE__
 static int
 prof_dump_open_maps_error() {
 	return -1;
 }
+#endif
 
 static bool started_piping_maps_file;
 
@@ -150,6 +152,7 @@ prof_dump_write_maps_file_error(int fd, const void *s, size_t len) {
 	}
 }
 
+#ifndef __APPLE__
 static void
 expect_maps_write_failure(int count) {
 	int mfd = prof_dump_open_maps();
@@ -162,6 +165,7 @@ expect_maps_write_failure(int count) {
 	expect_write_failure(count);
 	expect_true(started_piping_maps_file, "Should start piping maps");
 }
+#endif
 
 TEST_BEGIN(test_mdump_maps_error) {
 	test_skip_if(!config_prof);
@@ -169,8 +173,9 @@ TEST_BEGIN(test_mdump_maps_error) {
 
 	prof_dump_open_file_t *open_file_orig = prof_dump_open_file;
 	prof_dump_write_file_t *write_file_orig = prof_dump_write_file;
+#ifndef __APPLE__
 	prof_dump_open_maps_t *open_maps_orig = prof_dump_open_maps;
-
+#endif
 	prof_dump_open_file = prof_dump_open_file_intercept;
 	prof_dump_write_file = prof_dump_write_maps_file_error;
 
@@ -181,7 +186,9 @@ TEST_BEGIN(test_mdump_maps_error) {
 	 * When opening the maps file fails, there shouldn't be any maps write,
 	 * and mallctl() should return success.
 	 */
+#ifndef __APPLE__
 	prof_dump_open_maps = prof_dump_open_maps_error;
+#endif
 	started_piping_maps_file = false;
 	prof_dump_write_file_count = 0;
 	expect_d_eq(mallctl("prof.dump", NULL, NULL, (void *)&test_filename,
@@ -196,9 +203,11 @@ TEST_BEGIN(test_mdump_maps_error) {
 	 * maps file), there shouldn't be any more maps write, and mallctl()
 	 * should return failure.
 	 */
+#ifndef __APPLE__
 	prof_dump_open_maps = open_maps_orig;
 	expect_maps_write_failure(1); /* First write fails. */
 	expect_maps_write_failure(2); /* Second write fails. */
+#endif
 
 	dallocx(p, 0);
 


### PR DESCRIPTION
Enable heap profiling on macOS.

Both prof-libgcc and prof-gcc works with clang on macOS. The library mappings are dumped via dyld API.