### PR TITLE
Documentation updates

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -897,16 +897,6 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         during build configuration.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="config.prof_frameptr">
-        <term>
-          <mallctl>config.prof_frameptr</mallctl>
-          (<type>bool</type>)
-          <literal>r-</literal>
-        </term>
-        <listitem><para><option>--enable-prof-frameptr</option> was specified
-        during build configuration.</para></listitem>
-      </varlistentry>
-
       <varlistentry id="config.stats">
         <term>
           <mallctl>config.stats</mallctl>
@@ -1397,6 +1387,17 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         setting of tcache_max.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="opt.huge_arena_pac_thp">
+        <term>
+          <mallctl>opt.huge_arena_pac_thp</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Controls whether the oversize arena uses transparent huge
+        pages (THP) for oversize allocations.  This option is disabled by
+        default.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="opt.thp">
         <term>
           <mallctl>opt.thp</mallctl>
@@ -1417,6 +1418,17 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         linkend="arena.i.extent_hooks"><mallctl>extent_hooks</mallctl></link>,
         this option is bypassed as it is implemented as part of the default
         extent hooks.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="opt.prof_bt_max">
+        <term>
+          <mallctl>opt.prof_bt_max</mallctl>
+          (<type>unsigned</type>)
+          <literal>r-</literal>
+          [<option>--enable-prof</option>]
+        </term>
+        <listitem><para>Maximum number of stack frames to record in profiling
+        backtraces.  The default is 128.</para></listitem>
       </varlistentry>
 
       <varlistentry id="opt.prof">
@@ -1666,6 +1678,53 @@ malloc_conf = "xmalloc:true";]]></programlisting>
 	testing this behavior.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="opt.debug_double_free_max_scan">
