### PR TITLE
A couple of simplifications in tcache.c .

### DIFF
--- a/src/tcache.c
+++ b/src/tcache.c
@@ -166,7 +166,7 @@ tcache_gc_small(tsd_t *tsd, tcache_slow_t *tcache_slow, tcache_t *tcache,
 	 * the fill count is always at least 1.
 	 */
 	if ((cache_bin_ncached_max_get(cache_bin) >>
-	    (tcache_slow->lg_fill_div[szind] + 1)) >= 1) {
+	     tcache_slow->lg_fill_div[szind]) > 1) {
 		tcache_slow->lg_fill_div[szind]++;
 	}
 }
@@ -219,7 +219,6 @@ tcache_event(tsd_t *tsd) {
 		}
 		tcache_slow->bin_refilled[szind] = false;
 	}
-	cache_bin_low_water_set(cache_bin);
 
 label_done:
 	tcache_slow->next_gc_bin++;


### PR DESCRIPTION
Adjusting the low water mark in tcache_event is not necessary as tcache_gc_{small,large} already do it and other code path do not change the low water mark anyways.

The computation for lg_fill_div in tcache_gc_small was unnecessarily complex.