### PR TITLE
Enable fine tuning of the ncached_max of each bin

### DIFF
--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -198,7 +198,8 @@ arena_malloc(tsdn_t *tsdn, arena_t *arena, size_t size, szind_t ind, bool zero,
 			assert(sz_can_use_slab(size));
 			return tcache_alloc_small(tsdn_tsd(tsdn), arena,
 			    tcache, size, ind, zero, slow_path);
-		} else if (likely(size <= tcache_maxclass)) {
+		} else if (likely(size <=
+		    tsd_thread_tcache_max_get(tsdn_tsd(tsdn)))) {
 			return tcache_alloc_large(tsdn_tsd(tsdn), arena,
 			    tcache, size, ind, zero, slow_path);
 		}
@@ -297,7 +298,7 @@ arena_dalloc_no_tcache(tsdn_t *tsdn, void *ptr) {
 JEMALLOC_ALWAYS_INLINE void
 arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
     bool slow_path) {
-	if (szind < nhbins) {
+	if (szind < tsd_thread_nhbins_get(tsdn_tsd(tsdn))) {
 		if (config_prof && unlikely(szind < SC_NBINS)) {
 			arena_dalloc_promoted(tsdn, ptr, tcache, slow_path);
 		} else {

--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -125,6 +125,9 @@ struct cache_bin_s {
 	 * array.  Immutable after initialization.
 	 */
 	uint16_t low_bits_empty;
+
+	/* The maximum number of cached items in the bin. */
+	cache_bin_info_t bin_info;
 };
 
 /*

--- a/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -23,8 +23,14 @@ percpu_arena_update(tsd_t *tsd, unsigned cpu) {
 		tcache_t *tcache = tcache_get(tsd);
 		if (tcache != NULL) {
 			tcache_slow_t *tcache_slow = tsd_tcache_slowp_get(tsd);
-			tcache_arena_reassociate(tsd_tsdn(tsd), tcache_slow,
-			    tcache, newarena);
+			/* tcache may be disassociated when rebooted. */
+			if (tcache_slow->arena == NULL) {
+				tcache_arena_associate(tsd_tsdn(tsd),
+				    tcache_slow, tcache, newarena);
+			} else {
+				tcache_arena_reassociate(tsd_tsdn(tsd),
+				    tcache_slow, tcache, newarena);
+			}
 		}
 	}
 }

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -28,8 +28,6 @@ extern unsigned	nhbins;
 /* Maximum cached size class. */
 extern size_t	tcache_maxclass;
 
-extern cache_bin_info_t *tcache_bin_info;
-
 /*
  * Explicit tcaches, managed via the tcache.{create,flush,destroy} mallctls and
  * usable via the MALLOCX_TCACHE() flag.  The automatic per thread tcaches are

--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -64,6 +64,8 @@ void tcache_postfork_parent(tsdn_t *tsdn);
 void tcache_postfork_child(tsdn_t *tsdn);
 void tcache_flush(tsd_t *tsd);
 bool tsd_tcache_data_init(tsd_t *tsd);
+bool tsd_tcache_data_init_with_bin_info(tsd_t *tsd,
+    cache_bin_sz_t *ncached_max_arr);
 bool tsd_tcache_enabled_data_init(tsd_t *tsd);
 
 void tcache_assert_initialized(tcache_t *tcache);

--- a/include/jemalloc/internal/tsd_internals.h
+++ b/include/jemalloc/internal/tsd_internals.h
@@ -63,7 +63,9 @@ typedef ql_elm(tsd_t) tsd_link_t;
 #define TSD_DATA_SLOW							\
     O(tcache_enabled,		bool,			bool)		\
     O(reentrancy_level,		int8_t,			int8_t)		\
+    O(thread_tcache_max,	size_t,			size_t)		\
     O(min_init_state_nfetched,		uint8_t,	uint8_t)	\
+    O(thread_nhbins,		uint32_t,		uint32_t)	\
     O(thread_allocated_last_event,	uint64_t,	uint64_t)	\
     O(thread_allocated_next_event,	uint64_t,	uint64_t)	\
     O(thread_deallocated_last_event,	uint64_t,	uint64_t)	\
@@ -96,7 +98,9 @@ typedef ql_elm(tsd_t) tsd_link_t;
 #define TSD_DATA_SLOW_INITIALIZER					\
     /* tcache_enabled */	TCACHE_ENABLED_ZERO_INITIALIZER,	\
     /* reentrancy_level */	0,					\
+    /* thread_tcache_max */	TCACHE_MAXCLASS_LIMIT + 1,		\
     /* min_init_state_nfetched */	0,				\
+    /* thread_nhbins */		TCACHE_NBINS_MAX + 1,			\
     /* thread_allocated_last_event */	0,				\
     /* thread_allocated_next_event */	0,				\
     /* thread_deallocated_last_event */	0,				\

--- a/src/arena.c
+++ b/src/arena.c
@@ -157,11 +157,12 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 	malloc_mutex_lock(tsdn, &arena->tcache_ql_mtx);
 	cache_bin_array_descriptor_t *descriptor;
 	ql_foreach(descriptor, &arena->cache_bin_array_descriptor_ql, link) {
-		for (szind_t i = 0; i < nhbins; i++) {
+		for (szind_t i = 0; i < tsd_thread_nhbins_get(tsdn_tsd(tsdn));
+		    i++) {
 			cache_bin_t *cache_bin = &descriptor->bins[i];
 			cache_bin_sz_t ncached, nstashed;
 			cache_bin_nitems_get_remote(cache_bin,
-			    &tcache_bin_info[i], &ncached, &nstashed);
+			    &cache_bin->bin_info, &ncached, &nstashed);
 
 			astats->tcache_bytes += ncached * sz_index2size(i);
 			astats->tcache_stashed_bytes += nstashed *
@@ -720,7 +721,8 @@ arena_dalloc_promoted_impl(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 		safety_check_verify_redzone(ptr, usize, bumped_usize);
 	}
 	if (bumped_usize >= SC_LARGE_MINCLASS &&
-	    bumped_usize <= tcache_maxclass && tcache != NULL) {
+	    bumped_usize <= tsd_thread_tcache_max_get(tsdn_tsd(tsdn)) &&
+	    tcache != NULL) {
 		tcache_dalloc_large(tsdn_tsd(tsdn), tcache, ptr,
 		    sz_size2index(bumped_usize), slow_path);
 	} else {

--- a/src/cache_bin.c
+++ b/src/cache_bin.c
@@ -83,6 +83,7 @@ cache_bin_init(cache_bin_t *bin, cache_bin_info_t *info, void *alloc,
 	bin->low_bits_low_water = (uint16_t)(uintptr_t)bin->stack_head;
 	bin->low_bits_full = (uint16_t)(uintptr_t)full_position;
 	bin->low_bits_empty = (uint16_t)(uintptr_t)empty_position;
+	cache_bin_info_init(&bin->bin_info, info->ncached_max);
 	cache_bin_sz_t free_spots = cache_bin_diff(bin,
 	    bin->low_bits_full, (uint16_t)(uintptr_t)bin->stack_head);
 	assert(free_spots == bin_stack_size);

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -66,6 +66,7 @@ CTL_PROTO(epoch)
 CTL_PROTO(background_thread)
 CTL_PROTO(max_background_threads)
 CTL_PROTO(thread_tcache_enabled)
+CTL_PROTO(thread_tcache_max)
 CTL_PROTO(thread_tcache_flush)
 CTL_PROTO(thread_peak_read)
 CTL_PROTO(thread_peak_reset)
@@ -371,6 +372,7 @@ CTL_PROTO(stats_mutexes_reset)
 
 static const ctl_named_node_t	thread_tcache_node[] = {
 	{NAME("enabled"),	CTL(thread_tcache_enabled)},
+	{NAME("max"),		CTL(thread_tcache_max)},
 	{NAME("flush"),		CTL(thread_tcache_flush)}
 };
 
@@ -2283,6 +2285,29 @@ thread_tcache_enabled_ctl(tsd_t *tsd, const size_t *mib,
 		tcache_enabled_set(tsd, *(bool *)newp);
 	}
 	READ(oldval, bool);
+
+	ret = 0;
+label_return:
+	return ret;
+}
+
+static int
+thread_tcache_max_ctl(tsd_t *tsd, const size_t *mib,
+    size_t miblen, void *oldp, size_t *oldlenp, void *newp,
+    size_t newlen) {
+	int ret;
+	size_t oldval;
+
+	oldval = thread_tcache_max_get(tsd);
+	READ(oldval, size_t);
+
+	if (newp != NULL) {
+		if (newlen != sizeof(size_t)) {
+			ret = EINVAL;
+			goto label_return;
+		}
+		thread_tcache_max_set(tsd, *(size_t *)newp);
+	}
 
 	ret = 0;
 label_return:

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -4136,7 +4136,8 @@ batch_alloc(void **ptrs, size_t num, size_t size, int flags) {
 			filled += n;
 		}
 
-		if (likely(ind < nhbins) && progress < batch) {
+		if (likely(ind < tsd_thread_nhbins_get(tsd)) &&
+		    progress < batch) {
 			if (bin == NULL) {
 				unsigned tcache_ind = mallocx_tcache_get(flags);
 				tcache_t *tcache = tcache_get_from_ind(tsd,

--- a/test/unit/tcache_max.c
+++ b/test/unit/tcache_max.c
@@ -18,11 +18,10 @@ enum {
 	dalloc_option_end
 };
 
-static unsigned alloc_option, dalloc_option;
-static size_t tcache_max;
+static bool global_test;
 
 static void *
-alloc_func(size_t sz) {
+alloc_func(size_t sz, unsigned alloc_option) {
 	void *ret;
 
 	switch (alloc_option) {
@@ -41,7 +40,7 @@ alloc_func(size_t sz) {
 }
 
 static void
-dalloc_func(void *ptr, size_t sz) {
+dalloc_func(void *ptr, size_t sz, unsigned dalloc_option) {
 	switch (dalloc_option) {
 	case use_free:
 		free(ptr);
@@ -58,10 +57,10 @@ dalloc_func(void *ptr, size_t sz) {
 }
 
 static size_t
-tcache_bytes_read(void) {
+tcache_bytes_read_global(void) {
 	uint64_t epoch;
-	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sizeof(epoch)),
-	    0, "Unexpected mallctl() failure");
+	assert_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch,
+	    sizeof(epoch)), 0, "Unexpected mallctl() failure");
 
 	size_t tcache_bytes;
 	size_t sz = sizeof(tcache_bytes);
@@ -72,16 +71,30 @@ tcache_bytes_read(void) {
 	return tcache_bytes;
 }
 
+static size_t
+tcache_bytes_read_per_thread(void) {
+	size_t tcache_bytes = 0;
+	tsd_t *tsd = tsd_fetch();
+	tcache_t *tcache = tcache_get(tsd);
+	for (szind_t i=0; i < tsd_thread_nhbins_get(tsd); i++) {
+		cache_bin_t *cache_bin = &tcache->bins[i];
+		cache_bin_sz_t ncached =
+		    cache_bin_ncached_get_internal(cache_bin);
+		tcache_bytes += ncached * sz_index2size(i);
+	}
+	return tcache_bytes;
+}
 static void
 tcache_bytes_check_update(size_t *prev, ssize_t diff) {
-	size_t tcache_bytes = tcache_bytes_read();
+	size_t tcache_bytes = global_test ? tcache_bytes_read_global():
+	    tcache_bytes_read_per_thread();
 	expect_zu_eq(tcache_bytes, *prev + diff, "tcache bytes not expected");
-
 	*prev += diff;
 }
 
 static void
-test_tcache_bytes_alloc(size_t alloc_size) {
+test_tcache_bytes_alloc(size_t alloc_size, size_t tcache_max,
+    unsigned alloc_option, unsigned dalloc_option) {
 	expect_d_eq(mallctl("thread.tcache.flush", NULL, NULL, NULL, 0), 0,
 	    "Unexpected tcache flush failure");
 
@@ -90,65 +103,85 @@ test_tcache_bytes_alloc(size_t alloc_size) {
 	bool cached = (usize <= tcache_max);
 	ssize_t diff = cached ? usize : 0;
 
-	void *ptr1 = alloc_func(alloc_size);
-	void *ptr2 = alloc_func(alloc_size);
+	void *ptr1 = alloc_func(alloc_size, alloc_option);
+	void *ptr2 = alloc_func(alloc_size, alloc_option);
 
-	size_t bytes = tcache_bytes_read();
-	dalloc_func(ptr2, alloc_size);
+	size_t bytes = global_test ? tcache_bytes_read_global() :
+	    tcache_bytes_read_per_thread();
+	dalloc_func(ptr2, alloc_size, dalloc_option);
 	/* Expect tcache_bytes increase after dalloc */
 	tcache_bytes_check_update(&bytes, diff);
 
-	dalloc_func(ptr1, alloc_size);
+	dalloc_func(ptr1, alloc_size, alloc_option);
 	/* Expect tcache_bytes increase again */
 	tcache_bytes_check_update(&bytes, diff);
 
-	void *ptr3 = alloc_func(alloc_size);
+	void *ptr3 = alloc_func(alloc_size, alloc_option);
 	if (cached) {
 		expect_ptr_eq(ptr1, ptr3, "Unexpected cached ptr");
 	}
 	/* Expect tcache_bytes decrease after alloc */
 	tcache_bytes_check_update(&bytes, -diff);
 
-	void *ptr4 = alloc_func(alloc_size);
+	void *ptr4 = alloc_func(alloc_size, alloc_option);
 	if (cached) {
 		expect_ptr_eq(ptr2, ptr4, "Unexpected cached ptr");
 	}
 	/* Expect tcache_bytes decrease again */
 	tcache_bytes_check_update(&bytes, -diff);
 
-	dalloc_func(ptr3, alloc_size);
+	dalloc_func(ptr3, alloc_size, dalloc_option);
 	tcache_bytes_check_update(&bytes, diff);
-	dalloc_func(ptr4, alloc_size);
+	dalloc_func(ptr4, alloc_size, dalloc_option);
 	tcache_bytes_check_update(&bytes, diff);
 }
 
 static void
-test_tcache_max_impl(void) {
-	size_t sz;
+test_tcache_max_impl(size_t target_tcache_max, unsigned alloc_option,
+    unsigned dalloc_option) {
+	size_t tcache_max, sz;
 	sz = sizeof(tcache_max);
-	assert_d_eq(mallctl("arenas.tcache_max", (void *)&tcache_max,
-	    &sz, NULL, 0), 0, "Unexpected mallctl() failure");
+	if (global_test) {
+		assert_d_eq(mallctl("arenas.tcache_max", (void *)&tcache_max,
+		    &sz, NULL, 0), 0, "Unexpected mallctl() failure");
+		expect_zu_eq(tcache_max, target_tcache_max,
+		    "Global tcache_max not expected");
+	} else {
+		assert_d_eq(mallctl("thread.tcache.max",
+		    (void *)&tcache_max, &sz, NULL,.0), 0,
+		    "Unexpected.mallctl().failure");
+		if (tcache_max != target_tcache_max) {
+			abort();
+		}
+		expect_zu_eq(tcache_max, target_tcache_max,
+		    "Current thread's tcache_max not expected");
+	}
+	test_tcache_bytes_alloc(1, tcache_max, alloc_option, dalloc_option);
+	test_tcache_bytes_alloc(tcache_max - 1, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(tcache_max, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(tcache_max + 1, tcache_max, alloc_option,
+	    dalloc_option);
 
-	/* opt.tcache_max set to 1024 in tcache_max.sh */
-	expect_zu_eq(tcache_max, 1024, "tcache_max not expected");
-
-	test_tcache_bytes_alloc(1);
-	test_tcache_bytes_alloc(tcache_max - 1);
-	test_tcache_bytes_alloc(tcache_max);
-	test_tcache_bytes_alloc(tcache_max + 1);
-
-	test_tcache_bytes_alloc(PAGE - 1);
-	test_tcache_bytes_alloc(PAGE);
-	test_tcache_bytes_alloc(PAGE + 1);
+	test_tcache_bytes_alloc(PAGE - 1, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(PAGE, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(PAGE + 1, tcache_max, alloc_option,
+	    dalloc_option);
 
 	size_t large;
 	sz = sizeof(large);
 	assert_d_eq(mallctl("arenas.lextent.0.size", (void *)&large, &sz, NULL,
 	    0), 0, "Unexpected mallctl() failure");
 
-	test_tcache_bytes_alloc(large - 1);
-	test_tcache_bytes_alloc(large);
-	test_tcache_bytes_alloc(large + 1);
+	test_tcache_bytes_alloc(large - 1, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(large, tcache_max, alloc_option,
+	    dalloc_option);
+	test_tcache_bytes_alloc(large + 1, tcache_max, alloc_option,
+	    dalloc_option);
 }
 
 TEST_BEGIN(test_tcache_max) {
@@ -157,26 +190,101 @@ TEST_BEGIN(test_tcache_max) {
 	test_skip_if(opt_prof);
 	test_skip_if(san_uaf_detection_enabled());
 
-	unsigned arena_ind;
+	unsigned arena_ind, alloc_option, dalloc_option;
 	size_t sz = sizeof(arena_ind);
 	expect_d_eq(mallctl("arenas.create", (void *)&arena_ind, &sz, NULL, 0),
 	    0, "Unexpected mallctl() failure");
 	expect_d_eq(mallctl("thread.arena", NULL, NULL, &arena_ind,
 	    sizeof(arena_ind)), 0, "Unexpected mallctl() failure");
 
+	global_test = true;
 	for (alloc_option = alloc_option_start;
 	     alloc_option < alloc_option_end;
 	     alloc_option++) {
 		for (dalloc_option = dalloc_option_start;
 		     dalloc_option < dalloc_option_end;
 		     dalloc_option++) {
-			test_tcache_max_impl();
+			/* opt.tcache_max set to 1024 in tcache_max.sh. */
+			test_tcache_max_impl(1024, alloc_option,
+			    dalloc_option);
 		}
+	}
+}
+TEST_END
+
+static size_t
+tcache_max2nhbins(size_t tcache_max) {
+	return sz_size2index(tcache_max) + 1;
+}
+static void *
+tcache_check(void *arg) {
+	size_t old_thread_tcache_max, new_thread_tcache_max, sz;
+	unsigned thread_nhbins;
+	tsd_t *tsd = tsd_fetch();
+	sz = sizeof(size_t);
+	new_thread_tcache_max = *(size_t *)arg;
+
+	/* Check the default tcache_max and nhbins of each thread. */
+	thread_nhbins = thread_nhbins_get(tsd);
+	expect_zu_eq(thread_nhbins, (size_t)nhbins,
+	    "Unexpected default value for thread_nhbins");
+	assert_d_eq(mallctl("thread.tcache.max",
+	    (void *)&old_thread_tcache_max, &sz,
+	    (void *)&new_thread_tcache_max, sz),.0,
+	    "Unexpected.mallctl().failure");
+	expect_zu_eq(old_thread_tcache_max, opt_tcache_max,
+	    "Unexpected default value for thread_tcache_max");
+	/*
+	 * After reset, check the thread's tcache_max and nhbins both through
+	 * direct query and alloc tests.
+	 */
+	if (new_thread_tcache_max> TCACHE_MAXCLASS_LIMIT) {
+		new_thread_tcache_max = TCACHE_MAXCLASS_LIMIT;
+	}
+	for (unsigned alloc_option = alloc_option_start;
+	     alloc_option < alloc_option_end;
+	     alloc_option++) {
+		for (unsigned dalloc_option = dalloc_option_start;
+		     dalloc_option < dalloc_option_end;
+		     dalloc_option++) {
+			test_tcache_max_impl(new_thread_tcache_max,
+			    alloc_option, dalloc_option);
+		}
+	}
+	thread_nhbins = thread_nhbins_get(tsd);
+	expect_zu_eq(thread_nhbins, tcache_max2nhbins(new_thread_tcache_max),
+	    "Unexpected value for thread_nhbins");
+
+	return NULL;
+}
+
+TEST_BEGIN(test_thread_tcache_max) {
+	test_skip_if(!config_stats);
+	test_skip_if(!opt_tcache);
+	test_skip_if(opt_prof);
+	test_skip_if(san_uaf_detection_enabled());
+
+	unsigned nthreads = 50;
+	global_test = false;
+	VARIABLE_ARRAY(thd_t, threads, nthreads);
+	VARIABLE_ARRAY(size_t, all_threads_tcache_max, nthreads);
+	for (unsigned i=0; i < nthreads; i++) {
+		all_threads_tcache_max[i] = 1024 * (1<<(i%20));
+	}
+	for (unsigned i = 0; i < nthreads; i++) {
+		thd_create(&threads[i], tcache_check,
+		    &(all_threads_tcache_max[i]));
+	}
+	for (unsigned i = 0; i < nthreads; i++) {
+		thd_join(threads[i], NULL);
 	}
 }
 TEST_END
 
 int
 main(void) {
-	return test(test_tcache_max);
+	return test(
+	    test_tcache_max,
+	    test_thread_tcache_max);
 }
+


### PR DESCRIPTION
This PR is based on #2493. 
Summary:
1. enables fine tuning on the maximum cached items in each bin through mallctl
2. adds tests regarding the ncached_max