+        <term>
+          <mallctl>opt.debug_double_free_max_scan</mallctl>
+          (<type>unsigned</type>)
+          <literal>r-</literal>
+          [<option>--enable-debug</option>]
+        </term>
+        <listitem><para>Maximum number of cached pointers to scan in the
+        thread cache when checking for double-free errors on deallocation.
+        When debug is enabled, each deallocation into the tcache scans up to
+        this many recently cached pointers to detect whether the same pointer
+        is being freed twice.  Setting this to 0 disables the check.  This
+        option is set to 0 and has no effect when debug is not enabled.  The
+        default is 32.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="opt.disable_large_size_classes">
+        <term>
+          <mallctl>opt.disable_large_size_classes</mallctl>
+          (<type>bool</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>When enabled (the default), large allocations
+        (i.e. allocations of size &gt;= <constant>SC_LARGE_MINCLASS</constant>)
+        are rounded up to the nearest page boundary rather than the nearest
+        large size class.  This minimizes memory overhead, especially when
+        using hugepages, at the cost of disabling the standard large size
+        class hierarchy.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="opt.process_madvise_max_batch">
+        <term>
+          <mallctl>opt.process_madvise_max_batch</mallctl>
+          (<type>size_t</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Maximum number of memory regions to include in each
+        <citerefentry><refentrytitle>process_madvise</refentrytitle>
+        <manvolnum>2</manvolnum></citerefentry> batch call.  When set to 0
+        (the default), process_madvise is not used, and the standard
+        <citerefentry><refentrytitle>madvise</refentrytitle>
+        <manvolnum>2</manvolnum></citerefentry> is used instead.  Setting this
+        to a positive value enables batched purging via process_madvise, which
+        can reduce the number of system calls needed for
+        purging.</para></listitem>
+      </varlistentry>
+
       <varlistentry id="thread.arena">
         <term>
           <mallctl>thread.arena</mallctl>
@@ -1800,6 +1859,47 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         activity, so it is possible for a thread that stops
         allocating/deallocating to retain its cache indefinitely, in which case
         the developer may find manual flushing useful.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="thread.tcache.max">
+        <term>
+          <mallctl>thread.tcache.max</mallctl>
+          (<type>size_t</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Get or set the maximum cached size class
+        (<varname>tcache_max</varname>) for the calling thread's tcache.  The
+        value is clamped to the maximum allowed limit and rounded up to the
+        nearest size class boundary.  Changing this value will resize the
+        thread cache accordingly.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="thread.tcache.ncached_max.read_sizeclass">
+        <term>
+          <mallctl>thread.tcache.ncached_max.read_sizeclass</mallctl>
+          (<type>size_t</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Query the maximum number of cached objects
+        (<varname>ncached_max</varname>) for a given size class in the calling
+        thread's tcache.  The size class is passed in via
+        <parameter>newp</parameter>, and the corresponding
+        <varname>ncached_max</varname> is returned via
+        <parameter>oldp</parameter>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="thread.tcache.ncached_max.write">
+        <term>
+          <mallctl>thread.tcache.ncached_max.write</mallctl>
+          (<type>char *</type>)
+          <literal>-w</literal>
+        </term>
+        <listitem><para>Set the maximum number of cached objects
+        (<varname>ncached_max</varname>) for size classes in the calling
+        thread's tcache.  The input is a string of colon-separated settings,
+        where each setting specifies a size range and a count, in the same
+        format as the <mallctl>opt.tcache_ncached_max</mallctl> runtime
+        option.</para></listitem>
       </varlistentry>
 
       <varlistentry id="thread.prof.name">
@@ -1983,6 +2083,24 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         recycle the arena index.  Destruction will fail if any threads are
         currently associated with the arena as a result of calls to <link
         linkend="thread.arena"><mallctl>thread.arena</mallctl></link>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="arena.i.name">
+        <term>
+          <mallctl>arena.&lt;i&gt;.name</mallctl>
+          (<type>char *</type>)
+          <literal>rw</literal>
+        </term>
+        <listitem><para>Get or set a descriptive name for arena &lt;i&gt;.
+        Arena names can be up to 32 characters long (including the null
+        terminator); longer names are truncated.  When reading, the caller
+        passes a pointer to a pre-allocated buffer (of at least 32 bytes) via
+        <parameter>oldp</parameter>, and
+        <parameter>*oldlenp</parameter> must be
+        <code language="C">sizeof(<type>char *</type>)</code>.
+        Arena names are also included in the output of <link
+        linkend="stats_print"><function>malloc_stats_print()</function></link>.
+        </para></listitem>
       </varlistentry>
 
       <varlistentry id="arena.i.dss">
@@ -2342,6 +2460,18 @@ struct extent_hooks_s {
         <listitem><para>Page size.</para></listitem>
       </varlistentry>
 
+      <varlistentry id="arenas.hugepage">
+        <term>
+          <mallctl>arenas.hugepage</mallctl>
+          (<type>size_t</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Hugepage size.  This value is also reported in the
+        output of <link
+        linkend="stats_print"><function>malloc_stats_print()</function></link>.
+        </para></listitem>
+      </varlistentry>
+
       <varlistentry id="arenas.tcache_max">
         <term>
           <mallctl>arenas.tcache_max</mallctl>
@@ -2559,6 +2689,24 @@ struct extent_hooks_s {
         <link
         linkend="opt.lg_prof_interval"><mallctl>opt.lg_prof_interval</mallctl></link>
         option for additional information.</para></listitem>
+      </varlistentry>
+
+      <varlistentry id="approximate_stats.active">
+        <term>
+          <mallctl>approximate_stats.active</mallctl>
+          (<type>size_t</type>)
+          <literal>r-</literal>
+        </term>
+        <listitem><para>Return the total number of bytes in active pages
+        collected in an unsynchronized manner, without requiring an
+        <link linkend="epoch"><mallctl>epoch</mallctl></link> update.
+        As a result, this value should NOT be compared with other
+        stats.  For example, the relative ordering between
+        <mallctl>approximate_stats.active</mallctl> and <link
+        linkend="stats.active"><mallctl>stats.active</mallctl></link> or <link
+        linkend="stats.resident"><mallctl>stats.resident</mallctl></link> is
+        not guaranteed.  This interface is intended for lightweight monitoring
+        where an approximate value is sufficient.</para></listitem>
       </varlistentry>
 
       <varlistentry id="stats.allocated">

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1393,9 +1393,10 @@ malloc_conf = "xmalloc:true";]]></programlisting>
           (<type>bool</type>)
           <literal>r-</literal>
         </term>
-        <listitem><para>Controls whether the oversize arena uses transparent huge
-        pages (THP) for oversize allocations.  This option is disabled by
-        default.</para></listitem>
+        <listitem><para>Controls whether the huge (oversized) arena's backing
+        memory is promoted to transparent huge pages via madvise. Only effective
+        when the system THP mode is madvise, opt.thp is left at its default, and
+        opt.metadata_thp is enabled.</para></listitem>
       </varlistentry>
 
       <varlistentry id="opt.thp">
@@ -1896,7 +1897,7 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         </term>
         <listitem><para>Set the maximum number of cached objects
         (<varname>ncached_max</varname>) for size classes in the calling
-        thread's tcache.  The input is a string of colon-separated settings,
+        thread's tcache.  The input is a string of pipe-separated settings,
         where each setting specifies a size range and a count, in the same
         format as the <mallctl>opt.tcache_ncached_max</mallctl> runtime
         option.</para></listitem>

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1387,18 +1387,6 @@ malloc_conf = "xmalloc:true";]]></programlisting>
         setting of tcache_max.</para></listitem>
       </varlistentry>
 
-      <varlistentry id="opt.huge_arena_pac_thp">
-        <term>
-          <mallctl>opt.huge_arena_pac_thp</mallctl>
-          (<type>bool</type>)
-          <literal>r-</literal>
-        </term>
-        <listitem><para>Controls whether the huge (oversized) arena's backing
-        memory is promoted to transparent huge pages via madvise. Only effective
-        when the system THP mode is madvise, opt.thp is left at its default, and
-        opt.metadata_thp is enabled.</para></listitem>
-      </varlistentry>
-
       <varlistentry id="opt.thp">
         <term>
           <mallctl>opt.thp</mallctl>


### PR DESCRIPTION
Add documentation for the following new mallctl entries:
- opt.debug_double_free_max_scan: double-free detection scan limit
- opt.prof_bt_max: max profiling backtrace depth
- opt.disable_large_size_classes: page-align (instead of size-class align) large allocations
- opt.process_madvise_max_batch: batched purging using process_madvise
- thread.tcache.max: per-thread tcache_max control
- thread.tcache.ncached_max.read_sizeclass: query ncached_max
- thread.tcache.ncached_max.write: set ncached_max per size range
- arena.\<i\>.name: get/set arena names
- arenas.hugepage: queries the hugepage size
- approximate_stats.active: lightweight active bytes estimate

Removed config.prof_frameptr since the feature is still experimental.