### PR TITLE
Fix `opt.max_background_threads` default in docs

### DIFF
--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -1137,7 +1137,7 @@ mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".decay",
         </term>
         <listitem><para>Maximum number of background threads that will be created
         if <link linkend="background_thread">background_thread</link> is set.
-        Defaults to number of cpus.</para></listitem>
+        Defaults to 4.</para></listitem>
       </varlistentry>
 
       <varlistentry id="opt.dirty_decay_ms">


### PR DESCRIPTION
Previously, the `opt.max_background_threads` docs said this defaulted to the number of CPUs. In the code, the implementation falls back to `DEFAULT_NUM_BACKGROUND_THREAD`, which is 4, so this updates `doc/jemalloc.xml.in` to match.