### PR TITLE
Make JEMALLOC_CXX_THROW definition compatible with newer C++

### DIFF
--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -52,7 +52,7 @@
 #define MALLCTL_ARENAS_DESTROYED	4097
 
 #if defined(__cplusplus) && defined(JEMALLOC_USE_CXX_THROW)
-#  define JEMALLOC_CXX_THROW throw()
+#  define JEMALLOC_CXX_THROW noexcept (true)
 #else
 #  define JEMALLOC_CXX_THROW
 #endif


### PR DESCRIPTION
Picking up #2654 here, thanks to @r-barnes for bringing this to our attention.

This PR changes the usage of `throw()` to `noexcept (true)` to be better compatible with newr C++ versions since `throw()` is deprecated since C++17. glibc malloc is doing the same thing for the definition of `__THROW` in their codebase.

While jemalloc requires at least c++14 as specified [here](https://github.com/jemalloc/jemalloc/blob/dev/configure.ac#L302), it is safe to use `noexcept(true)` directly without checking `__cplusplus`. Using `noexcept (true)` instead of `noexcept` because they are [subtly different before C++17](https://en.cppreference.com/w/cpp/language/noexcept) although this difference shouldn't be a concern to its current jemalloc usage.
