### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -476,6 +476,20 @@ If you're having any issues with the above, ensure the following:
    variables. Otherwise, check the path to the `vcvarsall.bat` in `$vcvarsall`
    script and fix it.
 
+### Building jemalloc from vcpkg
+
+The jemalloc port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install jemalloc using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install jemalloc
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Development
 
 If you intend to make non-trivial changes to jemalloc, use the 'autogen.sh'


### PR DESCRIPTION
Jemalloc is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for jemalloc and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build jemalloc, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/jemalloc/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.