### PR TITLE
Allow spaces in prefix.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -609,38 +609,38 @@ build_lib: build_lib_static
 endif
 
 install_bin:
-	$(INSTALL) -d $(BINDIR)
+	$(INSTALL) -d '$(BINDIR)'
 	@for b in $(BINS); do \
-	echo "$(INSTALL) -m 755 $$b $(BINDIR)"; \
-	$(INSTALL) -m 755 $$b $(BINDIR); \
+	echo "$(INSTALL) -m 755 $$b '$(BINDIR)'"; \
+	$(INSTALL) -m 755 $$b '$(BINDIR)'; \
 done
 
 install_include:
-	$(INSTALL) -d $(INCLUDEDIR)/jemalloc
+	$(INSTALL) -d '$(INCLUDEDIR)/jemalloc'
 	@for h in $(C_HDRS); do \
-	echo "$(INSTALL) -m 644 $$h $(INCLUDEDIR)/jemalloc"; \
-	$(INSTALL) -m 644 $$h $(INCLUDEDIR)/jemalloc; \
+	echo "$(INSTALL) -m 644 $$h '$(INCLUDEDIR)/jemalloc'"; \
+	$(INSTALL) -m 644 $$h '$(INCLUDEDIR)/jemalloc'; \
 done
 
 install_lib_shared: $(DSOS)
-	$(INSTALL) -d $(LIBDIR)
-	$(INSTALL) -m 755 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) $(LIBDIR)
+	$(INSTALL) -d '$(LIBDIR)'
+	$(INSTALL) -m 755 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) '$(LIBDIR)'
 ifneq ($(SOREV),$(SO))
-	ln -sf $(LIBJEMALLOC).$(SOREV) $(LIBDIR)/$(LIBJEMALLOC).$(SO)
+	ln -sf $(LIBJEMALLOC).$(SOREV) '$(LIBDIR)/$(LIBJEMALLOC).$(SO)'
 endif
 
 install_lib_static: $(STATIC_LIBS)
-	$(INSTALL) -d $(LIBDIR)
+	$(INSTALL) -d '$(LIBDIR)'
 	@for l in $(STATIC_LIBS); do \
-	echo "$(INSTALL) -m 644 $$l $(LIBDIR)"; \
-	$(INSTALL) -m 644 $$l $(LIBDIR); \
+	echo "$(INSTALL) -m 644 $$l '$(LIBDIR)'"; \
+	$(INSTALL) -m 644 $$l '$(LIBDIR)'; \
 done
 
 install_lib_pc: $(PC)
-	$(INSTALL) -d $(LIBDIR)/pkgconfig
+	$(INSTALL) -d '$(LIBDIR)/pkgconfig'
 	@for l in $(PC); do \
-	echo "$(INSTALL) -m 644 $$l $(LIBDIR)/pkgconfig"; \
-	$(INSTALL) -m 644 $$l $(LIBDIR)/pkgconfig; \
+	echo "$(INSTALL) -m 644 $$l '$(LIBDIR)/pkgconfig'"; \
+	$(INSTALL) -m 644 $$l '$(LIBDIR)/pkgconfig'; \
 done
 
 ifeq ($(enable_shared), 1)
@@ -652,17 +652,17 @@ endif
 install_lib: install_lib_pc
 
 install_doc_html: build_doc_html
-	$(INSTALL) -d $(DATADIR)/doc/jemalloc$(install_suffix)
+	$(INSTALL) -d '$(DATADIR)/doc/jemalloc$(install_suffix)'
 	@for d in $(DOCS_HTML); do \
-	echo "$(INSTALL) -m 644 $$d $(DATADIR)/doc/jemalloc$(install_suffix)"; \
-	$(INSTALL) -m 644 $$d $(DATADIR)/doc/jemalloc$(install_suffix); \
+	echo "$(INSTALL) -m 644 $$d '$(DATADIR)/doc/jemalloc$(install_suffix)'"; \
+	$(INSTALL) -m 644 $$d '$(DATADIR)/doc/jemalloc$(install_suffix)'; \
 done
 
 install_doc_man: build_doc_man
-	$(INSTALL) -d $(MANDIR)/man3
+	$(INSTALL) -d '$(MANDIR)/man3'
 	@for d in $(DOCS_MAN3); do \
-	echo "$(INSTALL) -m 644 $$d $(MANDIR)/man3"; \
-	$(INSTALL) -m 644 $$d $(MANDIR)/man3; \
+	echo "$(INSTALL) -m 644 $$d '$(MANDIR)/man3'"; \
+	$(INSTALL) -m 644 $$d '$(MANDIR)/man3'; \
 done
 
 install_doc: install_doc_html install_doc_man
@@ -674,23 +674,23 @@ install: install_doc
 endif
 
 uninstall_bin:
-	$(RM) -v $(foreach b,$(notdir $(BINS)),$(BINDIR)/$(b))
+	$(RM) -v $(foreach b,$(notdir $(BINS)),'$(BINDIR)/$(b)')
 
 uninstall_include:
