### PR TITLE
Add usize to prof_sample_hook_t

### DIFF
--- a/include/jemalloc/internal/prof_hook.h
+++ b/include/jemalloc/internal/prof_hook.h
@@ -20,8 +20,8 @@ typedef void (*prof_backtrace_hook_t)(void **, unsigned *, unsigned);
  */
 typedef void (*prof_dump_hook_t)(const char *filename);
 
-/* ptr, size, backtrace vector, backtrace vector length */
-typedef void (*prof_sample_hook_t)(const void *, size_t, void **, unsigned);
+/* ptr, size, backtrace vector, backtrace vector length, usize */
+typedef void (*prof_sample_hook_t)(const void *ptr, size_t size, void **backtrace, unsigned backtrace_length, size_t usize);
 
 /* ptr, size */
 typedef void (*prof_sample_free_hook_t)(const void *, size_t);

--- a/src/prof.c
+++ b/src/prof.c
@@ -166,7 +166,7 @@ prof_malloc_sample_object(tsd_t *tsd, const void *ptr, size_t size,
 	if (prof_sample_hook != NULL) {
 		prof_bt_t *bt = &tctx->gctx->bt;
 		pre_reentrancy(tsd, NULL);
-		prof_sample_hook(ptr, size, bt->vec, bt->len);
+		prof_sample_hook(ptr, size, bt->vec, bt->len, usize);
 		post_reentrancy(tsd);
 	}
 }


### PR DESCRIPTION
Enable tools which rely on `prof_sample_hook_t` to aggregate results that match jemalloc profile data.

Previously only `size` (the requested allocation size) was available. This diff extends the hook with `usize` (usable size, which is the input size rounded up to the next jemalloc size class)
