### PR TITLE
Add profiling stats for backtrace unwind

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -266,6 +266,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_stats.c \
 	$(srcroot)test/unit/prof_tctx.c \
 	$(srcroot)test/unit/prof_thread_name.c \
+	$(srcroot)test/unit/prof_sys_backtrace.c \
 	$(srcroot)test/unit/prof_sys_thread_name.c \
 	$(srcroot)test/unit/psset.c \
 	$(srcroot)test/unit/ql.c \

--- a/include/jemalloc/internal/prof_stats.h
+++ b/include/jemalloc/internal/prof_stats.h
@@ -17,4 +17,11 @@ void prof_stats_dec(tsd_t *tsd, szind_t ind, size_t size);
 void prof_stats_get_live(tsd_t *tsd, szind_t ind, prof_stats_t *stats);
 void prof_stats_get_accum(tsd_t *tsd, szind_t ind, prof_stats_t *stats);
 
+extern atomic_u64_t prof_backtrace_count;
+extern atomic_u64_t prof_backtrace_time_ns;
+#ifdef JEMALLOC_PROF_FRAME_POINTER
+extern atomic_u64_t prof_stack_range_count;
+extern atomic_u64_t prof_stack_range_time_ns;
+#endif
+
 #endif /* JEMALLOC_INTERNAL_PROF_STATS_H */

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -351,6 +351,12 @@ CTL_PROTO(stats_resident)
 CTL_PROTO(stats_mapped)
 CTL_PROTO(stats_retained)
 CTL_PROTO(stats_zero_reallocs)
+CTL_PROTO(stats_prof_backtrace_count)
+CTL_PROTO(stats_prof_backtrace_time_ns)
+#ifdef JEMALLOC_PROF_FRAME_POINTER
+CTL_PROTO(stats_prof_stack_range_count)
+CTL_PROTO(stats_prof_stack_range_time_ns)
+#endif
 CTL_PROTO(experimental_hooks_install)
 CTL_PROTO(experimental_hooks_remove)
 CTL_PROTO(experimental_hooks_prof_backtrace)
@@ -956,6 +962,12 @@ static const ctl_named_node_t stats_node[] = {
 	{NAME("mutexes"),	CHILD(named, stats_mutexes)},
 	{NAME("arenas"),	CHILD(indexed, stats_arenas)},
 	{NAME("zero_reallocs"),	CTL(stats_zero_reallocs)},
+	{NAME("prof_backtrace_count"), CTL(stats_prof_backtrace_count)},
+	{NAME("prof_backtrace_time_ns"), CTL(stats_prof_backtrace_time_ns)},
+#ifdef JEMALLOC_PROF_FRAME_POINTER
+	{NAME("prof_stack_range_count"), CTL(stats_prof_stack_range_count)},
+	{NAME("prof_stack_range_time_ns"), CTL(stats_prof_stack_range_time_ns)},
+#endif
 };
 
 static const ctl_named_node_t experimental_hooks_node[] = {
@@ -3821,6 +3833,20 @@ CTL_RO_CGEN(config_stats, stats_background_thread_run_interval,
 
 CTL_RO_CGEN(config_stats, stats_zero_reallocs,
     atomic_load_zu(&zero_realloc_count, ATOMIC_RELAXED), size_t)
+
+CTL_RO_CGEN(config_stats, stats_prof_backtrace_count,
+    atomic_load_u64(&prof_backtrace_count, ATOMIC_RELAXED), uint64_t)
+
+CTL_RO_CGEN(config_stats, stats_prof_backtrace_time_ns,
+    atomic_load_u64(&prof_backtrace_time_ns, ATOMIC_RELAXED), uint64_t)
+
+#ifdef JEMALLOC_PROF_FRAME_POINTER
+CTL_RO_CGEN(config_stats, stats_prof_stack_range_count,
+    atomic_load_u64(&prof_stack_range_count, ATOMIC_RELAXED), uint64_t)
+
+CTL_RO_CGEN(config_stats, stats_prof_stack_range_time_ns,
+    atomic_load_u64(&prof_stack_range_time_ns, ATOMIC_RELAXED), uint64_t)
+#endif
 
 CTL_RO_GEN(stats_arenas_i_dss, arenas_i(mib[2])->dss, const char *)
 CTL_RO_GEN(stats_arenas_i_dirty_decay_ms, arenas_i(mib[2])->dirty_decay_ms,

--- a/test/unit/prof_sys_backtrace.c
+++ b/test/unit/prof_sys_backtrace.c
@@ -1,0 +1,53 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/prof_sys.h"
+
+TEST_BEGIN(test_prof_backtrace_stats) {
+	test_skip_if(!config_prof);
+	test_skip_if(!config_stats);
+
+	uint64_t oldval;
+	size_t sz = sizeof(oldval);
+	assert_d_eq(mallctl("stats.prof_backtrace_count", &oldval, &sz, NULL, 0),
+		0, "mallctl failed");
+
+	void *p = malloc(1);
+	free(p);
+
+	uint64_t newval;
+	assert_d_eq(mallctl("stats.prof_backtrace_count", &newval, &sz, NULL, 0),
+		0, "mallctl failed");
+
+	assert_u64_eq(newval, oldval + 1, "prof_backtrace_count not incremented");
+}
+TEST_END
+
+TEST_BEGIN(test_prof_stack_range_stats) {
+#ifdef __linux__
+    test_skip_if(!config_prof);
+    test_skip_if(!config_prof_frameptr);
+    test_skip_if(!config_stats);
+
+    uint64_t oldval;
+    size_t sz = sizeof(oldval);
+    assert_d_eq(mallctl("stats.prof_stack_range_count", &oldval, &sz, NULL, 0),
+      0, "mallctl failed");
+
+    uintptr_t stack_end = (uintptr_t)__builtin_frame_address(0);
+    prof_thread_stack_start(stack_end);
+
+    uint64_t newval;
+    assert_d_eq(mallctl("stats.prof_stack_range_count", &newval, &sz, NULL, 0),
+      0, "mallctl failed");
+
+    assert_u64_eq(newval, oldval + 1, "prof_stack_range_count not incremented");
+#else
+    test_skip_if(true);
+#endif  // __linux__
+}
+TEST_END
+
+int
+main(void) {
+    return test(test_prof_backtrace_stats, test_prof_stack_range_stats);
+}

--- a/test/unit/prof_sys_backtrace.sh
+++ b/test/unit/prof_sys_backtrace.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0,prof_sys_thread_name:true"
+fi


### PR DESCRIPTION
Add malloc stats for profiling / unwinding.

Example of newly added output for a small test program that does allocations with MALLOC_CONF set as:

```
$ MALLOC_CONF=prof:true,lg_prof_sample:15,stats_print:true,stats_print_opts:mda
$ ./tool/run_stats.sh 
...
___ Begin jemalloc statistics ___
...
Profiling stats:
  Backtrace Count: 3929605 (654934 / sec)
  Backtrace Time (ns): 2015039350 total (512 avg)
...
```


```
$ MALLOC_CONF=prof:true,lg_prof_sample:15,stats_print:true,stats_print_opts:mdaJ
$ ./tool/run_stats.sh 
...
{
  "jemalloc": {
...
    "prof": {
      "thread_active_init": true,
      "active": true,
      "gdump": false,
      "interval": 0,
      "lg_sample": 15,
      "backtrace": {
        "backtrace_count": 3865607,
        "backtrace_total_time_ns": 2013999702,
        "backtrace_avg_time_ns": 521
      }
    },
...
```