### PR TITLE
jemalloc: fix always_inline build failure with -Og

### DIFF
--- a/include/jemalloc/internal/ph.h
+++ b/include/jemalloc/internal/ph.h
@@ -534,7 +534,7 @@ ph_enumerate_next(
 
 /* The ph_gen() macro generates a type-specific pairing heap implementation. */
 #define ph_gen(a_attr, a_prefix, a_type, a_field, a_cmp)                       \
-	JEMALLOC_ALWAYS_INLINE int a_prefix##_ph_cmp(void *a, void *b) {       \
+	static inline int a_prefix##_ph_cmp(void *a, void *b) {       \
 		return a_cmp((a_type *)a, (a_type *)b);                        \
 	}                                                                      \
                                                                                \


### PR DESCRIPTION
The ph_gen macro generates functions with always_inline attribute, but the called functions are not inline, causing build failure with gcc -Og optimization. Change EMALLOC_ALWAYS_INLINE to static inline can fix this failure.

Before this fix, the build result on Yocto wrlinux: 
do_compile_ptest_base: Failed

After fix, build result on Yocto wrlinux:
recipe jemalloc-5.3.0+git-r0.wr2600: task do_compile_ptest_base: Started 
recipe jemalloc-5.3.0+git-r0.wr2600: task do_compile_ptest_base: Succeeded

[xiaozhan.log](https://github.com/user-attachments/files/26920039/xiaozhan.log)
