### PR TITLE
Remove locked flag set in malloc_mutex_trylock

### DIFF
--- a/include/jemalloc/internal/mutex.h
+++ b/include/jemalloc/internal/mutex.h
@@ -175,7 +175,6 @@ malloc_mutex_trylock(tsdn_t *tsdn, malloc_mutex_t *mutex) {
 	witness_assert_not_owner(tsdn_witness_tsdp_get(tsdn), &mutex->witness);
 	if (isthreaded) {
 		if (malloc_mutex_trylock_final(mutex)) {
-			atomic_store_b(&mutex->locked, true, ATOMIC_RELAXED);
 			return true;
 		}
 		mutex_owner_stats_update(tsdn, mutex);


### PR DESCRIPTION
While locked is a flag for the lock, modifying it after a failure to gain the lock may cause unnecessary spins. Specifically, if a thread A is doing try_lock and it fails, but before it sets the flag locked to true another thread owning the lock frees it and sets locked to false. The locked is then set to true by thread A again. Other threads that are spinning to wait for the lock will keep spinning while one of them should actually stop spinning and get the lock.