### PR TITLE
Set errno to ENOMEM on rallocx() OOM failures

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -3493,6 +3493,7 @@ do_rallocx(void *ptr, size_t size, int flags, bool is_realloc) {
 
 	return p;
 label_oom:
+	set_errno(ENOMEM);
 	if (config_xmalloc && unlikely(opt_xmalloc)) {
 		malloc_write("<jemalloc>: Error in rallocx(): out of memory\n");
 		abort();


### PR DESCRIPTION
realloc() and rallocx() shares path, and realloc() should set errno to ENOMEM upon OOM failures.

Fixes: ee961c23100e ("Merge realloc and rallocx pathways.")