### PR TITLE
Fix initialization of pop_attempt_results in bin_batching test

### DIFF
--- a/test/unit/bin_batching.c
+++ b/test/unit/bin_batching.c
@@ -118,7 +118,8 @@ stress_run(void (*main_thread_fn)(), int nruns) {
 	bin_batching_test_after_unlock_hook = &increment_slab_dalloc_count;
 
 	atomic_store_zu(&push_failure_count, 0, ATOMIC_RELAXED);
-	atomic_store_zu(&pop_attempt_results[2], 0, ATOMIC_RELAXED);
+	atomic_store_zu(&pop_attempt_results[0], 0, ATOMIC_RELAXED);
+	atomic_store_zu(&pop_attempt_results[1], 0, ATOMIC_RELAXED);
 	atomic_store_zu(&dalloc_zero_slab_count, 0, ATOMIC_RELAXED);
 	atomic_store_zu(&dalloc_nonzero_slab_count, 0, ATOMIC_RELAXED);
 	atomic_store_zu(&dalloc_nonempty_list_count, 0, ATOMIC_RELAXED);


### PR DESCRIPTION
Fix warnings (treated as errors) on Fedora 40 (x86_64) when running tests.

## Before

```
$ ./autogen.sh
$ ./run_tests.sh 
...
Error; see run_tests.out/run_test_16.out/run_test.log
xargs: sh: exited with status 255; aborting
Error; see run_tests.out/run_test_1.out/run_test.log
xargs: sh: exited with status 255; aborting
slingn@fedora:~/jemalloc$ Error; see run_tests.out/run_test_3.out/run_test.log
Error; see run_tests.out/run_test_2.out/run_test.log
Error; see run_tests.out/run_test_11.out/run_test.log
Error; see run_tests.out/run_test_5.out/run_test.log
Error; see run_tests.out/run_test_0.out/run_test.log
Error; see run_tests.out/run_test_25.out/run_test.log
Error; see run_tests.out/run_test_4.out/run_test.log
Error; see run_tests.out/run_test_6.out/run_test.log
Error; see run_tests.out/run_test_7.out/run_test.log
Error; see run_tests.out/run_test_20.out/run_test.log
Error; see run_tests.out/run_test_10.out/run_test.log
Error; see run_tests.out/run_test_15.out/run_test.log
Error; see run_tests.out/run_test_14.out/run_test.log
Error; see run_tests.out/run_test_24.out/run_test.log
Error; see run_tests.out/run_test_8.out/run_test.log
Error; see run_tests.out/run_test_9.out/run_test.log
Error; see run_tests.out/run_test_12.out/run_test.log
Error; see run_tests.out/run_test_13.out/run_test.log
```

`run_tests.out/run_test_5.out/run_test.log`
```
In file included from ../../include/jemalloc/internal/atomic.h:8,
                 from ../../include/jemalloc/internal/jemalloc_internal_externs.h:5,
                 from ../../include/jemalloc/internal/tsd_internals.h:11,
                 from ../../include/jemalloc/internal/tsd_tls.h:7,
                 from ../../include/jemalloc/internal/tsd.h:13,
                 from ../../include/jemalloc/internal/ckh.h:5,
                 from ../../include/jemalloc/internal/prof_structs.h:5,
                 from ../../include/jemalloc/internal/jemalloc_internal_includes.h:51,
                 from test/include/test/jemalloc_test.h:50,
                 from ../../test/unit/bin_batching.c:1:
In function ‘atomic_store_zu’,
    inlined from ‘stress_run’ at ../../test/unit/bin_batching.c:121:2:
../../include/jemalloc/internal/atomic_gcc_atomic.h:59:9: error: ‘__atomic_store_8’ writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   59 |         __atomic_store(&a->repr, &val, atomic_enum_to_builtin(mo));     \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../include/jemalloc/internal/atomic_gcc_atomic.h:95:1: note: in expansion of macro ‘JEMALLOC_GENERATE_ATOMICS’
   95 | JEMALLOC_GENERATE_ATOMICS(type, short_type, /* unused */ lg_size)       \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
../../include/jemalloc/internal/atomic.h:61:5: note: in expansion of macro ‘JEMALLOC_GENERATE_INT_ATOMICS’
   61 |     JEMALLOC_GENERATE_INT_ATOMICS(type, short_type, lg_size)            \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../include/jemalloc/internal/atomic.h:95:1: note: in expansion of macro ‘JEMALLOC_GENERATE_EXPANDED_INT_ATOMICS’
   95 | JEMALLOC_GENERATE_EXPANDED_INT_ATOMICS(size_t, zu, LG_SIZEOF_PTR)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../test/unit/bin_batching.c: In function ‘stress_run’:
../../test/unit/bin_batching.c:19:20: note: at offset 16 into destination object ‘pop_attempt_results’ of size 16
   19 | static atomic_zu_t pop_attempt_results[2];
      |                    ^~~~~~~~~~~~~~~~~~~
```

## After

```
$ ./autogen.sh
$ ./run_tests.sh
...
Error; see run_tests.out/run_test_30.out/run_test.log
xargs: sh: exited with status 255; aborting
Error; see run_tests.out/run_test_26.out/run_test.log
xargs: sh: exited with status 255; aborting
```

-> only two test failures now (reported in #2707)