### PR TITLE
Remove errant `#include`s in public `jemalloc.h` header

### DIFF
--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -1,6 +1,3 @@
-#include "jemalloc/jemalloc_defs.h"
-#include "jemalloc/jemalloc_macros.h"
-
 /*
  * The @je_@ prefix on the following public symbol declarations is an artifact
  * of namespace management, and should be omitted in application code unless


### PR DESCRIPTION
In an attempt to make all headers self-contained, I inadvertently added `#include`s which refer to intermediate, generated headers that aren't included in the final install. Closes #2489.