### PR TITLE
Only use strings.h when not targeting Win32

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_decls.h
+++ b/include/jemalloc/internal/jemalloc_internal_decls.h
@@ -17,6 +17,7 @@
 #    endif
 #  endif
 #else
+#  include <strings.h>
 #  include <sys/param.h>
 #  include <sys/mman.h>
 #  if !defined(__pnacl__) && !defined(__native_client__)
@@ -72,7 +73,6 @@
 #  define offsetof(type, member)	((size_t)&(((type *)NULL)->member))
 #endif
 #include <string.h>
-#include <strings.h>
 #include <ctype.h>
 #ifdef _MSC_VER
 #  include <io.h>

--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -2,7 +2,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <limits.h>
-#include <strings.h>
+#ifdef _WIN32
+#  include "msvc_compat/strings.h"
+#else
+#  include <strings.h>
+#endif
 
 #define JEMALLOC_VERSION "@jemalloc_version@"
 #define JEMALLOC_VERSION_MAJOR @jemalloc_version_major@


### PR DESCRIPTION
When targeting Win32, msvc_compat/strings.h should be used instead of strings.h.

Without this PR getting this error when compiling using NodeJS gyp build:

```
D:\a\rocksdb\rocksdb\deps\jemalloc\jemalloc\include\jemalloc\jemalloc.h(99,10): fatal  error C1083: Cannot open include file: 'strings.h': No such file or directory [D:\a\rocksdb\rocksdb\deps\rocksdb\rocksdb.vcxproj]
```