### PR TITLE
Windows profiling backend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1463,6 +1463,35 @@ else
   enable_prof_gcc="0"
 fi
 
+AC_ARG_ENABLE([prof-msvc],
+  [AS_HELP_STRING([--disable-prof-msvc],
+  [Do not use MSVC for backtracing])],
+[if test "x$enable_prof_msvc" = "xno" ; then
+  enable_prof_msvc="0"
+else
+  enable_prof_msvc="1"
+fi
+],
+[enable_prof_msvc="1"]
+)
+if test "x$backtrace_method" = "x" -a "x$enable_prof_msvc" = "x1" \
+     -a "x$je_cv_msvc" = "xyes" ; then
+  JE_COMPILABLE([RtlCaptureStackBackTrace], [
+  #include <WinBase.h>
+  ], [
+	    CaptureStackBackTrace(0, 0, NULL, NULL);
+  ], [je_cv_rtlcapturestackbacktrace])
+  if test "x${je_cv_rtlcapturestackbacktrace}" = "xyes" ; then
+    enable_prof_msvc="1"
+  fi
+  if test "x${enable_prof_msvc}" = "x1" ; then
+    backtrace_method="msvc"
+    AC_DEFINE([JEMALLOC_PROF_MSVC], [ ], [ ])
+  fi
+else
+  enable_prof_msvc="0"
+fi
+
 if test "x$backtrace_method" = "x" ; then
   backtrace_method="none (disabling profiling)"
   enable_prof="0"
@@ -2819,6 +2848,7 @@ AC_MSG_RESULT([prof               : ${enable_prof}])
 AC_MSG_RESULT([prof-libunwind     : ${enable_prof_libunwind}])
 AC_MSG_RESULT([prof-libgcc        : ${enable_prof_libgcc}])
 AC_MSG_RESULT([prof-gcc           : ${enable_prof_gcc}])
+AC_MSG_RESULT([prof-msvc          : ${enable_prof_msvc}])
 AC_MSG_RESULT([fill               : ${enable_fill}])
 AC_MSG_RESULT([utrace             : ${enable_utrace}])
 AC_MSG_RESULT([xmalloc            : ${enable_xmalloc}])

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -167,6 +167,9 @@
 /* Use gcc intrinsics for profile backtracing if defined. */
 #undef JEMALLOC_PROF_GCC
 
+/* Use MSVC functions for profile backtracing if defined. */
+#undef JEMALLOC_PROF_MSVC
+
 /* JEMALLOC_PAGEID enabled page id */
 #undef JEMALLOC_PAGEID
 

--- a/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/include/jemalloc/internal/jemalloc_internal_types.h
@@ -68,8 +68,8 @@ typedef enum malloc_init_e malloc_init_t;
 /* Smallest size class to support. */
 #define TINY_MIN		(1U << LG_TINY_MIN)
 
-#define LONG			((size_t)(1U << LG_SIZEOF_LONG))
-#define LONG_MASK		(LONG - 1)
+#define SIZEOF_LONG			((size_t)(1U << LG_SIZEOF_LONG))
+#define LONG_MASK		(SIZEOF_LONG - 1)
 
 /* Return the smallest long multiple that is >= a. */
 #define LONG_CEILING(a)							\

--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -641,7 +641,18 @@ prof_log_stop(tsdn_t *tsdn) {
 	if (prof_log_dummy) {
 		fd = 0;
 	} else {
-		fd = creat(log_filename, 0644);
+		int mode = 0644;
+#ifdef _MSC_VER
+		/*
+		* On windows, creat only supports S_IREAD and S_IWRITE. Setting any
+		* other flags in the mode results in raising an assertion, crashing the
+		* program. This is because creat is implemented by (indirectly) calling
+		* sopen_s, which asserts if pmode contains an "invalid mode", AKA a mode
+		* that the CRT does not know how to handle.
+		*/
+		mode &= 0600;
+#endif
+		fd = creat(log_filename, mode);
 	}
 
 	if (fd == -1) {

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -593,6 +593,16 @@ prof_dump_check_possible_error(prof_dump_arg_t *arg, bool err_cond,
 
 static int
 prof_dump_open_file_impl(const char *filename, int mode) {
+#ifdef _MSC_VER
+	/*
+	* On windows, creat only supports S_IREAD and S_IWRITE. Setting any
+	* other flags in the mode results in raising an assertion, crashing the
+	* program. This is because creat is implemented by (indirectly) calling
+	* sopen_s, which asserts if pmode contains an "invalid mode", AKA a mode
+	* that the CRT does not know how to handle.
+	*/
+	mode &= 0600;
+#endif
 	return creat(filename, mode);
 }
 prof_dump_open_file_t *JET_MUTABLE prof_dump_open_file =


### PR DESCRIPTION
Adds a new profiling backend, using [`CaptureStackBackTrace`](https://learn.microsoft.com/en-us/windows/win32/debug/capturestackbacktrace) to grab the stacktrace.

The backend doesn't currently grab the memory mapping of libraries, but is otherwise perfectly functional. I'm currently using it in conjunction with [`rust-jemalloc-pprof`](https://github.com/polarsignals/rust-jemalloc-pprof), to great effect.