### PR TITLE
macOS: Fix linking statically

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -434,6 +434,7 @@ zone_promote(void) {
 }
 
 JEMALLOC_ATTR(constructor)
+JEMALLOC_ATTR(used)
 void
 zone_register(void) {
 	/*


### PR DESCRIPTION
`__attribute__((constructor))` does not mark the symbol as used, so the linker ends up dead-stripping the symbol when linked statically.

Adding the `used` attribute fixes that.

Fixes https://github.com/jemalloc/jemalloc/issues/708.