### PR TITLE
Added sb instruction support for ARMv9 architecture

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -152,6 +152,7 @@ C_SRCS := $(srcroot)src/jemalloc.c \
 	$(srcroot)src/safety_check.c \
 	$(srcroot)src/sc.c \
 	$(srcroot)src/sec.c \
+	$(srcroot)src/spin_delay_arm.c \
 	$(srcroot)src/stats.c \
 	$(srcroot)src/sz.c \
 	$(srcroot)src/tcache.c \

--- a/include/jemalloc/internal/spin.h
+++ b/include/jemalloc/internal/spin.h
@@ -12,7 +12,8 @@ typedef struct {
 
 static inline void
 spin_cpu_spinwait(void) {
-#  if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+#  if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__)) && \
+	(defined(__GNUC__) || defined(__clang__))
 	spin_delay_arm();
 #  elif HAVE_CPU_SPINWAIT
 	CPU_SPINWAIT;

--- a/include/jemalloc/internal/spin.h
+++ b/include/jemalloc/internal/spin.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_SPIN_H
 
 #include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/spin_delay_arm.h"
 
 #define SPIN_INITIALIZER {0U}
 
@@ -11,7 +12,9 @@ typedef struct {
 
 static inline void
 spin_cpu_spinwait(void) {
-#  if HAVE_CPU_SPINWAIT
+#  if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+	spin_delay_arm();
+#  elif HAVE_CPU_SPINWAIT
 	CPU_SPINWAIT;
 #  else
 	volatile int x = 0;

--- a/include/jemalloc/internal/spin_delay_arm.h
+++ b/include/jemalloc/internal/spin_delay_arm.h
@@ -1,0 +1,21 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include <stdatomic.h>
+
+/* Global variable to track SB support, declared as extern to be defined in one TU */
+extern _Atomic int arm_has_sb_instruction;
+
+/* Constructor function declaration - implementation in spin_delay_arm.c */
+__attribute__((constructor))
+void detect_arm_sb_support(void);
+
+/* Use SB instruction if available, otherwise ISB */
+static inline void
+spin_delay_arm(void) {
+	if (__builtin_expect(arm_has_sb_instruction == 1, 1)) {
+		/* SB instruction encoding */
+		asm volatile(".inst 0xd50330ff \n");
+	} else {
+		/* ISB instruction */
+		asm volatile("isb; \n");
+	}
+}

--- a/include/jemalloc/internal/spin_delay_arm.h
+++ b/include/jemalloc/internal/spin_delay_arm.h
@@ -1,23 +1,13 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
-#include <stdatomic.h>
 
-/* Global variable to track SB support, declared as extern to be defined in one TU */
-extern _Atomic int arm_has_sb_instruction;
-
-/* Constructor function declaration - implementation in spin_delay_arm.c */
-__attribute__((constructor))
-void detect_arm_sb_support(void);
+/* Global variable to track SB support */
+extern int arm_has_sb_instruction;
 
 /* Use SB instruction if available, otherwise ISB */
-static inline void
-spin_delay_arm(void) {
-#ifdef HWCAP_SB
+static inline void spin_delay_arm(void) {
 	if (__builtin_expect(arm_has_sb_instruction == 1, 1)) {
-		/* SB instruction encoding */
-		asm volatile(".inst 0xd50330ff \n");
+		asm volatile(".inst 0xd50330ff \n");   /* SB instruction encoding */
 	} else {
-		/* ISB instruction */
 		asm volatile("isb; \n");
 	}
-#endif // HWCAP_SB
 }

--- a/include/jemalloc/internal/spin_delay_arm.h
+++ b/include/jemalloc/internal/spin_delay_arm.h
@@ -11,6 +11,7 @@ void detect_arm_sb_support(void);
 /* Use SB instruction if available, otherwise ISB */
 static inline void
 spin_delay_arm(void) {
+#ifdef HWCAP_SB
 	if (__builtin_expect(arm_has_sb_instruction == 1, 1)) {
 		/* SB instruction encoding */
 		asm volatile(".inst 0xd50330ff \n");
@@ -18,4 +19,5 @@ spin_delay_arm(void) {
 		/* ISB instruction */
 		asm volatile("isb; \n");
 	}
+#endif // HWCAP_SB
 }

--- a/src/spin_delay_arm.c
+++ b/src/spin_delay_arm.c
@@ -1,22 +1,15 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/spin_delay_arm.h"
-#include <stdatomic.h>
 
-#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+/* Initialize to 0 (false) by default */
+int arm_has_sb_instruction = 0;
+
+#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__)) && \
+	(defined(__GNUC__) || defined(__clang__))
 #include <sys/auxv.h>
-#endif   // __linux__ && (defined(__aarch64__) || defined(__arm64__))
 
-/* Global variable to track SB support, defined here to avoid multiple definitions */
-_Atomic int arm_has_sb_instruction = ATOMIC_VAR_INIT(0);
-
-/* Constructor function to detect hardware capabilities at program startup */
 __attribute__((constructor))
-void
-detect_arm_sb_support(void) {
-#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
-	/* Check if SB instruction is supported */
-	if (getauxval(AT_HWCAP) & HWCAP_SB) {
-		atomic_store_explicit(&arm_has_sb_instruction, 1, memory_order_release);
-	}
-#endif
+void detect_arm_sb_support(void) {
+    arm_has_sb_instruction = (getauxval(AT_HWCAP) & HWCAP_SB) ? 1 : 0;
 }
+#endif

--- a/src/spin_delay_arm.c
+++ b/src/spin_delay_arm.c
@@ -4,11 +4,6 @@
 
 #if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
 #include <sys/auxv.h>
-
-/* Define HWCAP_SB if not already defined in system headers */
-#ifndef HWCAP_SB
-#define HWCAP_SB (1ULL << 56) /* Speculation Barrier */
-#endif   // HWCAP_SB
 #endif   // __linux__ && (defined(__aarch64__) || defined(__arm64__))
 
 /* Global variable to track SB support, defined here to avoid multiple definitions */

--- a/src/spin_delay_arm.c
+++ b/src/spin_delay_arm.c
@@ -1,0 +1,27 @@
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/spin_delay_arm.h"
+#include <stdatomic.h>
+
+#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+#include <sys/auxv.h>
+
+/* Define HWCAP_SB if not already defined in system headers */
+#ifndef HWCAP_SB
+#define HWCAP_SB (1ULL << 56) /* Speculation Barrier */
+#endif   // HWCAP_SB
+#endif   // __linux__ && (defined(__aarch64__) || defined(__arm64__))
+
+/* Global variable to track SB support, defined here to avoid multiple definitions */
+_Atomic int arm_has_sb_instruction = ATOMIC_VAR_INIT(0);
+
+/* Constructor function to detect hardware capabilities at program startup */
+__attribute__((constructor))
+void
+detect_arm_sb_support(void) {
+#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+	/* Check if SB instruction is supported */
+	if (getauxval(AT_HWCAP) & HWCAP_SB) {
+		atomic_store_explicit(&arm_has_sb_instruction, 1, memory_order_release);
+	}
+#endif
+}


### PR DESCRIPTION
We would like to add the support for ARMv9 architecture to use `sb` instruction instead of `isb`. 
Based on our micro benchmark (patch attached), `sb` is ~30% faster than `isb` (ratio=1.710:1)  and the change do not seems to introduce any regression on the spin_cpu_spinwait() function  (isb_spin=8740725us vs standard_spin=8739722us).

```
# Jemalloc build
$ make clean all ; ./autogen.sh && ./configure && make -j4

# Test on m8g.2xlarge with patch
$ make tests_stress && ./test/stress/arm_spin_bench
Running on ARM64 architecture
SB instruction is supported
1000000 iterations, isb_spin=8740725us (8740.725 ns/iter), standard_spin=5110839us (5110.839 ns/iter), time consumption ratio=1.710:1

# Test on m8g.2xlarge without patch 
1000000 iterations, isb_spin=8739722us (8739.722 ns/iter), standard_spin=8739722us (8739.722 ns/iter), time consumption ratio=1.000:1
```

[benchmark.patch](https://github.com/user-attachments/files/20006592/benchmark.patch)
