### PR TITLE
Add support for namespace pids in heap profile names

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,6 +60,7 @@ enable_doc := @enable_doc@
 enable_shared := @enable_shared@
 enable_static := @enable_static@
 enable_prof := @enable_prof@
+enable_pid_namespace := @enable_pid_namespace@
 enable_zone_allocator := @enable_zone_allocator@
 enable_experimental_smallocx := @enable_experimental_smallocx@
 MALLOC_CONF := @JEMALLOC_CPREFIX@MALLOC_CONF
@@ -160,6 +161,9 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 ifeq ($(enable_zone_allocator), 1)
 C_SRCS += $(srcroot)src/zone.c
 endif
+ifeq ($(enable_pid_namespace), 1)
+C_SRCS += $(srcroot)src/pid_namespace.c
+endif
 ifeq ($(IMPORTLIB),$(SO))
 STATIC_LIBS := $(objroot)lib/$(LIBJEMALLOC).$(A)
 endif
@@ -257,6 +261,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_idump.c \
 	$(srcroot)test/unit/prof_log.c \
 	$(srcroot)test/unit/prof_mdump.c \
+	$(srcroot)test/unit/prof_pid_namespace.c \
 	$(srcroot)test/unit/prof_recent.c \
 	$(srcroot)test/unit/prof_reset.c \
 	$(srcroot)test/unit/prof_small.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1080,6 +1080,28 @@ enable_shared="1"
 )
 AC_SUBST([enable_shared])
 
+dnl Enable pid namespace support
+AC_CHECK_FUNCS([unshare])
+AC_ARG_ENABLE([pid_namespace],
+  [AS_HELP_STRING([--enable-pid-namespace], [Enable pid namespace support])],
+if test "x$enable_pid_namespace" = "xno" ; then
+  enable_pid_namespace="0"
+else
+  if test "x$ac_cv_func_unshare" != x; then
+    enable_pid_namespace="1"
+  else
+    enable_pid_namespace="0"
+  fi
+fi
+,
+enable_pid_namespace="0"
+)
+AC_SUBST([enable_pid_namespace])
+if test "x$enable_pid_namespace" = "x1"; then
+  AC_DEFINE([JEMALLOC_PID_NAMESPACE], [1], [Enable pid namespace support])
+fi
+
+
 dnl Enable static libs
 AC_ARG_ENABLE([static],
   [AS_HELP_STRING([--enable-static], [Build static libaries])],
@@ -2814,6 +2836,7 @@ AC_MSG_RESULT([static libs        : ${enable_static}])
 AC_MSG_RESULT([autogen            : ${enable_autogen}])
 AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([stats              : ${enable_stats}])
+AC_MSG_RESULT([pid_namespace      : ${enable_pid_namespace}])
 AC_MSG_RESULT([experimental_smallocx : ${enable_experimental_smallocx}])
 AC_MSG_RESULT([prof               : ${enable_prof}])
 AC_MSG_RESULT([prof-libunwind     : ${enable_prof_libunwind}])

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1514,6 +1514,23 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         by default.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="opt.prof_pid_namespace">
+        <term>
+          <mallctl>opt.prof_pid_namespace</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+          [<option>--enable-pid-namespace</option>]
+        </term>
+        <listitem><para>Enable adding the pid namespace to the profile
+        filename. Profiles are dumped to files named according to the pattern
+        <filename>&lt;prefix&gt;.&lt;pid_namespace&gt;.&lt;pid&gt;.&lt;seq&gt;.i&lt;iseq&gt;.heap</filename>,
+        where <literal>&lt;prefix&gt;</literal> is controlled by the <link
+        linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link> and
+        <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
+        options.
+        </para></listitem>
+      </varlistentry>
+
       <varlistentry id="opt.lg_prof_interval">
         <term>
           <mallctl>opt.lg_prof_interval</mallctl>

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -456,4 +456,7 @@
 
 #include "jemalloc/internal/jemalloc_internal_overrides.h"
 
+/* Defined if pid namespaces are supported. */
+#undef JEMALLOC_PID_NAMESPACE
+
 #endif /* JEMALLOC_INTERNAL_DEFS_H_ */

--- a/include/jemalloc/internal/jemalloc_internal_includes.h
+++ b/include/jemalloc/internal/jemalloc_internal_includes.h
@@ -61,6 +61,7 @@
 #include "jemalloc/internal/arena_externs.h"
 #include "jemalloc/internal/large_externs.h"
 #include "jemalloc/internal/tcache_externs.h"
+#include "jemalloc/internal/pid_namespace_externs.h"
 #include "jemalloc/internal/prof_externs.h"
 #include "jemalloc/internal/background_thread_externs.h"
 

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -260,4 +260,13 @@ static const bool have_memcntl =
 #endif
     ;
 
+/* Whether or not the pid namespaces are enabled. */
+static const bool config_enable_pid_namespace =
+#ifdef JEMALLOC_PID_NAMESPACE
+    true
+#else
+    false
+#endif
+;
+
 #endif /* JEMALLOC_PREAMBLE_H */

--- a/include/jemalloc/internal/pid_namespace_externs.h
+++ b/include/jemalloc/internal/pid_namespace_externs.h
@@ -1,0 +1,14 @@
+#ifndef JEMALLOC_INTERNAL_PID_NAMESPACE_EXTERNS_H
+#define JEMALLOC_INTERNAL_PID_NAMESPACE_EXTERNS_H
+
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#ifdef JEMALLOC_PID_NAMESPACE
+#include <stddef.h>
+#include <sys/types.h>
+
+ssize_t pid_namespace();
+#endif /* JEMALLOC_PID_NAMESPACE */
+
+#endif /* JEMALLOC_INTERNAL_PID_NAMESPACE_EXTERNS_H */

--- a/include/jemalloc/internal/prof_externs.h
+++ b/include/jemalloc/internal/prof_externs.h
@@ -26,6 +26,9 @@ extern char opt_prof_prefix[
     1];
 extern bool opt_prof_unbias;
 
+/* Include pid namespace in profile file names. */
+extern bool opt_prof_pid_namespace;
+
 /* For recording recent allocations */
 extern ssize_t opt_prof_recent_alloc_max;
 

--- a/include/jemalloc/jemalloc_defs.h.in
+++ b/include/jemalloc/jemalloc_defs.h.in
@@ -22,6 +22,9 @@
 /* Defined if deprecated attribute is supported. */
 #undef JEMALLOC_HAVE_ATTR_DEPRECATED
 
+/* Defined if pid namespaces are supported */
+#undef JEMALLOC_PID_NAMESPACE
+
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -153,6 +153,7 @@ CTL_PROTO(opt_prof_final)
 CTL_PROTO(opt_prof_leak)
 CTL_PROTO(opt_prof_leak_error)
 CTL_PROTO(opt_prof_accum)
+CTL_PROTO(opt_prof_pid_namespace)
 CTL_PROTO(opt_prof_recent_alloc_max)
 CTL_PROTO(opt_prof_stats)
 CTL_PROTO(opt_prof_sys_thread_name)
@@ -495,6 +496,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("prof_leak"),	CTL(opt_prof_leak)},
 	{NAME("prof_leak_error"),	CTL(opt_prof_leak_error)},
 	{NAME("prof_accum"),	CTL(opt_prof_accum)},
