### PR TITLE
Only enable `-Wstrict-prototypes` in CI to unbreak feature detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -262,7 +262,6 @@ if test "x$GCC" = "xyes" ; then
   dnl This one too.
   JE_CFLAGS_ADD([-Wno-missing-field-initializers])
   JE_CFLAGS_ADD([-Wno-missing-attributes])
-  JE_CFLAGS_ADD([-Wstrict-prototypes])
   JE_CFLAGS_ADD([-pipe])
   JE_CFLAGS_ADD([-g3])
 elif test "x$je_cv_msvc" = "xyes" ; then

--- a/scripts/run_static_analysis.sh
+++ b/scripts/run_static_analysis.sh
@@ -13,7 +13,7 @@ compile_time_malloc_conf='background_thread:true,'\
 'prof_unbias:false,'\
 'prof_time_resolution:high'
 
-./autogen.sh \
+EXTRA_CFLAGS='-Wstrict-prototypes' EXTRA_CXXFLAGS='-Wstrict-prototypes' ./autogen.sh \
 	--with-private-namespace=jemalloc_ \
 	--disable-cache-oblivious \
 	--enable-prof \


### PR DESCRIPTION
Adding `-Wstrict-prototypes` to the default `CFLAGS` in PR #2473 had the non-obvious side-effect of breaking configure-time feature detection, because the [test-program `autoconf` generates for feature detection](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Generating-Sources.html#:~:text=main%20()) defines `main` as:
```c
int main()
```
Which causes all feature checks to fail, since this triggers `-Wstrict-prototypes` and the feature checks use `-Werror`.

Resolved by only adding `-Wstrict-prototypes` to
`EXTRA_{CFLAGS,CXXFLAGS}` in CI, since these flags are not used during feature detection and we control which compiler is used.