### PR TITLE
Remove unreachable() macro as c23 already defines it.

### DIFF
--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -39,12 +39,6 @@
 #  define unlikely(x) !!(x)
 #endif
 
-#if !defined(JEMALLOC_INTERNAL_UNREACHABLE)
-#  error JEMALLOC_INTERNAL_UNREACHABLE should have been defined by configure
-#endif
-
-#define unreachable() JEMALLOC_INTERNAL_UNREACHABLE()
-
 /* Set error code. */
 UTIL_INLINE void
 set_errno(int errnum) {

--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -39,6 +39,15 @@
 #  define unlikely(x) !!(x)
 #endif
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#include <stddef.h>
+#else
+#if !defined(JEMALLOC_INTERNAL_UNREACHABLE)
+#  error JEMALLOC_INTERNAL_UNREACHABLE should have been defined by configure
+#endif
+#define unreachable() JEMALLOC_INTERNAL_UNREACHABLE()
+#endif
+
 /* Set error code. */
 UTIL_INLINE void
 set_errno(int errnum) {


### PR DESCRIPTION
Taken from https://android-review.git.corp.google.com/c/platform/external/jemalloc_new/+/3316478

This might need more cleanups to remove the definition of JEMALLOC_INTERNAL_UNREACHABLE.

This macro was first introduced in jemalloc in https://github.com/jemalloc/jemalloc/commit/1167e9eff342d3c0f39bb7e8aabc40a34ac0b2fe

Fixes: https://github.com/jemalloc/jemalloc/issues/2743