### PR TITLE
[stats] add option to view # of threads terminated

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -2857,6 +2857,16 @@ struct extent_hooks_s {
         arena.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="stats.arenas.i.nthreads_terminated">
+        <term>
+          <mallctl>stats.arenas.&lt;i&gt;.nthreads_terminated</mallctl>
+          (<type>unsigned</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Number of threads terminated by
+        arena.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="stats.arenas.i.uptime">
         <term>
           <mallctl>stats.arenas.&lt;i&gt;.uptime</mallctl>

--- a/include/jemalloc/internal/arena_stats.h
+++ b/include/jemalloc/internal/arena_stats.h
@@ -83,6 +83,9 @@ struct arena_stats_s {
 
 	/* Arena uptime. */
 	nstime_t		uptime;
+
+	/* Number of threads terminated. */
+	atomic_u_t nthreads_terminated;
 };
 
 static inline bool

--- a/src/arena.c
+++ b/src/arena.c
@@ -101,6 +101,7 @@ arena_stats_merge(tsdn_t *tsdn, arena_t *arena, unsigned *nthreads,
 
 	LOCKEDINT_MTX_LOCK(tsdn, arena->stats.mtx);
 
+	astats->nthreads_terminated = arena->stats.nthreads_terminated;
 	astats->base += base_allocated;
 	atomic_load_add_store_zu(&astats->internal, arena_internal_get(arena));
 	astats->metadata_thp += metadata_thp;

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -275,6 +275,7 @@ CTL_PROTO(stats_arenas_i_hpa_shard_nonfull_slabs_j_ndirty_huge)
 
 INDEX_PROTO(stats_arenas_i_hpa_shard_nonfull_slabs_j)
 CTL_PROTO(stats_arenas_i_nthreads)
+CTL_PROTO(stats_arenas_i_nthreads_terminated)
 CTL_PROTO(stats_arenas_i_uptime)
 CTL_PROTO(stats_arenas_i_dss)
 CTL_PROTO(stats_arenas_i_dirty_decay_ms)
@@ -781,6 +782,7 @@ static const ctl_named_node_t stats_arenas_i_hpa_shard_node[] = {
 
 static const ctl_named_node_t stats_arenas_i_node[] = {
 	{NAME("nthreads"),	CTL(stats_arenas_i_nthreads)},
+	{NAME("nthreads_terminated"),	CTL(stats_arenas_i_nthreads_terminated)},
 	{NAME("uptime"),	CTL(stats_arenas_i_uptime)},
 	{NAME("dss"),		CTL(stats_arenas_i_dss)},
 	{NAME("dirty_decay_ms"), CTL(stats_arenas_i_dirty_decay_ms)},
@@ -3628,6 +3630,8 @@ CTL_RO_CGEN(config_stats, stats_arenas_i_base,
 CTL_RO_CGEN(config_stats, stats_arenas_i_internal,
     atomic_load_zu(&arenas_i(mib[2])->astats->astats.internal, ATOMIC_RELAXED),
     size_t)
+CTL_RO_CGEN(config_stats, stats_arenas_i_nthreads_terminated,
+ 	atomic_load_u(&arenas_i(mib[2])->astats->astats.nthreads_terminated, ATOMIC_RELAXED), unsigned)
 CTL_RO_CGEN(config_stats, stats_arenas_i_metadata_thp,
     arenas_i(mib[2])->astats->astats.metadata_thp, size_t)
 CTL_RO_CGEN(config_stats, stats_arenas_i_tcache_bytes,

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -632,6 +632,9 @@ arena_cleanup(tsd_t *tsd) {
 	arena = tsd_arena_get(tsd);
 	if (arena != NULL) {
 		arena_unbind(tsd, arena_ind_get(arena), false);
+		if (config_stats) {
+			atomic_fetch_add_u(&arena->stats.nthreads_terminated, 1, ATOMIC_RELAXED);
+		}
 	}
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1049,6 +1049,7 @@ stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
 	char name[ARENA_NAME_LEN];
 	char *namep = name;
 	unsigned nthreads;
+	unsigned nthreads_terminated;
 	const char *dss;
 	ssize_t dirty_decay_ms, muzzy_decay_ms;
 	size_t page, pactive, pdirty, pmuzzy, mapped, retained;
@@ -1073,6 +1074,10 @@ stats_arena_print(emitter_t *emitter, unsigned i, bool bins, bool large,
 	CTL_M2_GET("stats.arenas.0.nthreads", i, &nthreads, unsigned);
 	emitter_kv(emitter, "nthreads", "assigned threads",
 	    emitter_type_unsigned, &nthreads);
+
+	CTL_M2_GET("stats.arenas.0.nthreads_terminated", i, &nthreads, unsigned);
+	emitter_kv(emitter, "nthreads_terminated", "threads terminated",
+		emitter_type_unsigned, &nthreads_terminated);
 
 	CTL_M2_GET("stats.arenas.0.uptime", i, &uptime, uint64_t);
 	emitter_kv(emitter, "uptime_ns", "uptime", emitter_type_uint64,


### PR DESCRIPTION
- adds an option to see number of threads terminated, see [related issue](https://github.com/jemalloc/jemalloc/issues/1727)
- tested with
```
$ ./configure --enable-debug 
$ make check -j$(nproc) 
```

```
=== test/unit/zero_reallocs ===
test_zero_reallocs (non-reentrant): pass
--- pass: 1/1, skip: 0/1, fail: 0/1 ---

Test suite summary: pass: 79/98, skip: 19/98, fail: 0/98
```