### PR TITLE
Remove dead code: extent_commit_wrapper, large_salloc, tcache_gc_dalloc event waits

### DIFF
--- a/include/jemalloc/internal/extent.h
+++ b/include/jemalloc/internal/extent.h
@@ -57,8 +57,6 @@ void extent_dalloc_wrapper_purged(
     tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks, edata_t *edata);
 void extent_destroy_wrapper(
     tsdn_t *tsdn, pac_t *pac, ehooks_t *ehooks, edata_t *edata);
-bool extent_commit_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
-    size_t offset, size_t length);
 bool extent_purge_lazy_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     size_t offset, size_t length);
 bool extent_purge_forced_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,

--- a/include/jemalloc/internal/large_externs.h
+++ b/include/jemalloc/internal/large_externs.h
@@ -17,7 +17,6 @@ void *large_ralloc(tsdn_t *tsdn, arena_t *arena, void *ptr, size_t usize,
 void   large_dalloc_prep_locked(tsdn_t *tsdn, edata_t *edata);
 void   large_dalloc_finish(tsdn_t *tsdn, edata_t *edata);
 void   large_dalloc(tsdn_t *tsdn, edata_t *edata);
-size_t large_salloc(tsdn_t *tsdn, const edata_t *edata);
 void   large_prof_info_get(
       tsd_t *tsd, edata_t *edata, prof_info_t *prof_info, bool reset_recent);
 void large_prof_tctx_reset(edata_t *edata);

--- a/src/extent.c
+++ b/src/extent.c
@@ -1239,13 +1239,6 @@ extent_commit_impl(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
 	return err;
 }
 
-bool
-extent_commit_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
-    size_t offset, size_t length) {
-	return extent_commit_impl(tsdn, ehooks, edata, offset, length,
-	    /* growing_retained */ false);
-}
-
 static bool
 extent_decommit_wrapper(tsdn_t *tsdn, ehooks_t *ehooks, edata_t *edata,
     size_t offset, size_t length) {

--- a/src/large.c
+++ b/src/large.c
@@ -276,11 +276,6 @@ large_dalloc(tsdn_t *tsdn, edata_t *edata) {
 	arena_decay_tick(tsdn, arena);
 }
 
-size_t
-large_salloc(tsdn_t *tsdn, const edata_t *edata) {
-	return edata_usize_get(edata);
-}
-
 void
 large_prof_info_get(
     tsd_t *tsd, edata_t *edata, prof_info_t *prof_info, bool reset_recent) {

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -111,16 +111,6 @@ tcache_gc_postponed_event_wait(tsd_t *tsd) {
 	return TE_MIN_START_WAIT;
 }
 
-uint64_t
-tcache_gc_dalloc_new_event_wait(tsd_t *tsd) {
-	return opt_tcache_gc_incr_bytes;
-}
-
-uint64_t
-tcache_gc_dalloc_postponed_event_wait(tsd_t *tsd) {
-	return TE_MIN_START_WAIT;
-}
-
 static inline void
 tcache_bin_fill_ctl_init(tcache_slow_t *tcache_slow, szind_t szind) {
 	assert(szind < SC_NBINS);


### PR DESCRIPTION
Remove dead code: extent_commit_wrapper, large_salloc, tcache_gc_dalloc event waits
    
    These functions had zero callers anywhere in the codebase:
    - extent_commit_wrapper: wrapper never called, _impl used directly
    - large_salloc: trivial wrapper never called
    - tcache_gc_dalloc_new_event_wait: no header declaration, no callers
    - tcache_gc_dalloc_postponed_event_wait: no header declaration, no callers
    
    Functions `pages_dontdump`  and `pages_dodump` will be used soon. Did not remove `pac_reset` as well as it shows some intent. 