### PR TITLE
Fix undeclared function 'gettid' on Ubuntu18

### DIFF
--- a/src/prof_stack_range.c
+++ b/src/prof_stack_range.c
@@ -13,6 +13,13 @@
 #include <string.h>
 #include <unistd.h>
 
+// Fix undeclared function 'gettid' on Ubuntu18
+#ifndef SYS_gettid
+#error "SYS_gettid unavailable on this system"
+#endif
+
+#define gettid() ((pid_t)syscall(SYS_gettid))
+
 static int prof_mapping_containing_addr(
     uintptr_t addr,
     const char* maps_path,


### PR DESCRIPTION
Fix undeclared function 'gettid' on Ubuntu18

```
$ make
<snip>
src/prof_stack_range.c:131:15: error: call to undeclared function 'gettid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  131 |   pid_t tid = gettid();
      |               ^
1 error generated.
Makefile:495: recipe for target 'src/prof_stack_range.sym.o' failed
make: *** [src/prof_stack_range.sym.o] Error 1
make: *** Waiting for unfinished jobs....
```