### PR TITLE
Fix build with gcc 16.x

### DIFF
--- a/src/jemalloc_cpp.cpp
+++ b/src/jemalloc_cpp.cpp
@@ -93,7 +93,7 @@ handleOOM(std::size_t size, bool nothrow) {
 	}
 
 	if (ptr == nullptr && !nothrow)
-		std::__throw_bad_alloc();
+		throw std::bad_alloc();
 	return ptr;
 }
 


### PR DESCRIPTION
```
src/jemalloc_cpp.cpp: In function 'void* handleOOM(std::size_t, bool)': src/jemalloc_cpp.cpp:90:22: error: '__throw_bad_alloc' is not a member
 of 'std'; did you mean '__throw_bad_cast'?
   90 |                 std::__throw_bad_alloc();
```
https://bugs.gentoo.org/967868

Patch downloaded from
https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-libs/jemalloc/files/jemalloc-5.3.0-dont-call-libstdcxx-internals.patch?id=4b929d70d69b013ea881879d66687b461d812aec