### PR TITLE
xallocx() and various fixes

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,6 +5,7 @@ Copyright (C) 2002-present Jason Evans <jasone@canonware.com>.
 All rights reserved.
 Copyright (C) 2007-2012 Mozilla Foundation.  All rights reserved.
 Copyright (C) 2009-present Facebook, Inc.  All rights reserved.
+Copyright (C) 2024 Arm Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/include/jemalloc/internal/bitmap.h
+++ b/include/jemalloc/internal/bitmap.h
@@ -284,14 +284,16 @@ bitmap_ffu(const bitmap_t *bitmap, const bitmap_info_t *binfo, size_t min_bit) {
 	bitmap_t g = bitmap[i] & ~((1LU << (min_bit & BITMAP_GROUP_NBITS_MASK))
 	    - 1);
 	size_t bit;
-	do {
+	while (1) {
 		if (g != 0) {
 			bit = ffs_lu(g);
 			return (i << LG_BITMAP_GROUP_NBITS) + bit;
 		}
-		i++;
+		if (++i >= binfo->ngroups) {
+			break;
+		}
 		g = bitmap[i];
-	} while (i < binfo->ngroups);
+	}
 	return binfo->nbits;
 #endif
 }

--- a/src/large.c
+++ b/src/large.c
@@ -146,7 +146,7 @@ large_ralloc_no_move(tsdn_t *tsdn, edata_t *edata, size_t usize_min,
 		}
 		/* Try again, this time with usize_min. */
 		if (usize_min < usize_max && usize_min > oldusize &&
-		    large_ralloc_no_move_expand(tsdn, edata, usize_min, zero)) {
+		    !large_ralloc_no_move_expand(tsdn, edata, usize_min, zero)) {
 			arena_decay_tick(tsdn, arena_get_from_edata(edata));
 			return false;
 		}

--- a/test/integration/rallocx.c
+++ b/test/integration/rallocx.c
@@ -64,7 +64,7 @@ TEST_BEGIN(test_grow_and_shrink) {
 			    "Unexpected rallocx() error for size=%zu-->%zu",
 			    szs[j-1], szs[j-1]+1);
 			szs[j] = sallocx(q, 0);
-			expect_zu_ne(szs[j], szs[j-1]+1,
+			expect_zu_ge(szs[j], szs[j-1]+1,
 			    "Expected size to be at least: %zu", szs[j-1]+1);
 			p = q;
 		}

--- a/test/integration/xallocx.c
+++ b/test/integration/xallocx.c
@@ -258,6 +258,12 @@ TEST_BEGIN(test_extra_large) {
 	expect_zu_ge(xallocx(p, large1, 0, flags), large1,
 	    "Unexpected xallocx() behavior");
 	/* Test size increase with non-zero extra. */
+	expect_zu_le(xallocx(p, large2, SIZE_T_MAX - large2, flags), largemax,
+	    "Unexpected xallocx() behavior");
+
+	expect_zu_ge(xallocx(p, large1, 0, flags), large1,
+	    "Unexpected xallocx() behavior");
+	/* Test size increase with non-zero extra. */
 	expect_zu_le(xallocx(p, large1, large3 - large1, flags), large3,
 	    "Unexpected xallocx() behavior");
 

--- a/test/unit/stats_print.c
+++ b/test/unit/stats_print.c
@@ -140,7 +140,10 @@ parser_tokenize(parser_t *parser) {
 	    "Position is past end of buffer");
 
 	while (state != STATE_ACCEPT) {
-		char c = parser->buf[parser->pos];
+		char c;
+		if (state != STATE_EOI) {
+			c = parser->buf[parser->pos];
+		}
 
 		switch (state) {
 		case STATE_START:


### PR DESCRIPTION
Hi,
This fixes some out-of-bounds accesses, corrects a rallocx() integration test issue, and fixes a bug in xallocx() (new tests are added to detect that).
Please note this PR contains a patch adding Arm as a copyright owner to `COPYING` as an alternative to extending per-file copyright headers.
Kind regards,
Oli