### PR TITLE
Fix integer overflow in test/unit/hash.c

### DIFF
--- a/test/unit/hash.c
+++ b/test/unit/hash.c
@@ -115,8 +115,11 @@ hash_variant_verify_key(hash_variant_t variant, uint8_t *key) {
 	} default: not_reached();
 	}
 
-	computed = (final[0] << 0) | (final[1] << 8) | (final[2] << 16) |
-	    (final[3] << 24);
+	computed =
+	    ((uint32_t)final[0] << 0) |
+	    ((uint32_t)final[1] << 8) |
+	    ((uint32_t)final[2] << 16) |
+	    ((uint32_t)final[3] << 24);
 
 	switch (variant) {
 #ifdef JEMALLOC_BIG_ENDIAN


### PR DESCRIPTION
`final[3]` is `uint8_t`. Integer conversion rank of `uint8_t` is lower than integer conversion rank of `int`, so `uint8_t` got promoted to `int`, which is signed integer type. Shift `final[3]` value left on 24, when leftmost bit is set overflows `int` and it is undefined behaviour.

Before this change Undefined Behaviour Sanitizer was unhappy about it with the following message.

```
../test/unit/hash.c:119:25: runtime error: left shift of 176 by 24
places cannot be represented in type 'int'
```

After this commit problem is gone.