### PR TITLE
Print the failed assertion before aborting in test cases

### DIFF
--- a/test/include/test/test.h
+++ b/test/include/test/test.h
@@ -13,11 +13,7 @@
 		    __func__, __FILE__, __LINE__,			\
 		    #a, #b, a_, b_);					\
 		malloc_snprintf(message, sizeof(message), __VA_ARGS__);	\
-		if (may_abort) {					\
-			abort();					\
-		} else {						\
-			p_test_fail(prefix, message);			\
-		}							\
+		p_test_fail(may_abort, prefix, message);		\
 	}								\
 } while (0)
 
@@ -230,11 +226,7 @@
 		    #a, #b, a_ ? "true" : "false",			\
 		    b_ ? "true" : "false");				\
 		malloc_snprintf(message, sizeof(message), __VA_ARGS__);	\
-		if (may_abort) {					\
-			abort();					\
-		} else {						\
-			p_test_fail(prefix, message);			\
-		}							\
+		p_test_fail(may_abort, prefix, message);		\
 	}								\
 } while (0)
 
@@ -251,11 +243,7 @@
 		    #a, #b, a_ ? "true" : "false",			\
 		    b_ ? "true" : "false");				\
 		malloc_snprintf(message, sizeof(message), __VA_ARGS__);	\
-		if (may_abort) {					\
-			abort();					\
-		} else {						\
-			p_test_fail(prefix, message);			\
-		}							\
+		p_test_fail(may_abort, prefix, message);		\
 	}								\
 } while (0)
 
@@ -275,11 +263,7 @@
 		    "\"%s\" differs from \"%s\": ",			\
 		    __func__, __FILE__, __LINE__, #a, #b, a, b);	\
 		malloc_snprintf(message, sizeof(message), __VA_ARGS__);	\
-		if (may_abort) {					\
-			abort();					\
-		} else {						\
-			p_test_fail(prefix, message);			\
-		}							\
+		p_test_fail(may_abort, prefix, message);		\
 	}								\
 } while (0)
 
@@ -293,11 +277,7 @@
 		    "\"%s\" same as \"%s\": ",				\
 		    __func__, __FILE__, __LINE__, #a, #b, a, b);	\
 		malloc_snprintf(message, sizeof(message), __VA_ARGS__);	\
-		if (may_abort) {					\
-			abort();					\
-		} else {						\
-			p_test_fail(prefix, message);			\
-		}							\
+		p_test_fail(may_abort, prefix, message);		\
 	}								\
 } while (0)
 
@@ -311,11 +291,7 @@
 	    "%s:%s:%d: Unreachable code reached: ",			\
 	    __func__, __FILE__, __LINE__);				\
 	malloc_snprintf(message, sizeof(message), __VA_ARGS__);		\
-	if (may_abort) {						\
-		abort();						\
-	} else {							\
-		p_test_fail(prefix, message);				\
-	}								\
+	p_test_fail(may_abort, prefix, message);			\
 } while (0)
 
 #define expect_not_reached(...) verify_not_reached(false, __VA_ARGS__)
@@ -580,4 +556,4 @@ test_status_t	p_test_no_reentrancy(test_t *t, ...);
 test_status_t	p_test_no_malloc_init(test_t *t, ...);
 void	p_test_init(const char *name);
 void	p_test_fini(void);
-void	p_test_fail(const char *prefix, const char *message);
+void	p_test_fail(bool may_abort, const char *prefix, const char *message);

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -228,7 +228,10 @@ p_test_no_malloc_init(test_t *t, ...) {
 }
 
 void
-p_test_fail(const char *prefix, const char *message) {
+p_test_fail(bool may_abort, const char *prefix, const char *message) {
 	malloc_cprintf(NULL, NULL, "%s%s\n", prefix, message);
 	test_status = test_status_fail;
+	if (may_abort) {
+		abort();
+	}
 }


### PR DESCRIPTION
This makes it faster and easier to debug, so that you don't need to fire up a debugger just to see which assertion triggered in a failing test.