### PR TITLE
Mark jemalloc.h as system header to resolve header conflicts.

### DIFF
--- a/include/jemalloc/jemalloc.sh
+++ b/include/jemalloc/jemalloc.sh
@@ -5,6 +5,7 @@ objroot=$1
 cat <<EOF
 #ifndef JEMALLOC_H_
 #define JEMALLOC_H_
+#pragma GCC system_header
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This is should help solve the header conflicts between jemalloc.h and mm_malloc.h in some cases. Planning to separate all jemalloc-specific functions in a new header to solve the conflict for good in the future.

#2255