### PR TITLE
Update Github Actions generation script and upgrade freeBSD actions.

### DIFF
--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: FreeBSD (${{ matrix.arch }}, debug=${{ matrix.debug }}, prof=${{ matrix.prof }}${{ matrix.uncommon && ', uncommon' || '' }})
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 1
 

--- a/scripts/gen_gh_actions.py
+++ b/scripts/gen_gh_actions.py
@@ -287,7 +287,7 @@ def generate_linux_job(arch):
 
     job += f"""
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Show OS version
       run: |
@@ -302,7 +302,7 @@ def generate_linux_job(arch):
         cat /etc/os-release || true
         echo ""
         echo "=== CPU Info ==="
-        lscpu | grep -E "Architecture|CPU op-mode|Byte Order|CPU\(s\):" || true
+        lscpu | grep -E "Architecture|CPU op-mode|Byte Order|CPU\\(s\\):" || true
 
     - name: Install dependencies (32-bit)
       if: matrix.env.CROSS_COMPILE_32BIT == 'yes'
@@ -387,7 +387,7 @@ def generate_macos_job(arch):
 
     job += f"""
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Show OS version
       run: |
@@ -469,7 +469,7 @@ def generate_windows_job(arch):
 
     job += f"""
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Show OS version
       shell: cmd
@@ -590,7 +590,7 @@ def generate_freebsd_job(arch):
     name: FreeBSD (${{{{ matrix.arch }}}}, debug=${{{{ matrix.debug }}}}, prof=${{{{ matrix.prof }}}}${{{{ matrix.uncommon && ', uncommon' || '' }}}})
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 1
 


### PR DESCRIPTION
A follow-up of #2865, changes include:
1. Update the Github Action generation script (`scripts/gen_gh_actions.py`) to upgrade `actions/checkout` from v4 to v6.
2. Fix a warning in the script. Outputs unchanged after the fix.
3. Update the freeBSD CI setup (by generating it using `./scripts/gen_gh_actions.py freebsd > .github/workflows/freebsd-ci.yml`.