### PR TITLE
Derive arena constants from MALLOCX_ARENA_BITS

### DIFF
--- a/include/jemalloc/jemalloc_macros.h.in
+++ b/include/jemalloc/jemalloc_macros.h.in
@@ -44,12 +44,12 @@
  *   mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", NULL, NULL, NULL,
  *       0);
  */
-#define MALLCTL_ARENAS_ALL	4096
+#define MALLCTL_ARENAS_ALL	(1U << MALLOCX_ARENA_BITS)
 /*
  * Use as arena index in "stats.arenas.<i>.*" mallctl interfaces to select
  * destroyed arenas.
  */
-#define MALLCTL_ARENAS_DESTROYED	4097
+#define MALLCTL_ARENAS_DESTROYED	((1U << MALLOCX_ARENA_BITS) + 1)
 
 #if defined(__cplusplus) && defined(JEMALLOC_USE_CXX_THROW)
 #  define JEMALLOC_CXX_THROW noexcept (true)


### PR DESCRIPTION
Replaces the hardcoded values for `MALLCTL_ARENAS_ALL` and `MALLCTL_ARENAS_DESTROYED` with expressions derived from `MALLOCX_ARENA_BITS`.

This prevents a potential crash (e.g., in stats printing) that would occur if `MALLOCX_ARENA_BITS` were changed while these macro values remained hardcoded.