### PR TITLE
Avoid eager purging on the dedicated oversize arena when using bg thds.

### DIFF
--- a/src/extent.c
+++ b/src/extent.c
@@ -944,6 +944,7 @@ extent_record(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks, ecache_t *ecache,
 		} while (coalesced);
 		if (edata_size_get(edata) >=
 		    atomic_load_zu(&pac->oversize_threshold, ATOMIC_RELAXED)
+		    && !background_thread_enabled()
 		    && extent_may_force_decay(pac)) {
 			/* Shortcut to purge the oversize extent eagerly. */
 			malloc_mutex_unlock(tsdn, &ecache->mtx);

--- a/test/unit/oversize_threshold.c
+++ b/test/unit/oversize_threshold.c
@@ -120,7 +120,10 @@ TEST_BEGIN(test_oversize_threshold) {
 	 */
 	ptr = mallocx(2 * 1024 * 1024, MALLOCX_ARENA(arena));
 	dallocx(ptr, MALLOCX_TCACHE_NONE);
-	expect_zu_ge(max_purged, 2 * 1024 * 1024, "Expected a 2MB purge");
+	if (!is_background_thread_enabled()) {
+		expect_zu_ge(max_purged, 2 * 1024 * 1024,
+		    "Expected a 2MB purge");
+	}
 }
 TEST_END
 


### PR DESCRIPTION
We have observed new workload patterns (namely ML training type) that cycle through oversized allocations frequently, because 1) the dataset might be sparse which is faster to go through, and 2) GPU accelerated.  As a result, the eager purging from the oversize arena becomes a bottleneck.  To offer an easy solution, allow normal purging of the oversized extents when background threads are enabled.