### PR TITLE
jemalloc: fix always_inline build failure

### DIFF
--- a/test/unit/ph.c
+++ b/test/unit/ph.c
@@ -13,7 +13,7 @@ struct node_s {
 	uint64_t    key;
 };
 
-static int
+static inline int
 node_cmp(const node_t *a, const node_t *b) {
 	int ret;
 
@@ -29,7 +29,7 @@ node_cmp(const node_t *a, const node_t *b) {
 	return ret;
 }
 
-static int
+static inline int
 node_cmp_magic(const node_t *a, const node_t *b) {
 	expect_u32_eq(a->magic, NODE_MAGIC, "Bad magic");
 	expect_u32_eq(b->magic, NODE_MAGIC, "Bad magic");


### PR DESCRIPTION
The ph_gen macro generates a function heap_ph_cmp with static linkage, and ph.h marks internal functions with always_inline.
	JEMALLOC_ALWAYS_INLINE int a_prefix##_ph_cmp(void *a, void *b) {
		return a_cmp((a_type *)a, (a_type *)b);
	}
In ph.c, ph_gen(static, heap, node_t, link, node_cmp_magic). The called functions node_cmp_magic and node_cmp are all static int but not static inline int. When gcc is using -Og, it will fail with error like "inlining failed in call to 'always_inline' 'heap_ph_cmp': function not considered for inlining".