### PR TITLE
Fixes make check failure with config.malloc_conf set differently.

### DIFF
--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -68,7 +68,8 @@ large_dalloc_safety_checks(edata_t *edata, const void *ptr, size_t input_size) {
 		    "possibly caused by double free bugs.", ptr);
 		return true;
 	}
-	if (unlikely(input_size != edata_usize_get(edata))) {
+	if (unlikely(input_size != edata_usize_get(edata) ||
+	    input_size > SC_LARGE_MAXCLASS)) {
 		safety_check_fail_sized_dealloc(/* current_dealloc */ true, ptr,
 		    /* true_size */ edata_usize_get(edata), input_size);
 		return true;

--- a/test/unit/binshard.sh
+++ b/test/unit/binshard.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-export MALLOC_CONF="narenas:1,bin_shards:1-160:16|129-512:4|256-256:8"
+export MALLOC_CONF="narenas:1,bin_shards:1-160:16|129-512:4|256-256:8|513-8070450532247928832:1"


### PR DESCRIPTION
When adding some options to config.malloc_conf, some errors are triggered during make check. This PR fixes those errors.

Specifically,

During tests (with `JEMALLOC_JET` defined in [`edata_usize_get`](https://github.com/jemalloc/jemalloc/blob/5e460bfea25c39d9bf8ea0077c3b6740e9515487/include/jemalloc/internal/edata.h#L315)), invalid index would return `SC_LARGE_MAXCLASS + 1` but this was not checked during the safety checks, adding that in;
Unit test bin_shard make assumptions on the default value of some options, which can be wrong with config.malloc_conf set differently. Adding these options into the corresponding .sh explicitly.