### PR TITLE
Fix dividing 0 error in stress/cpp/microbench

### DIFF
--- a/test/src/timer.c
+++ b/test/src/timer.c
@@ -28,6 +28,17 @@ timer_ratio(timedelta_t *a, timedelta_t *b, char *buf, size_t buflen) {
 	size_t i = 0;
 	size_t j, n;
 
+	/* 
+ 	* The time difference could be 0 if the two clock readings are 
+ 	* identical, either due to the operations being measured in the middle
+ 	* took very little time (or even got optimized away), or the clock 
+ 	* readings are bad / very coarse grained clock.
+ 	* Thus, bump t1 if it is 0 to avoid dividing 0. 
+ 	*/
+	if (t1 == 0) {
+	    t1 = 1;
+	}
+
 	/* Whole. */
 	n = malloc_snprintf(&buf[i], buflen-i, "%"FMTu64, t0 / t1);
 	i += n;

--- a/test/stress/cpp/microbench.cpp
+++ b/test/stress/cpp/microbench.cpp
@@ -3,45 +3,45 @@
 
 static void
 malloc_free(void) {
-	void *p = malloc(1);
-	expect_ptr_not_null(p, "Unexpected malloc failure");
-	free(p);
+	void* volatile p = malloc(1);
+	expect_ptr_not_null((void *)p, "Unexpected malloc failure");
+	free((void *)p);
 }
 
 static void
 new_delete(void) {
-	auto p = ::operator new(1);
-	expect_ptr_not_null(p, "Unexpected new failure");
-	::operator delete(p);
+	void* volatile p = ::operator new(1);
+	expect_ptr_not_null((void *)p, "Unexpected new failure");
+	::operator delete((void *)p);
 }
 
 static void
 malloc_free_array(void) {
-	void *p = malloc(sizeof(int)*8);
-	expect_ptr_not_null(p, "Unexpected malloc failure");
-	free(p);
+	void* volatile p = malloc(sizeof(int)*8);
+	expect_ptr_not_null((void *)p, "Unexpected malloc failure");
+	free((void *)p);
 }
 
 static void
 new_delete_array(void) {
-	auto p = new int[8];
-	expect_ptr_not_null(p, "Unexpected new[] failure");
-	delete[] p;
+	int* volatile p = new int[8];
+	expect_ptr_not_null((int *)p, "Unexpected new[] failure");
+	delete[] (int *)p;
 }
 
 #if __cpp_sized_deallocation >= 201309
 static void
 new_sized_delete(void) {
-	auto p = ::operator new(1);
-	expect_ptr_not_null(p, "Unexpected new failure");
-	::operator delete(p, 1);
+	void* volatile p = ::operator new(1);
+	expect_ptr_not_null((void *)p, "Unexpected new failure");
+	::operator delete((void *)p, 1);
 }
 
 static void
 malloc_sdallocx(void) {
-	void *p = malloc(1);
-	expect_ptr_not_null(p, "Unexpected malloc failure");
-        sdallocx(p, 1, 0);
+	void* volatile p = malloc(1);
+	expect_ptr_not_null((void *)p, "Unexpected malloc failure");
+        sdallocx((void *)p, 1, 0);
 }
 #endif
 


### PR DESCRIPTION
Per issue #2356, some CXX compilers may optimize away the new/delete operation in stress/cpp/microbench.cpp. Thus, this commit (1) bumps the time interval to 1 if it is 0, and (2) modifies the pointers in the microbench to volatile.