### PR TITLE
RFC: Fix exception specification errors when using musl C library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -707,6 +707,19 @@ case "${host}" in
 	fi
 	zero_realloc_default_free="1"
 	;;
+  *-*-linux-musl*)
+	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
+	JE_APPEND_VS(CPPFLAGS, -D_GNU_SOURCE)
+	abi="elf"
+	AC_DEFINE([JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS], [ ], [ ])
+	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H], [ ], [ ])
+	AC_DEFINE([JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY], [ ], [ ])
+	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ], [ ])
+	if test "${LG_SIZEOF_PTR}" = "3"; then
+	  default_retain="1"
+	fi
+	zero_realloc_default_free="1"
+	;;
   *-*-linux*)
 	dnl syscall(2) and secure_getenv(3) are exposed by _GNU_SOURCE.
 	JE_APPEND_VS(CPPFLAGS, -D_GNU_SOURCE)

--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -142,7 +142,7 @@
 #  define JEMALLOC_COLD
 #endif
 
-#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && !defined(JEMALLOC_NO_RENAME)
+#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__linux__) && !defined(__GLIBC__))) && !defined(JEMALLOC_NO_RENAME)
 #  define JEMALLOC_SYS_NOTHROW
 #else
 #  define JEMALLOC_SYS_NOTHROW JEMALLOC_NOTHROW


### PR DESCRIPTION
When trying to build jemalloc 5.3.0 on a `x86_64-pc-linux-musl` host using the LLVM toolchain (version 15.0.1) I encountered the following build errors due to different exception specifications on the malloc functions family:
```
x86_64-pc-linux-musl-c++ -std=c++17 -Wall -Wextra -g3 -fvisibility=hidden -Wimplicit-fallthrough -O3 -march=native -O2 -pipe -fPIC -DPIC -c -march=native -O
2 -pipe -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/jemalloc_cpp.pic.o src/jemalloc_cpp.cpp
In file included from src/jemalloc_cpp.cpp:9:
In file included from include/jemalloc/internal/jemalloc_preamble.h:27:
include/jemalloc/internal/../jemalloc.h:254:32: error: exception specification in declaration does not match previous declaration
    void JEMALLOC_SYS_NOTHROW   *je_malloc(size_t size)
                                 ^
include/jemalloc/internal/../jemalloc.h:75:21: note: expanded from macro 'je_malloc'
#  define je_malloc malloc
                    ^
/usr/x86_64-pc-linux-musl/include/stdlib.h:40:7: note: previous declaration is here
void *malloc (size_t);
      ^
```

As mentioned in https://github.com/jemalloc/jemalloc/issues/778 one part of the problem is that `JEMALLOC_USE_CXX_THROW` is defined for all Linux systems. The original intention was to appease glibc, but in turn it caused problems on `*-*-linux-musl*` systems. Adjust for this by adding a case for `*-*-linux-musl*` that doesn't set `glibc=1` and doesn't define `JEMALLOC_USE_CXX_THROW`.

With the first commit in place I was still getting the same exception specification errors because the `JEMALLOC_SYS_NOTHROW` definition caused a mismatch of the function declarations with the ones provided by musl too.
I added `defined(__linux__) && !defined(__GLIBC__)` to the condition to adjust for this.
Maybe the logic should be simplified/reversed, because it now reads:
```
#if MacOS || FreeBSD || OpenBSD || (Linux && !glibc)
  // no exception specifications
#else 
  // exception specifications
#endif
```
and I have a feeling it might be a complicated way to express:
```
#if glibc // or maybe "Linux && glibc" 
  // exception specifications
#else 
  // no exception specifications
#endif
```
But I'm not familiar with all the support systems to properly judge this

With these two changes I'm able to build jemalloc, but I'm getting a bunch of test failures:
```
test_alignment_errors (non-reentrant): fail                                                                                                                 
test_alignment_errors (libc-reentrant): fail                                                                                                                
test_alignment_errors (arena_new-reentrant): fail                                                                                                           
test_oom_errors (non-reentrant): fail                                                                                                                       
test_oom_errors (libc-reentrant): fail                                                                                                                      
test_oom_errors (arena_new-reentrant): fail                                                                                                                 
--- pass: 6/12, skip: 0/12, fail: 6/12 ---                                                                                                                  
--- pass: 15/15, skip: 0/15, fail: 0/15 ---                                                                                                                 
--- pass: 12/12, skip: 0/12, fail: 0/12 ---                                                                                                                 
--- pass: 3/3, skip: 0/3, fail: 0/3 ---                                                                                                                     
test_alignment_errors (non-reentrant): fail                                                                                                                 
test_alignment_errors (libc-reentrant): fail                                                                                                                
test_alignment_errors (arena_new-reentrant): fail                                                                                                           
test_oom_errors (non-reentrant): fail                                                                                                                       
test_oom_errors (libc-reentrant): fail                                                                                                                      
test_oom_errors (arena_new-reentrant): fail                                                                                                                 
--- pass: 6/12, skip: 0/12, fail: 6/12 ---
[...]
```
which all seem to look something like:
```
=== test/integration/aligned_alloc ===
test_alignment_errors:test/integration/aligned_alloc.c:24: Failed assertion: (p != ((void*)0) || get_errno() != 22) == (0) --> true != false: Expected error
 for invalid alignment 0
test_alignment_errors:test/integration/aligned_alloc.c:32: Failed assertion: (p != ((void*)0) || get_errno() != 22) == (0) --> true != false: Expected error
 for invalid alignment 9
test_alignment_errors:test/integration/aligned_alloc.c:32: Failed assertion: (p != ((void*)0) || get_errno() != 22) == (0) --> true != false: Expected error
 for invalid alignment 17
[...]
```
Same as mentioned in https://github.com/jemalloc/jemalloc/issues/2091#issuecomment-1258408590
I'm not passing `--with-jemalloc-prefix=` but I can confirm that compiling with `-O0` makes the test pass