### PR TITLE
Use MSVC __declspec(thread) to implement TSD on Windows

### DIFF
--- a/src/tsd.c
+++ b/src/tsd.c
@@ -22,8 +22,12 @@ JEMALLOC_TSD_TYPE_ATTR(tsd_t) tsd_tls = TSD_INITIALIZER;
 pthread_key_t tsd_tsd;
 bool tsd_booted = false;
 #elif (defined(_WIN32))
+#if defined(JEMALLOC_LEGACY_WINDOWS_SUPPORT) || !defined(_MSC_VER)
 DWORD tsd_tsd;
-tsd_wrapper_t tsd_boot_wrapper = {false, TSD_INITIALIZER};
+tsd_wrapper_t tsd_boot_wrapper = {TSD_INITIALIZER, false};
+#else
+JEMALLOC_TSD_TYPE_ATTR(tsd_wrapper_t) tsd_wrapper_tls = { TSD_INITIALIZER, false };
+#endif
 bool tsd_booted = false;
 #if JEMALLOC_WIN32_TLSGETVALUE2
 TGV2 tls_get_value2 = NULL;


### PR DESCRIPTION
MSVC supports thread-local storage through __declspec(thread), and thus we can use it to implement TSD on Windows. Compared to the original approach, we don't need manually manage thread-local memory allocation/deallocation, and getting thread-local data is directly inlined and doesn't have to go through TlsGetValue/TlsGetValue2, which helps improve performance.

Since __declspec(thread) has some limitations on pre-Vista Windows, we still keep the old TSD implementation just in case applications using jemalloc need to support pre-Vista Windows versions.

I used the same microbenchmark on [PR2583](https://github.com/jemalloc/jemalloc/pull/2583) to showcase the performance improvement, see below.

```
#define JEMALLOC_NO_DEMANGLE
#include <jemalloc/jemalloc.h>
#include <chrono>
#include <iostream>

const unsigned __int64 ITERATIONS = 0x800000;

void main() {
    static const int sizes[] =
    {
        7, 16, 32, 60, 91, 100, 120, 144, 169, 199, 255
    };
    
    auto start = std::chrono::high_resolution_clock::now();
    for (unsigned __int64 i = 0; i < ITERATIONS; i++)
    {
        for (auto sz : sizes)
        {
            void* p = je_malloc(sz);
            je_free(p);
        }
    }
    auto end = std::chrono::high_resolution_clock::now();
    std::chrono::duration<double> diff = end - start;
    std::cout << "Time: " << diff.count() << " s\n";
}

                                   Vanilla (sec)       This change (sec)      Time Delta
Intel i9-13900KF (x64)               0.99                      0.91               -8.1%
Snapdragon X1E78100 (Arm64)          0.98                      0.93               -5.1%
Snapdragon X1E78100 (Arm64EC)        1.76                      0.93              -47.2%
```