### PR TITLE
Minor fixes

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -245,6 +245,7 @@
 /*
  * popcount*() functions to use for bitmapping.
  */
+#undef JEMALLOC_INTERNAL_POPCOUNTLL
 #undef JEMALLOC_INTERNAL_POPCOUNTL
 #undef JEMALLOC_INTERNAL_POPCOUNT
 

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3334,7 +3334,12 @@ JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
  * be implemented also, so none of glibc's malloc.o functions are added to the
  * link.
  */
-#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), copy(je_fn)))
+#    ifdef __clang__
+       /* Clang doesn't support GCC's copy() attribute. */
+#      define ALIAS(je_fn)	__attribute__((alias (#je_fn), used))
+#    else
+#      define ALIAS(je_fn)	__attribute__((alias (#je_fn), copy(je_fn)))
+#    endif
 /* To force macro expansion of je_ prefix before stringification. */
 #    define PREALIAS(je_fn)	ALIAS(je_fn)
 #    ifdef JEMALLOC_OVERRIDE___LIBC_CALLOC

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2034,7 +2034,7 @@ malloc_init_narenas(void) {
 		} else {
 			if (ncpus >= MALLOCX_ARENA_LIMIT) {
 				malloc_printf("<jemalloc>: narenas w/ percpu"
-				    "arena beyond limit (%d)\n", ncpus);
+				    "arena beyond limit (%u)\n", ncpus);
 				if (opt_abort) {
 					abort();
 				}
@@ -2082,7 +2082,7 @@ malloc_init_narenas(void) {
 	 */
 	if (narenas_auto >= MALLOCX_ARENA_LIMIT) {
 		narenas_auto = MALLOCX_ARENA_LIMIT - 1;
-		malloc_printf("<jemalloc>: Reducing narenas to limit (%d)\n",
+		malloc_printf("<jemalloc>: Reducing narenas to limit (%u)\n",
 		    narenas_auto);
 	}
 	narenas_total_set(narenas_auto);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3334,7 +3334,7 @@ JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
  * be implemented also, so none of glibc's malloc.o functions are added to the
  * link.
  */
-#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), used))
+#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), copy(je_fn)))
 /* To force macro expansion of je_ prefix before stringification. */
 #    define PREALIAS(je_fn)	ALIAS(je_fn)
 #    ifdef JEMALLOC_OVERRIDE___LIBC_CALLOC


### PR DESCRIPTION
Use `%u` not `%d` when printing unsigned values.

Take advantage of GCC's copy() facility in `__attribute__` to duplicate all the attributes of these functions.  I'm not sure about this because I'm not sure if Clang supports it.