### PR TITLE
When building for aarch64 on Linux, use 64K granularity by default for LG_PAGE to allow 64K and 16K kernel pages to work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1911,10 +1911,11 @@ case "${host}" in
         LG_PAGE=14
       fi
       ;;
-  aarch64-linux-gnu*)
-      dnl When cross-compile for 64 bit Arm64, use memory granularity of 64K to ensure
-      dnl that 64K and 16K kernel sizes (default for many distros) function al all.
-      if test "x${host}" != "x${build}" -a "x$LG_PAGE" = "xdetect"; then
+  aarch64-*-linux-gnu*)
+      dnl When cross-compile for 64 bit Arm64, in the absence of an explicit flag setting page size, 
+      dnl use memory granularity of 64K to ensure that 64K and 16K kernel sizes (default for many
+      dnl distros) function al all.
+      if test "x$LG_PAGE" = "xdetect"; then
         LG_PAGE=16
       fi
       ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1911,6 +1911,13 @@ case "${host}" in
         LG_PAGE=14
       fi
       ;;
+  aarch64-linux-gnu*)
+      dnl When cross-compile for 64 bit Arm64, use memory granularity of 64K to ensure
+      dnl that 64K and 16K kernel sizes (default for many distros) function al all.
+      if test "x${host}" != "x${build}" -a "x$LG_PAGE" = "xdetect"; then
+        LG_PAGE=16
+      fi
+      ;;
 esac
 if test "x$LG_PAGE" = "xdetect"; then
   AC_CACHE_CHECK([LG_PAGE],


### PR DESCRIPTION
By default, jemalloc builds with LG_SIZE=12 for 2^12 byte page allocation granularity. This breaks any Arm64 system running a 16K kernel (as Macs and Raspberry Pi 5 systems do) and any Arm64 distributions running 16K or 64K kernels. As the larker kernel granule offers considerable performance benefits, many people want to use them, but projects with jemalloc as a dependency do not work when compiled with the default flags.

This patch changes the default LG_PAGE size to 16 (2^16 = 64K) which will work on all Arm64 systems. People who know they will be running jemalloc on 4K systems and want to optimize memory efficiency for that granule size can use `--with-lg-page=12 `.

This patch fixes the issue described in https://github.com/jemalloc/jemalloc/issues/2639 