### PR TITLE
Replace unsigned induction variable with size_t in background_threads

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -580,7 +580,7 @@ background_threads_enable(tsd_t *tsd) {
 
 	VARIABLE_ARRAY(bool, marked, max_background_threads);
 	unsigned nmarked;
-	for (unsigned i = 0; i < max_background_threads; i++) {
+	for (size_t i = 0; i < max_background_threads; i++) {
 		marked[i] = false;
 	}
 	nmarked = 0;


### PR DESCRIPTION
Hi, everyone! 
I'm a compiler developer and work on detecting missed compiler optimization opportunities in real-world projects. Recently, a missed optimization opportunity is detected in jemalloc project. This is hard to solve in compilers, but easy to solve in original project, so I post a pr to fix it here.

Since the type of `unsigned` induction is inconsistent with `size_t` variable `max_background_threads`, LLVM vectorizes it but produces weird IR and GCC fails to recognize memset pattern.

This patch avoids unnecessary vectorizations in clang and missed recognition of memset in gcc. See also [godbolt example](https://godbolt.org/z/aoeMsjr4c) and the upstream issue https://github.com/llvm/llvm-project/issues/83724.

This patch brings semantic change actually (original program may fall into infinite loop), but I assume we don't want infinite loop here. 

If there is any problem, feel free to correct it.