### PR TITLE
Add loongarch64 LG_QUANTUM size definition.

### DIFF
--- a/include/jemalloc/internal/quantum.h
+++ b/include/jemalloc/internal/quantum.h
@@ -71,6 +71,9 @@
 #  ifdef __arc__
 #    define LG_QUANTUM		3
 #  endif
+#  if (defined(__loongarch64) || defined(__loongarch__))
+#    define LG_QUANTUM		4
+#  endif
 #  ifndef LG_QUANTUM
 #    error "Unknown minimum alignment for architecture; specify via "
 	 "--with-lg-quantum"


### PR DESCRIPTION
**1. Jemalloc compiles failed on loongarch architecture. Error message of building jemalloc,such as:**
gcc -std=gnu11 -Wall -Wextra -Wsign-compare -Wundef -Wno-format-zero-length -pipe -g3 -fvisibility=hidden -O3 -funroll-loops -g -O2 -fdebug-prefix-map=/home/loongson/debian-community/jemalloc/sys-jemalloc/debian-pa/jemalloc-5.2.1=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -DPIC -c -Wdate-time -D_FORTIFY_SOURCE=2  -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -DJEMALLOC_NO_PRIVATE_NAMESPACE -o src/jemalloc.sym.o src/jemalloc.c
In file included from include/jemalloc/internal/jemalloc_internal_types.h:4,
                 from include/jemalloc/internal/sc.h:4,
                 from include/jemalloc/internal/arena_types.h:4,
                 from include/jemalloc/internal/jemalloc_internal_includes.h:45,
                 from src/jemalloc.c:3:
include/jemalloc/internal/quantum.h:68:6: error: #error "Unknown minimum alignment for architecture; specify via "
     error "Unknown minimum alignment for architecture; specify via "
include/jemalloc/internal/quantum.h:69:3: error: expected identifier or ‘(’ before string constant
   "--with-lg-quantum"

**2. Build env**
$ arch
loongarch64
$ gcc --version
gcc (Loongnix 8.3.0-6.lnd.vec.33) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.

Please consider this pull request, thanks.