### PR TITLE
Print out all malloc_conf settings in stats

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -38,6 +38,9 @@ extern atomic_zu_t zero_realloc_count;
 extern bool opt_cache_oblivious;
 extern unsigned opt_debug_double_free_max_scan;
 
+extern const char *opt_malloc_conf_symlink;
+extern const char *opt_malloc_conf_env_var;
+
 /* Escape free-fastpath when ptr & mask == 0 (for sanitization purpose). */
 extern uintptr_t san_cache_bin_nonfast_mask;
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -159,6 +159,10 @@ CTL_PROTO(opt_prof_sys_thread_name)
 CTL_PROTO(opt_prof_time_res)
 CTL_PROTO(opt_lg_san_uaf_align)
 CTL_PROTO(opt_zero_realloc)
+CTL_PROTO(opt_malloc_conf_symlink)
+CTL_PROTO(opt_malloc_conf_env_var)
+CTL_PROTO(opt_malloc_conf_global_var)
+CTL_PROTO(opt_malloc_conf_global_var_2_conf_harder)
 CTL_PROTO(tcache_create)
 CTL_PROTO(tcache_flush)
 CTL_PROTO(tcache_destroy)
@@ -426,6 +430,14 @@ static const ctl_named_node_t	config_node[] = {
 	{NAME("xmalloc"),	CTL(config_xmalloc)}
 };
 
+static const ctl_named_node_t opt_malloc_conf_node[] = {
+	{NAME("symlink"),	CTL(opt_malloc_conf_symlink)},
+	{NAME("env_var"),	CTL(opt_malloc_conf_env_var)},
+	{NAME("global_var"),	CTL(opt_malloc_conf_global_var)},
+	{NAME("global_var_2_conf_harder"),
+	    CTL(opt_malloc_conf_global_var_2_conf_harder)}
+};
+
 static const ctl_named_node_t opt_node[] = {
 	{NAME("abort"),		CTL(opt_abort)},
 	{NAME("abort_conf"),	CTL(opt_abort_conf)},
@@ -502,7 +514,8 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("lg_san_uaf_align"),	CTL(opt_lg_san_uaf_align)},
 	{NAME("zero_realloc"),	CTL(opt_zero_realloc)},
 	{NAME("debug_double_free_max_scan"),
-		CTL(opt_debug_double_free_max_scan)}
+		CTL(opt_debug_double_free_max_scan)},
+	{NAME("malloc_conf"),	CHILD(named, opt_malloc_conf)}
 };
 
 static const ctl_named_node_t	tcache_node[] = {
@@ -2229,6 +2242,17 @@ CTL_RO_NL_CGEN(config_uaf_detection, opt_lg_san_uaf_align,
     opt_lg_san_uaf_align, ssize_t)
 CTL_RO_NL_GEN(opt_zero_realloc,
     zero_realloc_mode_names[opt_zero_realloc_action], const char *)
+
+/* malloc_conf options */
+CTL_RO_NL_CGEN(opt_malloc_conf_symlink, opt_malloc_conf_symlink,
+    opt_malloc_conf_symlink, const char *)
+CTL_RO_NL_CGEN(opt_malloc_conf_env_var, opt_malloc_conf_env_var,
+    opt_malloc_conf_env_var, const char *)
+CTL_RO_NL_CGEN(je_malloc_conf, opt_malloc_conf_global_var, je_malloc_conf,
+    const char *)
+CTL_RO_NL_CGEN(je_malloc_conf_2_conf_harder,
+    opt_malloc_conf_global_var_2_conf_harder, je_malloc_conf_2_conf_harder,
+    const char *)
 
 /******************************************************************************/
 

--- a/test/unit/malloc_conf_2.c
+++ b/test/unit/malloc_conf_2.c
@@ -22,8 +22,32 @@ TEST_BEGIN(test_malloc_conf_2) {
 }
 TEST_END
 
+TEST_BEGIN(test_mallctl_global_var) {
+#ifdef _WIN32
+	bool windows = true;
+#else
+	bool windows = false;
+#endif
+	/* Windows doesn't support weak symbol linker trickery. */
+	test_skip_if(windows);
+
+	const char *mc;
+	size_t sz = sizeof(mc);
+	expect_d_eq(mallctl("opt.malloc_conf.global_var",
+	    (void *)&mc, &sz, NULL, 0), 0, "Unexpected mallctl() failure");
+	expect_str_eq(mc, malloc_conf, "Unexpected value for the global variable "
+	    "malloc_conf");
+
+	expect_d_eq(mallctl("opt.malloc_conf.global_var_2_conf_harder",
+	    (void *)&mc, &sz, NULL, 0), 0, "Unexpected mallctl() failure");
+	expect_str_eq(mc, malloc_conf_2_conf_harder, "Unexpected value for the "
+	    "global variable malloc_conf_2_conf_harder");
+}
+TEST_END
+
 int
 main(void) {
 	return test(
-	    test_malloc_conf_2);
+	    test_malloc_conf_2,
+	    test_mallctl_global_var);
 }


### PR DESCRIPTION
- Add the malloc conf settings under the existing Runtime Option Settings in stats output
- Print out the value of global variable malloc_conf, filename referenced by the symbolic link /etc/malloc.conf, and the value of env variable MALLOC_CONF in order.

With the symbolic link and the environment variable set,
     lrwxrwxrwx 1 root root 10 Feb 12 11:28 /etc/malloc.conf -> abort:true
     MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0,prof_stats:true,stats_print:true

Sample Output:
___ Begin jemalloc statistics ___
Version: "5.3.0-148-g287ac1775ddd07614e3f0ffddcb418d1f97e711b"
Build-time option settings
  config.cache_oblivious: true
  config.debug: true
  config.fill: true
  config.lazy_lock: false
  config.malloc_conf: ""
  config.opt_safety_checks: true
  config.prof: true
  config.prof_libgcc: true
  config.prof_libunwind: false
  config.stats: true
  config.utrace: false
  config.xmalloc: false
Run-time option settings
  Global variable malloc_conf: ""
  Symbolic link malloc.conf: "abort:true"
  Environment variable MALLOC_CONF: "prof:true,prof_active:true,lg_prof_sample:0,prof_stats:true,stats_print:true"
  opt.abort: true
  opt.abort_conf: true
  opt.cache_oblivious: true
  opt.confirm_conf: false
  opt.retain: true
  opt.dss: "secondary"
  opt.narenas: 320
  opt.percpu_arena: "disabled"
  opt.oversize_threshold: 8388608
  opt.hpa: false
  opt.hpa_slab_max_alloc: 65536
  opt.hpa_hugification_threshold: 1992294
.....