### PR TITLE
Fix compilation of C++ under clang with modules enabled

### DIFF
--- a/include/jemalloc/jemalloc.sh
+++ b/include/jemalloc/jemalloc.sh
@@ -6,9 +6,6 @@ cat <<EOF
 #ifndef JEMALLOC_H_
 #define JEMALLOC_H_
 #pragma GCC system_header
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 EOF
 
@@ -21,8 +18,5 @@ for hdr in jemalloc_defs.h jemalloc_rename.h jemalloc_macros.h \
 done
 
 cat <<EOF
-#ifdef __cplusplus
-}
-#endif
 #endif /* JEMALLOC_H_ */
 EOF

--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -3,6 +3,10 @@
  * of namespace management, and should be omitted in application code unless
  * JEMALLOC_NO_DEMANGLE is defined (see jemalloc_mangle@install_suffix@.h).
  */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern JEMALLOC_EXPORT const char	*@je_@malloc_conf;
 extern JEMALLOC_EXPORT const char	*@je_@malloc_conf_2_conf_harder;
 extern JEMALLOC_EXPORT void		(*@je_@malloc_message)(void *cbopaque,
@@ -78,4 +82,8 @@ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
 JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
     void JEMALLOC_SYS_NOTHROW	*@je_@pvalloc(size_t size) JEMALLOC_CXX_THROW
     JEMALLOC_ATTR(malloc);
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/jemalloc/jemalloc_typedefs.h.in
+++ b/include/jemalloc/jemalloc_typedefs.h.in
@@ -1,3 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct extent_hooks_s extent_hooks_t;
 
 /*
@@ -75,3 +79,7 @@ struct extent_hooks_s {
 	extent_split_t		*split;
 	extent_merge_t		*merge;
 };
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

This PR attempts to fix errors when compiling C++ code with modules enabled on clang.

Such a scenario happens when using Apple's Swift/C++ interop, and the C++ side includes jemalloc. There's little control over the compilation options due to the underlying build system (Swift package manager), so patching jemalloc seemed like the next best option. 

## Problem

When compiling C++ with modules enabled in clang (Apple clang version 16.0.0), jemalloc will cause errors.

A minimal example is compiling the following file:

```c++
#include <jemalloc/jemalloc.h>
#include <cstdint>

int main(int, const char*[]) {
  return 0;
}
```

with 

```sh
clang++ -fcxx-modules -fmodules jemalloc-test.cpp -I`jemalloc-config --includedir`
```

This will report the following errors:

```
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:96:1: error: import of C++ module 'std_stdint_h' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   96 | #include <stdint.h>
      | ^
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:4:1: note: extern "C" language linkage specification begins here
    4 | extern "C" {
      | ^
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:97:1: error: import of C++ module '_Builtin_limits' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   97 | #include <limits.h>
      | ^
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:4:1: note: extern "C" language linkage specification begins here
    4 | extern "C" {
      | ^
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:98:1: error: import of C++ module 'Darwin.POSIX.strings' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   98 | #include <strings.h>
      | ^
/opt/homebrew/Cellar/jemalloc/5.3.0/include/jemalloc/jemalloc.h:4:1: note: extern "C" language linkage specification begins here
    4 | extern "C" {
      | ^
3 errors generated.
```

## Solution

The solution seems to be moving the inclusion of the standard headers outside of the `extern "C"` language linkage specification.

This PR attempts to do this by removing the linkage specification from the top level to only the places where it is needed, using the authors best judgement.