### PR TITLE
Fix safety_check segfault in double free test

### DIFF
--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -223,10 +223,15 @@ large_dalloc_safety_checks(edata_t *edata, void *ptr, szind_t szind) {
 	 */
 	if (unlikely(edata == NULL ||
 	    edata_state_get(edata) != extent_state_active)) {
-		safety_check_fail("Invalid deallocation detected: "
-		    "pages being freed (%p) not currently active, "
-		    "possibly caused by double free bugs.",
-		    (uintptr_t)edata_addr_get(edata));
+	        if (edata == NULL)
+		    safety_check_fail("Invalid deallocation detected: "
+		        "pages being freed (edata=null) not currently active, "
+		        "possibly caused by double free bugs.");
+		else
+		    safety_check_fail("Invalid deallocation detected: "
+		        "pages being freed (%p) not currently active, "
+		        "possibly caused by double free bugs.",
+		        (uintptr_t)edata_addr_get(edata));
 		return true;
 	}
 	size_t input_size = sz_index2size(szind);


### PR DESCRIPTION
After https://github.com/jemalloc/jemalloc/pull/2062 `large_dalloc_safety_checks` got a `edata == NULL` case but error message wasn't working for `edata == NULL`

`test/unit/double_free` was failing with `EXC_BAD_ACCESS (code=1, address=0x8)` on aarch64-darwin with clang-11

Adding `edata==NULL` case to error logging here.