### PR TITLE
Fix possible `NULL` pointer dereference from `mallctl("prof.prefix", …)`

### DIFF
--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -749,6 +749,9 @@ bool
 prof_prefix_set(tsdn_t *tsdn, const char *prefix) {
 	cassert(config_prof);
 	ctl_mtx_assert_held(tsdn);
+	if (prefix == NULL) {
+		return true;
+	}
 	malloc_mutex_lock(tsdn, &prof_dump_filename_mtx);
 	if (prof_prefix == NULL) {
 		malloc_mutex_unlock(tsdn, &prof_dump_filename_mtx);


### PR DESCRIPTION
Static analysis flagged this issue. Here is a minimal program which causes a segfault within Jemalloc:
```c
#include <jemalloc/jemalloc.h>

const char *malloc_conf = "prof:true";

int main() {
  mallctl("prof.prefix", NULL, NULL, NULL, 0);
}
```

Fixed by checking if `prefix` is `NULL`.