### PR TITLE
Expose private library dependencies via pkg-config

### DIFF
--- a/jemalloc.pc.in
+++ b/jemalloc.pc.in
@@ -10,3 +10,4 @@ URL: https://jemalloc.net/
 Version: @jemalloc_version_major@.@jemalloc_version_minor@.@jemalloc_version_bugfix@_@jemalloc_version_nrev@
 Cflags: -I${includedir}
 Libs: -L${libdir} -ljemalloc${install_suffix}
+Libs.private: @LIBS@


### PR DESCRIPTION
When linking statically, these need to be included for linking to succeed.