+	{NAME("prof_pid_namespace"),	CTL(opt_prof_pid_namespace)},
 	{NAME("prof_recent_alloc_max"),	CTL(opt_prof_recent_alloc_max)},
 	{NAME("prof_stats"),	CTL(opt_prof_stats)},
 	{NAME("prof_sys_thread_name"),	CTL(opt_prof_sys_thread_name)},
@@ -2213,6 +2215,7 @@ CTL_RO_NL_CGEN(config_prof, opt_prof_thread_active_init,
 CTL_RO_NL_CGEN(config_prof, opt_prof_bt_max, opt_prof_bt_max, unsigned)
 CTL_RO_NL_CGEN(config_prof, opt_lg_prof_sample, opt_lg_prof_sample, size_t)
 CTL_RO_NL_CGEN(config_prof, opt_prof_accum, opt_prof_accum, bool)
+CTL_RO_NL_CGEN(config_prof, opt_prof_pid_namespace, opt_prof_pid_namespace, bool)
 CTL_RO_NL_CGEN(config_prof, opt_lg_prof_interval, opt_lg_prof_interval, ssize_t)
 CTL_RO_NL_CGEN(config_prof, opt_prof_gdump, opt_prof_gdump, bool)
 CTL_RO_NL_CGEN(config_prof, opt_prof_final, opt_prof_final, bool)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1619,6 +1619,7 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 				CONF_HANDLE_BOOL(opt_prof_leak_error,
 				    "prof_leak_error")
 				CONF_HANDLE_BOOL(opt_prof_log, "prof_log")
+				CONF_HANDLE_BOOL(opt_prof_pid_namespace, "prof_pid_namespace")
 				CONF_HANDLE_SSIZE_T(opt_prof_recent_alloc_max,
 				    "prof_recent_alloc_max", -1, SSIZE_MAX)
 				CONF_HANDLE_BOOL(opt_prof_stats, "prof_stats")

--- a/src/pid_namespace.c
+++ b/src/pid_namespace.c
@@ -1,0 +1,20 @@
+#include "jemalloc/internal/pid_namespace_externs.h"
+
+#ifdef JEMALLOC_PID_NAMESPACE
+#include <sys/stat.h>
+
+static const char* PID_NAMESPACE_PATH = "/proc/self/ns/pid";
+static const char* PID_NAMESPACE_SEP = "pid:[";
+
+ssize_t pid_namespace() {
+  char buf[PATH_MAX + 1];
+  ssize_t linklen = readlink(PID_NAMESPACE_PATH, buf, PATH_MAX);
+  if (linklen == -1) {
+    return 0;
+  }
+  // Trim the trailing "]"
+  buf[linklen-1] = '\0';
+  char* index = strtok(buf, PID_NAMESPACE_SEP);
+  return atol(index);
+}
+#endif

--- a/src/prof.c
+++ b/src/prof.c
@@ -34,6 +34,7 @@ bool opt_prof_final = false;
 bool opt_prof_leak = false;
 bool opt_prof_leak_error = false;
 bool opt_prof_accum = false;
+bool opt_prof_pid_namespace = false;
 char opt_prof_prefix[PROF_DUMP_FILENAME_LEN];
 bool opt_prof_sys_thread_name = false;
 bool opt_prof_unbias = true;

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -317,6 +317,7 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(unsigned, prof_bt_max, prof);
 	TEST_MALLCTL_OPT(ssize_t, lg_prof_sample, prof);
 	TEST_MALLCTL_OPT(bool, prof_accum, prof);
+	TEST_MALLCTL_OPT(bool, prof_pid_namespace, prof);
 	TEST_MALLCTL_OPT(ssize_t, lg_prof_interval, prof);
 	TEST_MALLCTL_OPT(bool, prof_gdump, prof);
 	TEST_MALLCTL_OPT(bool, prof_final, prof);

--- a/test/unit/prof_pid_namespace.c
+++ b/test/unit/prof_pid_namespace.c
@@ -1,0 +1,75 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/prof_sys.h"
+#ifdef JEMALLOC_PID_NAMESPACE
+#include "jemalloc/internal/pid_namespace_externs.h"
+#endif
+
+#define TEST_PREFIX "test_prefix"
+
+static bool did_prof_dump_open;
+
+static int
+prof_dump_open_file_intercept(const char *filename, int mode) {
+	int fd;
+
+	did_prof_dump_open = true;
+
+	char filename_prefix[] = TEST_PREFIX ".";
+#ifdef JEMALLOC_PID_NAMESPACE
+    if (config_enable_pid_namespace) {
+		ssize_t pid_ns = pid_namespace();
+		int len = snprintf(NULL, 0, "%ld", pid_ns);
+		snprintf(&filename_prefix[strlen(filename_prefix)], len + 1, "%ld", pid_ns);
+	} else {
+		int pid = getpid();
+		int len = snprintf(NULL, 0, "%d", pid);
+		snprintf(&filename_prefix[strlen(filename_prefix)], len + 1, "%d", pid);
+	}
+#else
+	int pid = getpid();
+	int len = snprintf(NULL, 0, "%d", pid);
+	snprintf(&filename_prefix[strlen(filename_prefix)], len + 1, "%d", pid);
+#endif
+	expect_d_eq(strncmp(filename_prefix, filename, sizeof(filename_prefix)
+	    - 1), 0, "Dump file name should start with \"" TEST_PREFIX ".\"");
+
+	fd = open("/dev/null", O_WRONLY);
+	assert_d_ne(fd, -1, "Unexpected open() failure");
+
+	return fd;
+}
+
+TEST_BEGIN(test_pid_namespace_dump) {
+	bool active;
+	void *p;
+
+	const char *test_prefix = TEST_PREFIX;
+
+	test_skip_if(!config_prof);
+
+	active = true;
+
+	expect_d_eq(mallctl("prof.prefix", NULL, NULL, (void *)&test_prefix,
+	    sizeof(test_prefix)), 0,
+	    "Unexpected mallctl failure while overwriting dump prefix");
+
+	expect_d_eq(mallctl("prof.active", NULL, NULL, (void *)&active,
+	    sizeof(active)), 0,
+	    "Unexpected mallctl failure while activating profiling");
+
+	prof_dump_open_file = prof_dump_open_file_intercept;
+
+	did_prof_dump_open = false;
+	p = mallocx(1, 0);
+	expect_ptr_not_null(p, "Unexpected mallocx() failure");
+	dallocx(p, 0);
+	expect_true(did_prof_dump_open, "Expected a profile dump");
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_pid_namespace_dump);
+}

--- a/test/unit/prof_pid_namespace.sh
+++ b/test/unit/prof_pid_namespace.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export MALLOC_CONF="tcache:false"
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="${MALLOC_CONF},prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0,lg_prof_interval:0,prof_pid_namespace:true"
+fi


### PR DESCRIPTION
This change adds support for writing pid namespaces to the filename of a heap profile. When running with namespaces pids may reused across namespaces and if mounts are shared where profiles are written there is not a great way to differentiate profiles between pids. I couldn't get the `check-formatting.sh` script to work well as it depends on a rather older version of `clang-format` and my version `12.0.0` produced rather difference values.