### PR TITLE
Some follow-up changes for the uszie calculation changes

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -496,7 +496,7 @@ bool free_fastpath(void *ptr, size_t size, bool size_hint) {
         assert(tsd_fast(tsd) ||
             *tsd_thread_deallocated_next_event_fastp_get_unsafe(tsd) == 0);
 
-        emap_alloc_ctx_t alloc_ctx;
+        emap_alloc_ctx_t alloc_ctx JEMALLOC_CC_SILENCE_INIT({0, 0, false});
 	size_t usize;
         if (!size_hint) {
                 bool err = emap_alloc_ctx_try_lookup_fast(tsd,

--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -29,7 +29,7 @@
  * wherever the compiler fails to recognize that the variable is never used
  * uninitialized.
  */
-#define JEMALLOC_CC_SILENCE_INIT(v) = v
+#define JEMALLOC_CC_SILENCE_INIT(...) = __VA_ARGS__
 
 #ifdef __GNUC__
 #  define likely(x)   __builtin_expect(!!(x), 1)

--- a/src/stats.c
+++ b/src/stats.c
@@ -1730,6 +1730,7 @@ stats_general_print(emitter_t *emitter) {
 	OPT_WRITE_CHAR_P("stats_interval_opts")
 	OPT_WRITE_CHAR_P("zero_realloc")
 	OPT_WRITE_SIZE_T("process_madvise_max_batch")
+	OPT_WRITE_BOOL("limit_usize_gap")
 
 	emitter_dict_end(emitter); /* Close "opt". */
 


### PR DESCRIPTION
Two changes:
1. include `opt.limit_usize_gap` into the stats;
2. Add an initializer to `emap_alloc_ctx_t` in `free_fastpath` to silence the warning from clang's `-Wmaybe-uninitialized`. 

Change 1 results in one more line in the stats:
```
...
  opt.zero_realloc: "free"
  opt.process_madvise_max_batch: 0
  opt.limit_usize_gap: true
Profiling settings
...
```

Change 2 fixes the warning while keeping the `free_fastpath` assembly unchanged. Below is the assembly compiled with `gcc` using an `-O3` optimization.

The new assembly:

```
0000000000426e40 <free>:
	return (size_t)((key >> rtree_leaf_maskbits()) &
  426e40:	48 89 f8             	mov    %rdi,%rax
	if (unlikely(rtree_ctx->cache[slot].leafkey != leafkey)) {
  426e43:	48 c7 c2 70 f8 ff ff 	mov    $0xfffffffffffff870,%rdx
	return (key & mask);
  426e4a:	48 89 f9             	mov    %rdi,%rcx
	return (size_t)((key >> rtree_leaf_maskbits()) &
  426e4d:	48 c1 e8 1a          	shr    $0x1a,%rax
	return (key & mask);
  426e51:	48 81 e1 00 00 00 c0 	and    $0xffffffffc0000000,%rcx
	if (unlikely(rtree_ctx->cache[slot].leafkey != leafkey)) {
  426e58:	25 f0 00 00 00       	and    $0xf0,%eax
  426e5d:	64 48 03 04 25 00 00 	add    %fs:0x0,%rax
  426e64:	00 00 
  426e66:	48 01 d0             	add    %rdx,%rax
  426e69:	48 3b 88 f8 01 00 00 	cmp    0x1f8(%rax),%rcx
  426e70:	75 7e                	jne    426ef0 <free+0xb0>
	return ((key >> shiftbits) & mask);
  426e72:	48 89 fe             	mov    %rdi,%rsi
  426e75:	4c 8b 80 00 02 00 00 	mov    0x200(%rax),%r8
  426e7c:	48 c1 ee 0c          	shr    $0xc,%rsi
  426e80:	81 e6 ff ff 03 00    	and    $0x3ffff,%esi
  426e86:	49 8b 04 f0          	mov    (%r8,%rsi,8),%rax
	contents.metadata.szind = bits >> LG_VADDR;
  426e8a:	49 89 c1             	mov    %rax,%r9
  426e8d:	49 c1 e9 30          	shr    $0x30,%r9
        if (!size_hint) {
                bool err = emap_alloc_ctx_try_lookup_fast(tsd,
                    &arena_emap_global, ptr, &alloc_ctx);

                /* Note: profiled objects will have alloc_ctx.slab set */
                if (unlikely(err || !alloc_ctx.slab ||
  426e91:	a8 01                	test   $0x1,%al
  426e93:	74 5b                	je     426ef0 <free+0xb0>
        assert(alloc_ctx.slab);

        uint64_t deallocated, threshold;
        te_free_fastpath_ctx(tsd, &deallocated, &threshold);

        uint64_t deallocated_after = deallocated + usize;
  426e95:	64 4c 8b 9a 90 03 00 	mov    %fs:0x390(%rdx),%r11
  426e9c:	00 
  426e9d:	45 89 ca             	mov    %r9d,%r10d
  426ea0:	4e 03 1c cd 40 f9 6f 	add    0x6ff940(,%r9,8),%r11
  426ea7:	00 
         * 0) in a single branch.  Note that this handles the uninitialized case
         * as well (TSD init will be triggered on the non-fastpath).  Therefore
         * anything depends on a functional TSD (e.g. the alloc_ctx sanity check
         * below) needs to be after this branch.
         */
        if (unlikely(deallocated_after >= threshold)) {
  426ea8:	64 4c 39 9a 98 03 00 	cmp    %r11,%fs:0x398(%rdx)
  426eaf:	00 
  426eb0:	76 3e                	jbe    426ef0 <free+0xb0>
	return ((uint16_t)(uintptr_t)bin->stack_head == bin->low_bits_full);
  426eb2:	64 48 8b 34 25 00 00 	mov    %fs:0x0,%rsi
  426eb9:	00 00 
  426ebb:	4b 8d 0c 52          	lea    (%r10,%r10,2),%rcx
  426ebf:	48 8d 04 ce          	lea    (%rsi,%rcx,8),%rax
  426ec3:	48 01 d0             	add    %rdx,%rax
  426ec6:	4c 8b 88 a8 03 00 00 	mov    0x3a8(%rax),%r9
	if (unlikely(cache_bin_full(bin))) {
  426ecd:	66 44 39 88 ba 03 00 	cmp    %r9w,0x3ba(%rax)
  426ed4:	00 
  426ed5:	74 19                	je     426ef0 <free+0xb0>
	bin->stack_head--;
  426ed7:	4d 8d 41 f8          	lea    -0x8(%r9),%r8
  426edb:	4c 89 80 a8 03 00 00 	mov    %r8,0x3a8(%rax)
	*bin->stack_head = ptr;
  426ee2:	49 89 79 f8          	mov    %rdi,-0x8(%r9)

        if (!cache_bin_dalloc_easy(bin, ptr)) {
                return false;
        }

        *tsd_thread_deallocatedp_get(tsd) = deallocated_after;
  426ee6:	64 4c 89 9a 90 03 00 	mov    %r11,%fs:0x390(%rdx)
  426eed:	00 
}
  426eee:	c3                   	ret    
  426eef:	90                   	nop
}
``` 

The original one:
```
0000000000426e40 <free>:
	return (size_t)((key >> rtree_leaf_maskbits()) &
  426e40:	48 89 f8             	mov    %rdi,%rax
	if (unlikely(rtree_ctx->cache[slot].leafkey != leafkey)) {
  426e43:	48 c7 c2 70 f8 ff ff 	mov    $0xfffffffffffff870,%rdx
	return (key & mask);
  426e4a:	48 89 f9             	mov    %rdi,%rcx
	return (size_t)((key >> rtree_leaf_maskbits()) &
  426e4d:	48 c1 e8 1a          	shr    $0x1a,%rax
	return (key & mask);
  426e51:	48 81 e1 00 00 00 c0 	and    $0xffffffffc0000000,%rcx
	if (unlikely(rtree_ctx->cache[slot].leafkey != leafkey)) {
  426e58:	25 f0 00 00 00       	and    $0xf0,%eax
  426e5d:	64 48 03 04 25 00 00 	add    %fs:0x0,%rax
  426e64:	00 00 
  426e66:	48 01 d0             	add    %rdx,%rax
  426e69:	48 3b 88 f8 01 00 00 	cmp    0x1f8(%rax),%rcx
  426e70:	75 7e                	jne    426ef0 <free+0xb0>
	return ((key >> shiftbits) & mask);
  426e72:	48 89 fe             	mov    %rdi,%rsi
  426e75:	4c 8b 80 00 02 00 00 	mov    0x200(%rax),%r8
  426e7c:	48 c1 ee 0c          	shr    $0xc,%rsi
  426e80:	81 e6 ff ff 03 00    	and    $0x3ffff,%esi
  426e86:	49 8b 04 f0          	mov    (%r8,%rsi,8),%rax
	contents.metadata.szind = bits >> LG_VADDR;
  426e8a:	49 89 c1             	mov    %rax,%r9
  426e8d:	49 c1 e9 30          	shr    $0x30,%r9
        if (!size_hint) {
                bool err = emap_alloc_ctx_try_lookup_fast(tsd,
                    &arena_emap_global, ptr, &alloc_ctx);

                /* Note: profiled objects will have alloc_ctx.slab set */
                if (unlikely(err || !alloc_ctx.slab ||
  426e91:	a8 01                	test   $0x1,%al
  426e93:	74 5b                	je     426ef0 <free+0xb0>
        assert(alloc_ctx.slab);

        uint64_t deallocated, threshold;
        te_free_fastpath_ctx(tsd, &deallocated, &threshold);

        uint64_t deallocated_after = deallocated + usize;
  426e95:	64 4c 8b 9a 90 03 00 	mov    %fs:0x390(%rdx),%r11
  426e9c:	00 
  426e9d:	45 89 ca             	mov    %r9d,%r10d
  426ea0:	4e 03 1c cd 40 f9 6f 	add    0x6ff940(,%r9,8),%r11
  426ea7:	00 
         * 0) in a single branch.  Note that this handles the uninitialized case
         * as well (TSD init will be triggered on the non-fastpath).  Therefore
         * anything depends on a functional TSD (e.g. the alloc_ctx sanity check
         * below) needs to be after this branch.
         */
        if (unlikely(deallocated_after >= threshold)) {
  426ea8:	64 4c 39 9a 98 03 00 	cmp    %r11,%fs:0x398(%rdx)
  426eaf:	00 
  426eb0:	76 3e                	jbe    426ef0 <free+0xb0>
	return ((uint16_t)(uintptr_t)bin->stack_head == bin->low_bits_full);
  426eb2:	64 48 8b 34 25 00 00 	mov    %fs:0x0,%rsi
  426eb9:	00 00 
  426ebb:	4b 8d 0c 52          	lea    (%r10,%r10,2),%rcx
  426ebf:	48 8d 04 ce          	lea    (%rsi,%rcx,8),%rax
  426ec3:	48 01 d0             	add    %rdx,%rax
  426ec6:	4c 8b 88 a8 03 00 00 	mov    0x3a8(%rax),%r9
	if (unlikely(cache_bin_full(bin))) {
  426ecd:	66 44 39 88 ba 03 00 	cmp    %r9w,0x3ba(%rax)
  426ed4:	00 
  426ed5:	74 19                	je     426ef0 <free+0xb0>
	bin->stack_head--;
  426ed7:	4d 8d 41 f8          	lea    -0x8(%r9),%r8
  426edb:	4c 89 80 a8 03 00 00 	mov    %r8,0x3a8(%rax)
	*bin->stack_head = ptr;
  426ee2:	49 89 79 f8          	mov    %rdi,-0x8(%r9)

        if (!cache_bin_dalloc_easy(bin, ptr)) {
                return false;
        }

        *tsd_thread_deallocatedp_get(tsd) = deallocated_after;
  426ee6:	64 4c 89 9a 90 03 00 	mov    %r11,%fs:0x390(%rdx)
  426eed:	00 
}
  426eee:	c3                   	ret    
  426eef:	90                   	nop
}
```