### PR TITLE
Call Windows TlsGetValue2 instead of TlsGetValue when available

### DIFF
--- a/include/jemalloc/internal/quantum.h
+++ b/include/jemalloc/internal/quantum.h
@@ -24,7 +24,7 @@
 #  ifdef __arm__
 #    define LG_QUANTUM		3
 #  endif
-#  ifdef __aarch64__
+#  if defined(__aarch64__) || defined(_M_ARM64)
 #    define LG_QUANTUM		4
 #  endif
 #  ifdef __hppa__

--- a/include/jemalloc/internal/tsd_win.h
+++ b/include/jemalloc/internal/tsd_win.h
@@ -15,6 +15,16 @@ typedef struct {
 extern DWORD tsd_tsd;
 extern tsd_wrapper_t tsd_boot_wrapper;
 extern bool tsd_booted;
+#if defined(_M_ARM64EC)
+#define JEMALLOC_WIN32_TLSGETVALUE2 0
+#else
+#define JEMALLOC_WIN32_TLSGETVALUE2 1
+#endif
+#if JEMALLOC_WIN32_TLSGETVALUE2
+typedef LPVOID (WINAPI *TGV2)(DWORD dwTlsIndex);
+extern TGV2 tls_get_value2;
+extern HMODULE tgv2_mod;
+#endif
 
 /* Initialization/cleanup. */
 JEMALLOC_ALWAYS_INLINE bool
@@ -49,9 +59,17 @@ tsd_wrapper_set(tsd_wrapper_t *wrapper) {
 
 JEMALLOC_ALWAYS_INLINE tsd_wrapper_t *
 tsd_wrapper_get(bool init) {
-	DWORD error = GetLastError();
-	tsd_wrapper_t *wrapper = (tsd_wrapper_t *) TlsGetValue(tsd_tsd);
-	SetLastError(error);
+	tsd_wrapper_t *wrapper;
+#if JEMALLOC_WIN32_TLSGETVALUE2
+	if (tls_get_value2 != NULL) {
+		wrapper = (tsd_wrapper_t *) tls_get_value2(tsd_tsd);
+	} else
+#endif
+	{
+		DWORD error = GetLastError();
+		wrapper = (tsd_wrapper_t *) TlsGetValue(tsd_tsd);
+		SetLastError(error);
+	}
 
 	if (init && unlikely(wrapper == NULL)) {
 		wrapper = (tsd_wrapper_t *)
@@ -78,6 +96,12 @@ tsd_boot0(void) {
 	}
 	_malloc_tsd_cleanup_register(&tsd_cleanup_wrapper);
 	tsd_wrapper_set(&tsd_boot_wrapper);
+#if JEMALLOC_WIN32_TLSGETVALUE2
+	tgv2_mod = LoadLibraryA("api-ms-win-core-processthreads-l1-1-8.dll");
+	if (tgv2_mod != NULL) {
+		tls_get_value2 = (TGV2)GetProcAddress(tgv2_mod, "TlsGetValue2");
+	}
+#endif
 	tsd_booted = true;
 	return false;
 }

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -25,6 +25,10 @@ bool tsd_booted = false;
 DWORD tsd_tsd;
 tsd_wrapper_t tsd_boot_wrapper = {false, TSD_INITIALIZER};
 bool tsd_booted = false;
+#if JEMALLOC_WIN32_TLSGETVALUE2
+TGV2 tls_get_value2 = NULL;
+HMODULE tgv2_mod = NULL;
+#endif
 #else
 
 /*


### PR DESCRIPTION
Windows 11 24H2 supports [TlsGetValue2.](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsgetvalue2) Compared to TlsGetValue, TlsGetValue2 is guaranteed to not touch the last error, therefore eliminating the need to call GetLastError and SetLastError to save and restore the last error value. This has noticeable performance impact on tested CPUs measured by the following simple microbenchmark.
```
#define JEMALLOC_NO_DEMANGLE
#include <jemalloc/jemalloc.h>
#include <chrono>
#include <iostream>

const unsigned __int64 ITERATIONS = 0x800000;

void main() {
    static const int sizes[] =
    {
        7, 16, 32, 60, 91, 100, 120, 144, 169, 199, 255
    };
    
    auto start = std::chrono::high_resolution_clock::now();
    for (unsigned __int64 i = 0; i < ITERATIONS; i++)
    {
        for (auto sz : sizes)
        {
            void* p = je_malloc(sz);
            je_free(p);
        }
    }
    auto end = std::chrono::high_resolution_clock::now();
    std::chrono::duration<double> diff = end - start;
    std::cout << "Time: " << diff.count() << " s\n";
}

                                   Vanilla (sec)       This change (sec)      Time Delta
Intel i9-13900KF (x64)               1.12                      0.99               -11.6%
Snapdragon X1E78100 (Arm64)          1.71                      0.98               -42.7%
Snapdragon X1E78100 (Arm64EC)        1.76                      4.62              +162.5%
Windows Devkit 2023 (Arm64)          1.45                      1.32                -9.0%
Windows Devkit 2023 (Arm64EC)        1.45                      7.33              +405.5%
```
In x64 or Arm64 native cases, this PR eliminates calls against GetLastError/SetLastError so we saw noticeable time reduction. However, for Arm64EC, although GetLastError/SetLastError, are eliminated, we need to indirectly call TlsGetValue2, and Arm64EC indirect calls need to do EC bitmap check and fast-forward sequence check, so overall it's slower. Not because TlsGetValue2 is slower, but the cost of getting TlsGetValue2 is large. Therefore, this change is enabled for every architecture other than Arm64EC.