### PR TITLE
Makefile.in: link with g++, fixes build on 10.6.x (x86_64 and ppc)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -522,7 +522,11 @@ endif
 
 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) : $(if $(PIC_CFLAGS),$(C_PIC_OBJS),$(C_OBJS)) $(if $(PIC_CFLAGS),$(CPP_PIC_OBJS),$(CPP_OBJS))
 	@mkdir -p $(@D)
+ifeq (@enable_cxx@, 1)
+	$(CXX) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
+else
 	$(CC) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
+endif
 
 $(objroot)lib/$(LIBJEMALLOC)_pic.$(A) : $(C_PIC_OBJS) $(CPP_PIC_OBJS)
 $(objroot)lib/$(LIBJEMALLOC).$(A) : $(C_OBJS) $(CPP_OBJS)


### PR DESCRIPTION
C++ code should be linked with C++. Currently CC is used, which leads to errors on some systems. Example:
```
Undefined symbols for architecture x86_64:
  "__Unwind_Resume", referenced from:
      __ZL9handleOOMmb in jemalloc_cpp.pic.o
ld: symbol(s) not found for architecture x86_64
```
In particular, this PR fixes the build on 10.6.x (Intel and PowerPC). It is also necessary, though not sufficient, for 10.5.8.