### PR TITLE
Add malloc_open() / malloc_close() reentrancy safe helpers

### DIFF
--- a/include/jemalloc/internal/malloc_io.h
+++ b/include/jemalloc/internal/malloc_io.h
@@ -134,4 +134,25 @@ malloc_read_fd(int fd, void *buf, size_t count) {
 	return bytes_read;
 }
 
+static inline int malloc_open(const char *path, int flags) {
+	int fd;
+#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_open)
+	fd = (int)syscall(SYS_open, path, flags);
+#elif defined(JEMALLOC_USE_SYSCALL) && defined(SYS_openat)
+	fd = (int)syscall(SYS_openat, AT_FDCWD, path, flags);
+#else
+	fd = open(path, flags);
+#endif
+	return fd;
+}
+
+static inline int malloc_close(int fd) {
+#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_close)
+	return (int)syscall(SYS_close, fd);
+#else
+	return close(fd);
+#endif
+}
+
+
 #endif /* JEMALLOC_INTERNAL_MALLOC_IO_H */


### PR DESCRIPTION
Add `malloc_open()`, `malloc_close()` direct syscall wrappers. These were already implemented in `pages.c` - now moved to be reusable by other code. 