### PR TITLE
build: Make autogen.sh accept quoted extra options

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,8 +9,8 @@ for i in autoconf; do
     fi
 done
 
-echo "./configure --enable-autogen $@"
-./configure --enable-autogen $@
+echo "./configure --enable-autogen \"$@\""
+./configure --enable-autogen "$@"
 if [ $? -ne 0 ]; then
     echo "Error $? in ./configure"
     exit 1


### PR DESCRIPTION
The current autogen.sh script doesn't allow receiving quoted extra options.

If someone wants to pass extra CFLAGS that is split into multiple options with a whitespace, then a quote is required.

However, the configure inside autogen.sh fails in this case as follows.
```
  $ ./autogen.sh CFLAGS="-Dmmap=cxl_mmap -Dmunmap=cxl_munmap"
  autoconf
  ./configure --enable-autogen CFLAGS=-Dmmap=cxl_mmap -Dmunmap=cxl_munmap
  configure: error: unrecognized option: `-Dmunmap=cxl_munmap'
  Try `./configure --help' for more information
  Error 0 in ./configure
```
It's because the quote discarded unexpectedly when calling configure.

This patch is to fix this problem.