### PR TITLE
Fix arena 0 `deferral_allowed` flag init

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -1789,8 +1789,8 @@ arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config) {
 	 * We turn on the HPA if set to.  There are two exceptions:
 	 * - Custom extent hooks (we should only return memory allocated from
 	 *   them in that case).
-	 * - Arena 0 initialization.  In this case, we're mid-bootstrapping, and
-	 *   so arena_hpa_global is not yet initialized.
+	 * - Arena 0 initialization.  In this case, we're mid-bootstrapping,
+	 *   and so background_thread_enabled is not yet initialized.
 	 */
 	if (opt_hpa && ehooks_are_default(base_ehooks_get(base)) && ind != 0) {
 		hpa_shard_opts_t hpa_shard_opts = opt_hpa_opts;


### PR DESCRIPTION
Arena 0 have a dedicated initialization path, which differs from initialization path of other arenas. The main difference for the purpose of this change is that we initialize arena 0 before we initialize background threads. HPA shard options have `deferral_allowed` flag which should be equal to `background_thread_enabled()` return value, but it wasn't the case, before this change, because for arena 0 `background_thread_enabled()` was initialized correctly after arena 0 initialization phase already ended.

Below is initialization sequence after this commit to illustrate everything still should be initialized correctly.

* `hpa_central_init` initializes HPA Central, before we initialize every HPA shard (including arena's 0).
* `background_thread_boot1` initializes `background_thread_enabled()` return value.
* `pa_shard_enable_hpa` initializes arena 0 HPA shard.

 ```
                       malloc_init_hard -------------
                      /           /                  \   
                     /           /                    \   
                    /           /                      \   
malloc_init_hard_a0_locked  background_thread_boot1  pa_shard_enable_hpa
        /                     /                          \   
       /                     /                            \   
      /                     /                              \   
arena_boot       background_thread_enabled_seta         hpa_shard_init
     |   
     |   
pa_central_init
     |   
     |   
hpa_central_init
```