-	$(RM) -v $(foreach h,$(notdir $(C_HDRS)),$(INCLUDEDIR)/jemalloc/$(h))
-	rmdir -v $(INCLUDEDIR)/jemalloc
+	$(RM) -v $(foreach h,$(notdir $(C_HDRS)),'$(INCLUDEDIR)/jemalloc/$(h)')
+	rmdir -v '$(INCLUDEDIR)/jemalloc'
 
 uninstall_lib_shared:
-	$(RM) -v $(LIBDIR)/$(LIBJEMALLOC).$(SOREV)
+	$(RM) -v '$(LIBDIR)/$(LIBJEMALLOC).$(SOREV)'
 ifneq ($(SOREV),$(SO))
-	$(RM) -v $(LIBDIR)/$(LIBJEMALLOC).$(SO)
+	$(RM) -v '$(LIBDIR)/$(LIBJEMALLOC).$(SO)'
 endif
 
 uninstall_lib_static:
-	$(RM) -v $(foreach l,$(notdir $(STATIC_LIBS)),$(LIBDIR)/$(l))
+	$(RM) -v $(foreach l,$(notdir $(STATIC_LIBS)),'$(LIBDIR)/$(l)')
 
 uninstall_lib_pc:
-	$(RM) -v $(foreach p,$(notdir $(PC)),$(LIBDIR)/pkgconfig/$(p))
+	$(RM) -v $(foreach p,$(notdir $(PC)),'$(LIBDIR)/pkgconfig/$(p)')
 
 ifeq ($(enable_shared), 1)
 uninstall_lib: uninstall_lib_shared
@@ -701,11 +701,11 @@ endif
 uninstall_lib: uninstall_lib_pc
 
 uninstall_doc_html:
-	$(RM) -v $(foreach d,$(notdir $(DOCS_HTML)),$(DATADIR)/doc/jemalloc$(install_suffix)/$(d))
-	rmdir -v $(DATADIR)/doc/jemalloc$(install_suffix)
+	$(RM) -v $(foreach d,$(notdir $(DOCS_HTML)),'$(DATADIR)/doc/jemalloc$(install_suffix)/$(d)')
+	rmdir -v '$(DATADIR)/doc/jemalloc$(install_suffix)'
 
 uninstall_doc_man:
-	$(RM) -v $(foreach d,$(notdir $(DOCS_MAN3)),$(MANDIR)/man3/$(d))
+	$(RM) -v $(foreach d,$(notdir $(DOCS_MAN3)),'$(MANDIR)/man3/$(d)')
 
 uninstall_doc: uninstall_doc_html uninstall_doc_man
 

--- a/configure.ac
+++ b/configure.ac
@@ -158,29 +158,27 @@ AC_SUBST([abs_objroot])
 
 dnl Munge install path variables.
 case "$prefix" in
-   *\ * ) AC_MSG_ERROR([Prefix should not contain spaces]) ;;
    "NONE" ) prefix="/usr/local" ;;
 esac
 case "$exec_prefix" in
-   *\ * ) AC_MSG_ERROR([Exec prefix should not contain spaces]) ;;
    "NONE" ) exec_prefix=$prefix ;;
 esac
 PREFIX=$prefix
 AC_SUBST([PREFIX])
-BINDIR=`eval echo $bindir`
-BINDIR=`eval echo $BINDIR`
+BINDIR=`eval echo "\"$bindir\""`
+BINDIR=`eval echo "\"$BINDIR\""`
 AC_SUBST([BINDIR])
-INCLUDEDIR=`eval echo $includedir`
-INCLUDEDIR=`eval echo $INCLUDEDIR`
+INCLUDEDIR=`eval echo "\"$includedir\""`
+INCLUDEDIR=`eval echo "\"$INCLUDEDIR\""`
 AC_SUBST([INCLUDEDIR])
-LIBDIR=`eval echo $libdir`
-LIBDIR=`eval echo $LIBDIR`
+LIBDIR=`eval echo "\"$libdir\""`
+LIBDIR=`eval echo "\"$LIBDIR\""`
 AC_SUBST([LIBDIR])
-DATADIR=`eval echo $datadir`
-DATADIR=`eval echo $DATADIR`
+DATADIR=`eval echo "\"$datadir\""`
+DATADIR=`eval echo "\"$DATADIR\""`
 AC_SUBST([DATADIR])
-MANDIR=`eval echo $mandir`
-MANDIR=`eval echo $MANDIR`
+MANDIR=`eval echo "\"$mandir\""`
+MANDIR=`eval echo "\"$MANDIR\""`
 AC_SUBST([MANDIR])
 
 dnl Support for building documentation.


### PR DESCRIPTION
Allow spaces in prefix, i.e., the path to the folder where jemalloc will be installed to.

Resolves #2553. Thanks to @everschen for the contribution in #2567, which this PR is based on with some changes added in `configure.ac`

Local tests confirm that it can handle multiple spaces in the prefix as expected:
```
$ ./configure --prefix="/tmp/test test   test"
...
CONFIG             : '--prefix=/tmp/test test test'
...
PREFIX             : /tmp/test test   test
BINDIR             : /tmp/test test   test/bin
DATADIR            : /tmp/test test   test/share
INCLUDEDIR         : /tmp/test test   test/include
LIBDIR             : /tmp/test test   test/lib
MANDIR             : /tmp/test test   test/share/man
```