### PR TITLE
Fix type error with allocated that caused incorrect printing on 32bit

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -324,7 +324,7 @@ stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i,
 
 	COL_HDR(row, size, NULL, right, 20, size)
 	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, allocated, NULL, right, 13, uint64)
+	COL_HDR(row, allocated, NULL, right, 13, size)
 	COL_HDR(row, nmalloc, NULL, right, 13, uint64)
 	COL_HDR(row, nmalloc_ps, "(#/sec)", right, 8, uint64)
 	COL_HDR(row, ndalloc, NULL, right, 13, uint64)


### PR DESCRIPTION
accidentally saw this issue in our 32-bit test CI(https://github.com/redis/redis/actions/runs/7689292345/job/20951532396).

```
bins:           size ind    allocated      nmalloc (#/sec)      ndalloc (#/sec)    nrequests   (#/sec)  nshards      curregs     curslabs  nonfull_slabs regs pgs   util       nfills (#/sec)     nflushes (#/sec)       nslabs     nreslabs (#/sec)      n_lock_ops (#/sec)       n_waiting (#/sec)      n_spin_acq (#/sec)  n_owner_switch (#/sec)   total_wait_ns   (#/sec)     max_wait_ns  max_n_thds
                   8   018426612771719224472        51166     465        50251     456      2033836     18489        1          915            2              0  512   1  0.893         2113      19          564       5          100            1       0            6017      54               0       0               0       0              70       0               0         0               0           0
                  16   118426612771722053280      2169744   19724      1992486   18113     11267673    102433        1       177258          987            364  256   1  0.701        26604     241        15681     142         6597         7711      70        78313578  711941               0       0               0       0          889506    8086               0         0               0           0
                  24   218426612771719227136          607       5          191       1      4068099     36982        1          416            1              0  512   3  0.812          113       1          102       0            1            0       0            3416      31               0       0               0       0               2       0               0         0               0           0
```