### PR TITLE
Fix typo in prof_log_rep_check: use != instead of || for alloc_count

### DIFF
--- a/src/prof_log.c
+++ b/src/prof_log.c
@@ -375,7 +375,7 @@ prof_log_rep_check(void) {
 	size_t alloc_count = prof_log_alloc_count();
 
 	if (prof_logging_state == prof_logging_state_stopped) {
-		if (bt_count != 0 || thr_count != 0 || alloc_count || 0) {
+		if (bt_count != 0 || thr_count != 0 || alloc_count != 0) {
 			return true;
 		}
 	}


### PR DESCRIPTION
The condition incorrectly used 'alloc_count || 0' which was likely a typo for 'alloc_count != 0'. While both evaluate similarly for the zero/non-zero case, the fix ensures consistency with bt_count and thr_count checks and uses the correct comparison operator.