### PR TITLE
Add configure check for gettid() presence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2695,6 +2695,15 @@ if test "x${je_cv_pthread_mutex_adaptive_np}" = "xyes" ; then
   AC_DEFINE([JEMALLOC_HAVE_PTHREAD_MUTEX_ADAPTIVE_NP], [ ], [ ])
 fi
 
+JE_COMPILABLE([gettid], [
+#include <unistd.h>
+], [
+  int tid = gettid();
+], [je_cv_gettid])
+if test "x${je_cv_gettid}" = "xyes" ; then
+  AC_DEFINE([JEMALLOC_HAVE_GETTID], [ ], [ ])
+fi
+
 JE_CFLAGS_SAVE()
 JE_CFLAGS_ADD([-D_GNU_SOURCE])
 JE_CFLAGS_ADD([-Werror])

--- a/src/prof_stack_range.c
+++ b/src/prof_stack_range.c
@@ -4,7 +4,7 @@
 #include "jemalloc/internal/malloc_io.h"
 #include "jemalloc/internal/prof_sys.h"
 
-#if defined (__linux__)
+#if defined (__linux__) && defined(JE_HAVE_GETTID)
 
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
The gettid() function is available on Linux in glibc only since version 2.30. There are supported distributions that still use older glibc version. Thus add a configure check if the gettid() function is available and extend the check in src/prof_stack_range.c so it's skipped also when gettid() isn't available.

Fixes: https://github.com/jemalloc/jemalloc/issues/2740