### PR TITLE
Remove unsupported Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,9 +31,6 @@ task:
      - name: 15-CURRENT
        freebsd_instance:
          image_family: freebsd-15-0-snap
-     - name: 14-STABLE
-       freebsd_instance:
-         image_family: freebsd-14-0-snap
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - pkg upgrade -y


### PR DESCRIPTION
freebsd-14-0-snap is not supported anymore.