### PR TITLE
Fix Cirrus CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,9 +40,6 @@ task:
      - name: 13-STABLE
        freebsd_instance:
          image_family: freebsd-13-2-snap
-     - name: 13.0-RELEASE
-       freebsd_instance:
-         image_family: freebsd-13-0
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - pkg upgrade -y


### PR DESCRIPTION
13.0-RELEASE does not exist anymore.  "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-13-0' was not found"