### PR TITLE
Utilise the thread bin to their full extent when heavily allocating.

### DIFF
--- a/include/jemalloc/internal/tcache_externs.h
+++ b/include/jemalloc/internal/tcache_externs.h
@@ -49,6 +49,8 @@ size_t tcache_salloc(tsdn_t *tsdn, const void *ptr);
 void *tcache_alloc_small_hard(tsdn_t *tsdn, arena_t *arena, tcache_t *tcache,
     cache_bin_t *cache_bin, szind_t binind, bool *tcache_success);
 
+void tcache_bin_dalloc_small_flush(tsd_t *tsd, tcache_t *tcache,
+    cache_bin_t *cache_bin, szind_t binind, unsigned rem);
 void tcache_bin_flush_small(tsd_t *tsd, tcache_t *tcache,
     cache_bin_t *cache_bin, szind_t binind, unsigned rem);
 void tcache_bin_flush_large(tsd_t *tsd, tcache_t *tcache,

--- a/include/jemalloc/internal/tcache_inlines.h
+++ b/include/jemalloc/internal/tcache_inlines.h
@@ -202,7 +202,7 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 		}
 		cache_bin_sz_t max = cache_bin_ncached_max_get(bin);
 		unsigned remain = max >> opt_lg_tcache_flush_small_div;
-		tcache_bin_flush_small(tsd, tcache, bin, binind, remain);
+		tcache_bin_dalloc_small_flush(tsd, tcache, bin, binind, remain);
 		bool ret = cache_bin_dalloc_easy(bin, ptr);
 		assert(ret);
 	}

--- a/include/jemalloc/internal/tcache_structs.h
+++ b/include/jemalloc/internal/tcache_structs.h
@@ -39,6 +39,8 @@ struct tcache_slow_s {
 	uint8_t		lg_fill_div[SC_NBINS];
 	/* For small bins, whether has been refilled since last GC. */
 	bool		bin_refilled[SC_NBINS];
+	/* For small bins, whether has been flushed since last GC. */
+	bool		bin_flushed[SC_NBINS];
 	/*
 	 * For small bins, the number of items we can pretend to flush before
 	 * actually flushing.


### PR DESCRIPTION
I came up with that strategy because I implemented a similar thread cache mechanism in the context of a GC. When using a GC, it is common to allocate way more than you deallocate (at least explicitly) and we benefit from being able to utilize the full extent of the cache by setting lg_fill_div to 0.

The obvious downside is that it may not leave enough space behind for free, causing churn int he cache (fill in the bin, then flush a good chunk of it to be able to free allocations). We avoid that situation by remembering if we had to flush to free during the bin's gc cycle, and if so, we do not allow lg_fill_div to go down to 0.

As far as I can tell, this strategy is also beneficial in the malloc/free situation, when the application is in an "expansion" phase, as in allocates way more than it frees, but I'd be curious to see what you guys find when trying this and if it doesn't work for you, why?