### PR TITLE
Fix downloading LLVM in GitHub Action

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: 'llvm/llvm-project'
-          version: 'latest'
+          version: 'tags/llvmorg-16.0.4'
           file: 'clang[+]llvm-.*x86_64-linux-gnu.*'
           regex: true
           target: 'llvm_assets/'


### PR DESCRIPTION
It turns out LLVM does not include a build for every platform in the assets for every release, just some of them. As such, I've pinned us to the latest release version with a corresponding build.

Tested locally [using the `act` CLI](https://github.com/nektos/act) to verify that this fixes the issue.