### PR TITLE
Add safe frame-pointer backtrace unwinder

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,6 +139,7 @@ any of the following arguments (not a definitive list) to 'configure':
     in the following list that appears to function correctly:
 
     + libunwind      (requires --enable-prof-libunwind)
+    + frame pointer  (requires --enable-prof-frameptr)
     + libgcc         (unless --disable-prof-libgcc)
     + gcc intrinsics (unless --disable-prof-gcc)
 
@@ -146,6 +147,12 @@ any of the following arguments (not a definitive list) to 'configure':
 
     Use the libunwind library (http://www.nongnu.org/libunwind/) for stack
     backtracing.
+
+* `--enable-prof-frameptr`
+
+    Use the optimized frame pointer unwinder for stack backtracing. Safe
+    to use in mixed code (with and without frame pointers) - but requires
+    frame pointers to produce meaningful stacks. Linux only.
 
 * `--disable-prof-libgcc`
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -142,6 +142,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/prof_data.c \
 	$(srcroot)src/prof_log.c \
 	$(srcroot)src/prof_recent.c \
+	$(srcroot)src/prof_stack_range.c \
 	$(srcroot)src/prof_stats.c \
 	$(srcroot)src/prof_sys.c \
 	$(srcroot)src/psset.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1418,6 +1418,33 @@ if test "x$backtrace_method" = "x" -a "x$enable_prof_libunwind" = "x1" ; then
   fi
 fi
 
+if test `uname -s` = "Linux"
+then
+  AC_ARG_ENABLE([prof-frameptr],
+    [AS_HELP_STRING([--enable-prof-frameptr], [Use optimized frame pointer unwinder for backtracing (Linux only)])],
+  [if test "x$enable_prof_frameptr" = "xno" ; then
+    enable_prof_frameptr="0"
+  else
+    enable_prof_frameptr="1"
+    if test "x$enable_prof" = "x0" ; then
+      AC_MSG_ERROR([--enable-prof-frameptr should only be used with --enable-prof])
+    fi
+  fi
+  ],
+  [enable_prof_frameptr="0"]
+  )
+  if test "x$backtrace_method" = "x" -a "x$enable_prof_frameptr" = "x1" \
+      -a "x$GCC" = "xyes" ; then
+    JE_CFLAGS_ADD([-fno-omit-frame-pointer])
+    backtrace_method="frame pointer linux"
+    AC_DEFINE([JEMALLOC_PROF_FRAME_POINTER], [ ], [ ])
+  else
+    enable_prof_frameptr="0"
+  fi
+else
+  enable_prof_frameptr="0"
+fi
+
 AC_ARG_ENABLE([prof-libgcc],
   [AS_HELP_STRING([--disable-prof-libgcc],
   [Do not use libgcc for backtracing])],
@@ -2817,6 +2844,7 @@ AC_MSG_RESULT([stats              : ${enable_stats}])
 AC_MSG_RESULT([experimental_smallocx : ${enable_experimental_smallocx}])
 AC_MSG_RESULT([prof               : ${enable_prof}])
 AC_MSG_RESULT([prof-libunwind     : ${enable_prof_libunwind}])
+AC_MSG_RESULT([prof-frameptr      : ${enable_prof_frameptr}])
 AC_MSG_RESULT([prof-libgcc        : ${enable_prof_libgcc}])
 AC_MSG_RESULT([prof-gcc           : ${enable_prof_gcc}])
 AC_MSG_RESULT([fill               : ${enable_fill}])

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -897,6 +897,16 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         during build configuration.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="config.prof_frameptr">
+        <term>
+          <mallctl>config.prof_frameptr</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para><option>--enable-prof-frameptr</option> was specified
+        during build configuration.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="config.stats">
         <term>
           <mallctl>config.stats</mallctl>

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -167,6 +167,9 @@
 /* Use gcc intrinsics for profile backtracing if defined. */
 #undef JEMALLOC_PROF_GCC
 
+/* Use frame pointer for profile backtracing if defined. Linux only. */
+#undef JEMALLOC_PROF_FRAME_POINTER
+
 /* JEMALLOC_PAGEID enabled page id */
 #undef JEMALLOC_PAGEID
 

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -114,6 +114,13 @@ static const bool config_prof_libunwind =
     false
 #endif
     ;
+static const bool config_prof_frameptr =
+#ifdef JEMALLOC_PROF_FRAME_POINTER
+    true
+#else
+    false
+#endif
+    ;
 static const bool maps_coalesce =
 #ifdef JEMALLOC_MAPS_COALESCE
     true

--- a/include/jemalloc/internal/malloc_io.h
+++ b/include/jemalloc/internal/malloc_io.h
@@ -154,5 +154,12 @@ static inline int malloc_close(int fd) {
 #endif
 }
 
+static inline off_t malloc_lseek(int fd, off_t offset, int whence) {
+#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_lseek)
+  return (off_t)syscall(SYS_lseek, fd, offset, whence);
+#else
+  return lseek(fd, offset, whence);
+#endif
+}
 
 #endif /* JEMALLOC_INTERNAL_MALLOC_IO_H */

--- a/include/jemalloc/internal/prof_sys.h
+++ b/include/jemalloc/internal/prof_sys.h
@@ -20,6 +20,7 @@ void prof_fdump_impl(tsd_t *tsd);
 void prof_idump_impl(tsd_t *tsd);
 bool prof_mdump_impl(tsd_t *tsd, const char *filename);
 void prof_gdump_impl(tsd_t *tsd);
+uintptr_t prof_thread_stack_start(uintptr_t stack_end);
 
 /* Used in unit tests. */
 typedef int (prof_sys_thread_name_read_t)(char *buf, size_t limit);

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -89,6 +89,7 @@ CTL_PROTO(config_opt_safety_checks)
 CTL_PROTO(config_prof)
 CTL_PROTO(config_prof_libgcc)
 CTL_PROTO(config_prof_libunwind)
+CTL_PROTO(config_prof_frameptr)
 CTL_PROTO(config_stats)
 CTL_PROTO(config_utrace)
 CTL_PROTO(config_xmalloc)
@@ -437,6 +438,7 @@ static const ctl_named_node_t	config_node[] = {
 	{NAME("prof"),		CTL(config_prof)},
 	{NAME("prof_libgcc"),	CTL(config_prof_libgcc)},
 	{NAME("prof_libunwind"), CTL(config_prof_libunwind)},
+	{NAME("prof_frameptr"), CTL(config_prof_frameptr)},
 	{NAME("stats"),		CTL(config_stats)},
 	{NAME("utrace"),	CTL(config_utrace)},
 	{NAME("xmalloc"),	CTL(config_xmalloc)}
@@ -2181,6 +2183,7 @@ CTL_RO_CONFIG_GEN(config_opt_safety_checks, bool)
 CTL_RO_CONFIG_GEN(config_prof, bool)
 CTL_RO_CONFIG_GEN(config_prof_libgcc, bool)
 CTL_RO_CONFIG_GEN(config_prof_libunwind, bool)
+CTL_RO_CONFIG_GEN(config_prof_frameptr, bool)
 CTL_RO_CONFIG_GEN(config_stats, bool)
 CTL_RO_CONFIG_GEN(config_utrace, bool)
 CTL_RO_CONFIG_GEN(config_xmalloc, bool)

--- a/src/prof_stack_range.c
+++ b/src/prof_stack_range.c
@@ -1,0 +1,161 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/jemalloc_internal_includes.h"
+
+#include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/prof_sys.h"
+
+#if defined (__linux__)
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h> // strtoul
+#include <string.h>
+#include <unistd.h>
+
+static int prof_mapping_containing_addr(
+    uintptr_t addr,
+    const char* maps_path,
+    uintptr_t* mm_start,
+    uintptr_t* mm_end) {
+  int ret = ENOENT; // not found
+  *mm_start = *mm_end = 0;
+
+  // Each line of /proc/<pid>/maps is:
+  // <start>-<end> <perms> <offset> <dev> <inode> <pathname>
+  //
+  // The fields we care about are always within the first 34 characters so
+  // as long as `buf` contains the start of a mapping line it can always be
+  // parsed.
+  static const int kMappingFieldsWidth = 34;
+
+  int fd = -1;
+  char buf[4096];
+  ssize_t remaining = 0; // actual number of bytes read to buf
+  char* line = NULL;
+
+  while (1) {
+    if (fd < 0) {
+      // case 0: initial open of maps file
+      fd = malloc_open(maps_path, O_RDONLY);
+      if (fd < 0) {
+        return errno;
+      }
+
+      remaining = malloc_read_fd(fd, buf, sizeof(buf));
+      if (remaining <= 0) {
+        break;
+      }
+      line = buf;
+    } else if (line == NULL) {
+      // case 1: no newline found in buf
+      remaining = malloc_read_fd(fd, buf, sizeof(buf));
+      if (remaining <= 0) {
+        break;
+      }
+      line = memchr(buf, '\n', remaining);
+      if (line != NULL) {
+        line++; // advance to character after newline
+        remaining -= (line - buf);
+      }
+    } else if (line != NULL && remaining < kMappingFieldsWidth) {
+      // case 2: found newline but insufficient characters remaining in buf
+
+      // fd currently points to the character immediately after the last
+      // character in buf. Seek fd to the character after the newline.
+      if (malloc_lseek(fd, -remaining, SEEK_CUR) == -1) {
+        ret = errno;
+        break;
+      }
+
+      remaining = malloc_read_fd(fd, buf, sizeof(buf));
+      if (remaining <= 0) {
+        break;
+      }
+      line = buf;
+    } else {
+      // case 3: found newline and sufficient characters to parse
+
+      // parse <start>-<end>
+      char* tmp = line;
+      uintptr_t start_addr = strtoul(tmp, &tmp, 16);
+      if (addr >= start_addr) {
+        tmp++; // advance to character after '-'
+        uintptr_t end_addr = strtoul(tmp, &tmp, 16);
+        if (addr < end_addr) {
+          *mm_start = start_addr;
+          *mm_end = end_addr;
+          ret = 0;
+          break;
+        }
+      }
+
+      // Advance to character after next newline in the current buf.
+      char* prev_line = line;
+      line = memchr(line, '\n', remaining);
+      if (line != NULL) {
+        line++; // advance to character after newline
+        remaining -= (line - prev_line);
+      }
+    }
+  }
+
+  malloc_close(fd);
+  return ret;
+}
+
+static uintptr_t prof_main_thread_stack_start(const char* stat_path) {
+  uintptr_t stack_start = 0;
+
+  int fd = malloc_open(stat_path, O_RDONLY);
+  if (fd < 0) {
+    return 0;
+  }
+
+  char buf[512];
+  ssize_t n = malloc_read_fd(fd, buf, sizeof(buf) - 1);
+  if (n >= 0) {
+    buf[n] = '\0';
+    if (sscanf(
+            buf,
+            "%*d (%*[^)]) %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %*u %*u %*d %*d %*d %*d %*d %*d %*u %*u %*d %*u %*u %*u %"FMTuPTR,
+            &stack_start) != 1) {
+    }
+  }
+  malloc_close(fd);
+  return stack_start;
+}
+
+uintptr_t prof_thread_stack_start(uintptr_t stack_end) {
+  pid_t pid = getpid();
+  pid_t tid = gettid();
+  if (pid == tid) {
+    char stat_path[32]; // "/proc/<pid>/stat"
+    malloc_snprintf(stat_path, sizeof(stat_path), "/proc/%d/stat", pid);
+    return prof_main_thread_stack_start(stat_path);
+  } else {
+    // NOTE: Prior to kernel 4.5 an entry for every thread stack was included in
+    // /proc/<pid>/maps as [STACK:<tid>]. Starting with kernel 4.5 only the main
+    // thread stack remains as the [stack] mapping. For other thread stacks the
+    // mapping is still visible in /proc/<pid>/task/<tid>/maps (though not
+    // labeled as [STACK:tid]).
+    // https://lists.ubuntu.com/archives/kernel-team/2016-March/074681.html
+    char maps_path[64]; // "/proc/<pid>/task/<tid>/maps"
+    malloc_snprintf(maps_path, sizeof(maps_path), "/proc/%d/task/%d/maps", pid, tid);
+
+    uintptr_t mm_start, mm_end;
+    if (prof_mapping_containing_addr(
+            stack_end, maps_path, &mm_start, &mm_end) != 0) {
+      return 0;
+    }
+    return mm_end;
+  }
+}
+
+#else
+
+uintptr_t prof_thread_stack_start(UNUSED uintptr_t stack_end) {
+  return 0;
+}
+
+#endif // __linux__

--- a/src/stats.c
+++ b/src/stats.c
@@ -1467,6 +1467,7 @@ stats_general_print(emitter_t *emitter) {
 	CONFIG_WRITE_BOOL(prof);
 	CONFIG_WRITE_BOOL(prof_libgcc);
 	CONFIG_WRITE_BOOL(prof_libunwind);
+	CONFIG_WRITE_BOOL(prof_frameptr);
 	CONFIG_WRITE_BOOL(stats);
 	CONFIG_WRITE_BOOL(utrace);
 	CONFIG_WRITE_BOOL(xmalloc);

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -255,6 +255,7 @@ TEST_BEGIN(test_mallctl_config) {
 	TEST_MALLCTL_CONFIG(prof, bool);
 	TEST_MALLCTL_CONFIG(prof_libgcc, bool);
 	TEST_MALLCTL_CONFIG(prof_libunwind, bool);
+	TEST_MALLCTL_CONFIG(prof_frameptr, bool);
 	TEST_MALLCTL_CONFIG(stats, bool);
 	TEST_MALLCTL_CONFIG(utrace, bool);
 	TEST_MALLCTL_CONFIG(xmalloc, bool);


### PR DESCRIPTION
This diff adds a frame-pointer based backtrace unwinder that can be used safely in environments that may mix code built with and withut frame pointers. Safe means that unwinding will never segfault even if code built without frame pointers is encountered. Currently it is only supported on Linux, but can be extended to other platforms.

Jemalloc's sampled heap profiling must be enabled from the start of a process. For long-running processes switching to frame-pointer based unwinding can be significant. At Meta switching from libunwind to the frame-pointer unwinder in this diff for a production service reduced unwinding overhead by ~75%.

# Background

Jemalloc currently offers three unwiding strategies:

| method  | macro | type | notes | url |
| -------- | ------- | ----- | ----- |-----|
| libunwind  | `JEMALLOC_PROF_LIBUNWIND`   | DWARF | | [link](https://github.com/libunwind/libunwind) |
| libgcc | `JEMALLOC_PROF_LIBGCC`    |  DWARF | `_Unwind_Backtrace()` | [link](https://github.com/gcc-mirror/gcc/blob/master/libgcc/unwind.inc) |
| gcc    | `JEMALLOC_PROF_GCC`   | frame pointer | `__builtin_frame_address()`, `__builtin_return_address()` | [link](https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html) |

## Frame pointer unwinding
- Fast as it is effectively walking a linked list of stack frames.*
- Requires that all code be built with `-fno-omit-frame-pointer` and `-mno-omit-leaf-frame-pointer` to work correctly.
- If a call stack mixes code with and without frame pointers unwinding will be unreliable. Typically the result is truncated backtraces often ending with invalid stack frame addresses. It is also possible for frame pointer unwinding to result is a segfault when code without framepointers is encountered as registers / stack values not corresponding to stack frames will be dereferenced.

## DWARF based unwinding (e.g. libunwind)
- Works for all code - whether or not built with frame pointers.
- Requires debug information (unstripped binaries).
- Significantly slower than frame pointer based unwinding.*

(*it turns out that jemalloc's existing gcc intrinsics based frame pointer unwinder is actually slower than libunwind (DWARF) due to O(N^2) code generation)

It is increasingly common for Linux environments to be built with frame pointers enabled by default (https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html). At Meta this has also long been the default for Linux hosts and binaries built in-house. Still it is possible to encounter third-party code built without frame pointers on production hosts (e.g. Intel Math Kernel Library (MKL), Nvidia CUDA libraries) - so until now the default has been libunwind.

As the documentation for the `__builtin_frame_address()` gcc intrinsic calls out:

> Calling __builtin_frame_address with a value of 0 yields the frame address of the current function, a value of 1 yields the frame address of the caller of the current function, and so forth.
> ...
> Calling this function with a nonzero argument can have unpredictable effects, including crashing the calling program.

# Safe Unwinding

In order to safely unwind using frame pointers the unwinder needs to know the valid bounds for the stack of the current thread. The end of the stack is the current stack pointer address - which can always safely be found with `__builtin_frame_address(0)`. On Linux the stack always grows down from the initial start address. During unwinding the current frame address must always be less than the start of the stack - and must be greater than the previous stack frame address.

A helper function `prof_thread_stack_start()` is added that determines the valid stack start address for the current thread. The stack start address for the main thread on Linux is available in `/proc/<pid>/stats` ([man page](https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html)). For non-main threads `pthread_attr_getstack()` ([man page](https://man7.org/linux/man-pages/man3/pthread_attr_getstack.3p.html)) might be used but because it allocates memory on the heap it isn't a good option for jemalloc backtracing due to reentrancy concerns. Instead we can search for the memory mapping containing the current stack end address in `/proc/<pid>/task/<tid>/maps`. The highest address of the containing mapping is effectively the stack start address.

# Usage

A new configuration option `--enable-prof-frameptr` is added along with a `JEMALLOC_PROF_FRAME_POINTER` macro.