### PR TITLE
Fix the rdtscp detection bug and add prefix for the macro.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,10 +522,10 @@ typedef unsigned __int32 uint32_t;
       return 0;
 ]])],
       [je_cv_rdtscp=yes],
-      [je_cv_rdstcp=no],
+      [je_cv_rdtscp=no],
       [je_cv_rdtscp=no]))
       if test "x${je_cv_rdtscp}" = "xyes"; then
-        AC_DEFINE([HAVE_RDTSCP], 1, [])
+        AC_DEFINE([JEMALLOC_HAVE_RDTSCP], [ ], [ ])
       fi
     fi
     ;;

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -443,4 +443,10 @@
 /* If defined, use volatile asm during benchmarks. */
 #undef JEMALLOC_HAVE_ASM_VOLATILE
 
+/* 
+ * If defined, support the use of rdtscp to get the time stamp counter 
+ * and the processor ID. 
+ */
+#undef JEMALLOC_HAVE_RDTSCP
+
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -14,7 +14,7 @@ malloc_getcpu(void) {
 	return GetCurrentProcessorNumber();
 #elif defined(JEMALLOC_HAVE_SCHED_GETCPU)
 	return (malloc_cpuid_t)sched_getcpu();
-#elif defined(HAVE_RDTSCP)
+#elif defined(JEMALLOC_HAVE_RDTSCP)
 	unsigned int ax, cx, dx;
 	asm volatile("rdtscp" : "=a"(ax), "=d"(dx), "=c"(cx) ::);
 	return (malloc_cpuid_t)(dx & 0xfff);


### PR DESCRIPTION
1. Fix the missing definition of RDTSCP macro;
2. Fix a typo and rename the macro following the convention.