### PR TITLE
Added autoconf to installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,7 @@
 Building and installing a packaged release of jemalloc can be as simple as
 typing the following while in the root directory of the source tree:
 
+    autoconf
     ./configure
     make
     make install


### PR DESCRIPTION
./configure command doesn't exist in the repo. It needs to be generated using autoconf first.