### PR TITLE
Check for 0 input when setting max_background_thread through mallctl

### DIFF
--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2181,7 +2181,8 @@ max_background_threads_ctl(tsd_t *tsd, const size_t *mib,
 			ret = 0;
 			goto label_return;
 		}
-		if (newval > opt_max_background_threads) {
+		if (newval > opt_max_background_threads ||
+		    newval == 0) {
 			ret = EINVAL;
 			goto label_return;
 		}

--- a/test/unit/background_thread_enable.c
+++ b/test/unit/background_thread_enable.c
@@ -54,6 +54,9 @@ TEST_BEGIN(test_max_background_threads) {
 	    "opt.max_background_threads should match");
 	expect_d_eq(mallctl("max_background_threads", NULL, NULL, &max_n_thds,
 	    sz_m), 0, "Failed to set max background threads");
+	size_t size_zero = 0;
+	expect_d_ne(mallctl("max_background_threads", NULL, NULL, &size_zero,
+	    sz_m), 0, "Should not allow zero background threads");
 
 	unsigned id;
 	size_t sz_u = sizeof(unsigned);
@@ -80,6 +83,8 @@ TEST_BEGIN(test_max_background_threads) {
 	new_max_thds = 1;
 	expect_d_eq(mallctl("max_background_threads", NULL, NULL, &new_max_thds,
 	    sz_m), 0, "Failed to set max background threads");
+	expect_d_ne(mallctl("max_background_threads", NULL, NULL, &size_zero,
+	    sz_m), 0, "Should not allow zero background threads");
 	expect_zu_eq(n_background_threads, new_max_thds,
 	    "Number of background threads should be 1.\n");
 }


### PR DESCRIPTION
Reported by @nc7s.

Resolves #2784