### PR TITLE
Do not support hpa if HUGEPAGE is too large.

### DIFF
--- a/src/hpa.c
+++ b/src/hpa.c
@@ -51,6 +51,10 @@ hpa_supported(void) {
 	if (HUGEPAGE_PAGES == 1) {
 		return false;
 	}
+	/* As mentioned in pages.h, do not support If HUGEPAGE is too large. */
+	if (HUGEPAGE > HUGEPAGE_MAX_EXPECTED_SIZE) {
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
This is a follow-up of #2624. hpa is not supported on machines with too large `HUGEPAGE` as mentioned in [pages.h](https://github.com/jemalloc/jemalloc/blob/4f4fd424477142ee9962fcf4e4cd0349d4e6e4d3/include/jemalloc/internal/pages.h#L31).