### PR TITLE
Enable large hugepage tests for arm64 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -297,6 +297,9 @@ jobs:
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: arm64
+      env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-lg-page=16 --with-lg-hugepage=29" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
+    - os: linux
+      arch: arm64
       env: CC=gcc CXX=g++ CONFIGURE_FLAGS="--with-malloc-conf=tcache:false" EXTRA_CFLAGS="-Werror -Wno-array-bounds"
     - os: linux
       arch: arm64


### PR DESCRIPTION
Add large hugepage size (512MB) for arm64 tests on Travis.