### PR TITLE
Increase `emitter_print_value` buf size

### DIFF
--- a/include/jemalloc/internal/emitter.h
+++ b/include/jemalloc/internal/emitter.h
@@ -129,7 +129,7 @@ static inline void
 emitter_print_value(emitter_t *emitter, emitter_justify_t justify, int width,
     emitter_type_t value_type, const void *value) {
 	size_t str_written;
-#define BUF_SIZE 256
+#define BUF_SIZE 1024
 #define FMT_SIZE 10
 	/*
 	 * We dynamically generate a format string to emit, to let us use the


### PR DESCRIPTION
There are few long options (`bin_shards` and `slab_sizes` for example) when they are specified and we emit statistics, value gets truncated.

Worst case for `bin_shards` will be `|sssss:nnn`, where `sssss` is a size class (maximum 5 digits) and `nnn` three digits for number of shards. Total number of small classes currently is 36, so at most 360 (36 * 10) characters for `bin_shards`. Approximately same calculations should be true for `slab_sizes`, so them both in total should occupy no more than 720 characters (360 * 2).

256 characters was previous `buf` size plus 720 from calculations above is 976, we can round it up to round number like 1024.