### PR TITLE
EASY - be explicit in non-vectorized hpa tests

### DIFF
--- a/test/unit/hpa.sh
+++ b/test/unit/hpa.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="process_madvise_max_batch:0"


### PR DESCRIPTION
Make sure that test really tests hpa case where vectorization is disabled. 