### PR TITLE
[easy] Fix a zero-initializer warning on macOS.

### DIFF
--- a/include/jemalloc/internal/tcache_types.h
+++ b/include/jemalloc/internal/tcache_types.h
@@ -10,7 +10,7 @@ typedef struct tcaches_s tcaches_t;
 
 /* Used in TSD static initializer only. Real init in tsd_tcache_data_init(). */
 #define TCACHE_ZERO_INITIALIZER {0}
-#define TCACHE_SLOW_ZERO_INITIALIZER {0}
+#define TCACHE_SLOW_ZERO_INITIALIZER {{0}}
 
 /* Used in TSD static initializer only. Will be initialized to opt_tcache. */
 #define TCACHE_ENABLED_ZERO_INITIALIZER false


### PR DESCRIPTION
Warning msg such as:
```
include/jemalloc/internal/tsd_generic.h:134:22: warning: suggest braces around initialization of subobject [-Wmissing-braces]
        tsd_t initializer = TSD_INITIALIZER;
                            ^~~~~~~~~~~~~~~
include/jemalloc/internal/tsd.h:152:9: note: expanded from macro 'TSD_INITIALIZER'
                                TSD_DATA_SLOW_INITIALIZER               \
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
include/jemalloc/internal/tsd.h:123:24: note: expanded from macro 'TSD_DATA_SLOW_INITIALIZER'
    /* tcache_slow */           TCACHE_SLOW_ZERO_INITIALIZER,           \
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/jemalloc/internal/tcache_types.h:22:39: note: expanded from macro 'TCACHE_SLOW_ZERO_INITIALIZER'
#define TCACHE_SLOW_ZERO_INITIALIZER {0}
```
Verified on my mac locally.