### PR TITLE
`throw()` -> `noexcept`

### DIFF
--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -52,7 +52,7 @@
 #define MALLCTL_ARENAS_DESTROYED	4097
 
 #if defined(__cplusplus) && defined(JEMALLOC_USE_CXX_THROW)
-#  define JEMALLOC_CXX_THROW throw()
+#  define JEMALLOC_CXX_THROW noexcept
 #else
 #  define JEMALLOC_CXX_THROW
 #endif


### PR DESCRIPTION
`throw()` is eliminated in C++17. `noexcept`, available since C++11, should be used instead.