### PR TITLE
Remove unreachable() macro

### DIFF
--- a/include/jemalloc/internal/assert.h
+++ b/include/jemalloc/internal/assert.h
@@ -25,7 +25,7 @@
 		    __FILE__, __LINE__);				\
 		abort();						\
 	}								\
-	unreachable();							\
+	JEMALLOC_INTERNAL_UNREACHABLE();				\
 } while (0)
 #endif
 

--- a/include/jemalloc/internal/emitter.h
+++ b/include/jemalloc/internal/emitter.h
@@ -208,7 +208,7 @@ emitter_print_value(emitter_t *emitter, emitter_justify_t justify, int width,
 		EMIT_SIMPLE(char *const, "%s");
 		break;
 	default:
-		unreachable();
+		JEMALLOC_INTERNAL_UNREACHABLE();
 	}
 #undef FMT_SIZE
 }

--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -43,8 +43,6 @@
 #  error JEMALLOC_INTERNAL_UNREACHABLE should have been defined by configure
 #endif
 
-#define unreachable() JEMALLOC_INTERNAL_UNREACHABLE()
-
 /* Set error code. */
 UTIL_INLINE void
 set_errno(int errnum) {

--- a/src/extent.c
+++ b/src/extent.c
@@ -589,7 +589,7 @@ extent_recycle_split(tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks,
 		}
 		return NULL;
 	}
-	unreachable();
+	JEMALLOC_INTERNAL_UNREACHABLE();
 }
 
 /*

--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -33,7 +33,7 @@
 		malloc_write("<jemalloc>: Unreachable code reached\n");	\
 		abort();						\
 	}								\
-	unreachable();							\
+	JEMALLOC_INTERNAL_UNREACHABLE();							\
 } while (0)
 
 #define not_implemented() do {						\

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -30,7 +30,7 @@ reentrancy_t_str(reentrancy_t r) {
 	case arena_new_reentrant:
 		return "arena_new-reentrant";
 	default:
-		unreachable();
+		JEMALLOC_INTERNAL_UNREACHABLE();
 	}
 }
 


### PR DESCRIPTION
This macro was first introduced in jemalloc in 1167e9eff342d3c0f39bb7e8aabc40a34ac0b2fe

Fixes: #2743

