### PR TITLE
Allow zero sized memalign to pass.

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3052,6 +3052,7 @@ je_memalign(size_t alignment, size_t size) {
 	static_opts_init(&sopts);
 	dynamic_opts_init(&dopts);
 
+	sopts.bump_empty_aligned_alloc = true;
 	sopts.min_alignment = 1;
 	sopts.oom_string =
 	    "<jemalloc>: Error allocating aligned memory: out of memory\n";


### PR DESCRIPTION
Instead of failing on assertions.  Previously the same change was made for posix_memalign and aligned_alloc (#1554).  Make memalign behave the same way even though it's obsolete.

Reported by Conrad Meyer