### PR TITLE
Add attribute to compile some tests in aligned_alloc.c with no optimization

### DIFF
--- a/test/integration/aligned_alloc.c
+++ b/test/integration/aligned_alloc.c
@@ -13,7 +13,10 @@ purge(void) {
 	    "Unexpected mallctl error");
 }
 
-__attribute__((optnone)) TEST_BEGIN(test_alignment_errors) {
+#if __clang__
+__attribute__((optnone))
+#endif
+TEST_BEGIN(test_alignment_errors) {
 	size_t alignment;
 	void *p;
 
@@ -45,7 +48,10 @@ TEST_END
 JEMALLOC_DIAGNOSTIC_PUSH
 JEMALLOC_DIAGNOSTIC_IGNORE_ALLOC_SIZE_LARGER_THAN
 
-__attribute__((optnone)) TEST_BEGIN(test_oom_errors) {
+#if __clang__
+__attribute__((optnone))
+#endif
+TEST_BEGIN(test_oom_errors) {
 	size_t alignment, size;
 	void *p;
 

--- a/test/integration/aligned_alloc.c
+++ b/test/integration/aligned_alloc.c
@@ -13,7 +13,7 @@ purge(void) {
 	    "Unexpected mallctl error");
 }
 
-TEST_BEGIN(test_alignment_errors) {
+__attribute__((optnone)) TEST_BEGIN(test_alignment_errors) {
 	size_t alignment;
 	void *p;
 
@@ -45,7 +45,7 @@ TEST_END
 JEMALLOC_DIAGNOSTIC_PUSH
 JEMALLOC_DIAGNOSTIC_IGNORE_ALLOC_SIZE_LARGER_THAN
 
-TEST_BEGIN(test_oom_errors) {
+__attribute__((optnone)) TEST_BEGIN(test_oom_errors) {
 	size_t alignment, size;
 	void *p;
 


### PR DESCRIPTION
Building jemalloc with Clang 15+ results in errors during the check phase (#2540). Specifically, the tests `test_alignment_errors` and `test_oom_errors` fail because of Clang's optimizations. Adding  `__attribute__((optnone))` before these tests can prevent the optimizations, allowing the tests to pass.