### PR TITLE
background_thread: add fallback for pthread_create dlsym

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -63,6 +63,9 @@ pthread_create_fptr_init(void) {
 	 */
 #ifdef JEMALLOC_HAVE_DLSYM
 	pthread_create_fptr = dlsym(RTLD_NEXT, "pthread_create");
+	if (pthread_create_fptr == NULL) {
+		pthread_create_fptr = dlsym(RTLD_DEFAULT, "pthread_create");
+	}
 #else
 	pthread_create_fptr = NULL;
 #endif


### PR DESCRIPTION
If jemalloc is linked into a shared library, the RTLD_NEXT dlsym call may fail since RTLD_NEXT is only specified to search all objects after the current one in the loading order, and the pthread library may be earlier in the load order. Instead of failing immediately, attempt one more time to find pthread_create via RTLD_GLOBAL.

Errors cascading from this were observed on FreeBSD 14.1.