### PR TITLE
Remove the size assert of je_nallocx

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3870,8 +3870,6 @@ je_nallocx(size_t size, int flags) {
 	size_t usize;
 	tsdn_t *tsdn;
 
-	assert(size != 0);
-
 	if (unlikely(malloc_init())) {
 		LOG("core.nallocx.exit", "result: %zu", ZU(0));
 		return 0;


### PR DESCRIPTION
```
#include <iostream>
#include <string>
#include <math.h>
#include <vector>
#include <array>
#include <memory>
#include <queue>
#include <atomic>
#include <mutex>
#include "jemalloc.h"

using namespace std;

int main() {
    void* ptr = je_malloc(0);
    std::cout << "MALLOC OK:" << ptr << std::endl;
    std::cout << "SIZE: " << jemalloc_usable_size(ptr) << std::endl;
    std::cout << "NALLOCX_SIZE: " << je_nallocx(0, 0) << std::endl;
    je_free(ptr);

    return 0;
}
```

g++ b.cpp -lpthread -ljemalloc -L./lib_debug

```
./a.out 
MALLOC OK:0x7efc9e408000
SIZE: 8
<jemalloc>: src/jemalloc.c:3963: Failed assertion: "size != 0"
```

Behavior after removal

```
./a.out 
MALLOC OK:0x7f095bc08000
SIZE: 8
NALLOCX_SIZE: 8
```

