### PR TITLE
Fix: Adjust CACHE_BIN_NFLUSH_BATCH_MAX size to prevent assert failures

### DIFF
--- a/include/jemalloc/internal/cache_bin.h
+++ b/include/jemalloc/internal/cache_bin.h
@@ -616,7 +616,7 @@ struct cache_bin_fill_ctl_s {
  * This is to avoid stack overflow when we do batch edata look up, which
  * reserves a nflush * sizeof(emap_batch_lookup_result_t) stack variable.
  */
-#define CACHE_BIN_NFLUSH_BATCH_MAX (VARIABLE_ARRAY_SIZE_MAX >> LG_SIZEOF_PTR)
+#define CACHE_BIN_NFLUSH_BATCH_MAX ((VARIABLE_ARRAY_SIZE_MAX >> LG_SIZEOF_PTR) - 1)
 
 /*
  * Filling and flushing are done in batch, on arrays of void *s.  For filling,


### PR DESCRIPTION
The maximum allowed value for `nflush_batch` is
`CACHE_BIN_NFLUSH_BATCH_MAX`. 
https://github.com/jemalloc/jemalloc/blob/3c14707b016b156c5f86dfd21304b01161c40750/include/jemalloc/internal/cache_bin.h#L619

However, `tcache_bin_flush_impl_small` could potentially declare an array of `emap_batch_lookup_result_t` of size `CACHE_BIN_NFLUSH_BATCH_MAX + 1`. 

https://github.com/jemalloc/jemalloc/blob/3c14707b016b156c5f86dfd21304b01161c40750/src/tcache.c#L699

leads to a `VARIABLE_ARRAY` assertion failure, 

https://github.com/jemalloc/jemalloc/blob/3c14707b016b156c5f86dfd21304b01161c40750/include/jemalloc/internal/jemalloc_internal_types.h#L143-L146

observed when `tcache_nslots_small_max` is configured to 2048. This patch ensures the array size does not exceed the allowed maximum.