### PR TITLE
Fix NSTIME_MONOTONIC flag for win32 implementation.

### DIFF
--- a/src/nstime.c
+++ b/src/nstime.c
@@ -172,7 +172,7 @@ nstime_ns_since(const nstime_t *past) {
 }
 
 #ifdef _WIN32
-#  define NSTIME_MONOTONIC true
+#  define NSTIME_MONOTONIC false
 static void
 nstime_get(nstime_t *time) {
 	FILETIME ft;


### PR DESCRIPTION
the GetSystemTimeAsFileTime API in Win32 does not guarantee monotonic time. This time can be adjusted by the system clock, meaning it can move forward or backward due to time synchronization, daylight saving time adjustments, or manual changes.
So we should claim NSTIME_MONOTONIC as false, otherwise it causes crash at arena_maybe_decay() function in arena.c.

![image](https://github.com/jemalloc/jemalloc/assets/17753898/1de1d071-56a7-4770-8839-3a9a588e80ac)