### PR TITLE
Experimental calloc implementation with using memset() on larger sizes

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -37,6 +37,7 @@ extern const char *const zero_realloc_mode_names[];
 extern atomic_zu_t zero_realloc_count;
 extern bool opt_cache_oblivious;
 extern unsigned opt_debug_double_free_max_scan;
+extern size_t opt_calloc_madvise_threshold;
 
 extern const char *opt_malloc_conf_symlink;
 extern const char *opt_malloc_conf_env_var;

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -160,6 +160,8 @@ unsigned	ncpus;
 unsigned opt_debug_double_free_max_scan =
     SAFETY_CHECK_DOUBLE_FREE_MAX_SCAN_DEFAULT;
 
+size_t opt_calloc_madvise_threshold = 0;
+
 /* Protects arenas initialization. */
 static malloc_mutex_t arenas_lock;
 
@@ -1453,6 +1455,9 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			    "debug_double_free_max_scan", 0, UINT_MAX,
 			    CONF_DONT_CHECK_MIN, CONF_DONT_CHECK_MAX,
 			    /* clip */ false)
+			CONF_HANDLE_SIZE_T(opt_calloc_madvise_threshold,
+			    "calloc_madvise_threshold", 0, SC_LARGE_MAXCLASS,
+			    CONF_DONT_CHECK_MIN, CONF_CHECK_MAX, /* clip */ false)
 
 			/*
 			 * The runtime option of oversize_threshold remains


### PR DESCRIPTION
- Add a run-time option **opt_calloc_madvise_threshold** that controls when shoud memset be used to zero out memory, it's by default **0**, which means,
    - `usize >= opt_calloc_madvise_threshold` always stands, so `zero_override = zero`, the original code flow is unchanged.

- When **opt_calloc_madvise_threshold** is set to a value no smaller than `SC_LARGE_MINCLASS`, in this case when `usize` is between `SC_LARGE_MINCLASS` to `opt_calloc_madvise_threshold`, `zero_override` will be set to false, which means that we won't zero out memory inside pa_alloc() (which is using madvise()), and `memset()` will be used to do the zeroing.