### PR TITLE
Two initialization fixes

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -1954,9 +1954,6 @@ arena_init_huge(tsdn_t *tsdn, arena_t *a0) {
 		huge_arena_ind = narenas_total_get();
 		assert(huge_arena_ind != 0);
 		oversize_threshold = opt_oversize_threshold;
-		/* a0 init happened before malloc_conf_init. */
-		atomic_store_zu(&a0->pa_shard.pac.oversize_threshold,
-		    oversize_threshold, ATOMIC_RELAXED);
 		/* Initialize huge_arena_pac_thp fields. */
 		base_t *b0 = a0->base;
 		/* Make sure that b0 thp auto-switch won't happen concurrently here. */
@@ -1973,6 +1970,10 @@ arena_init_huge(tsdn_t *tsdn, arena_t *a0) {
 		malloc_mutex_unlock(tsdn, &b0->mtx);
 		huge_enabled = true;
 	}
+
+	/* a0 init happened before malloc_conf_init. */
+	atomic_store_zu(&a0->pa_shard.pac.oversize_threshold,
+	    oversize_threshold, ATOMIC_RELAXED);
 
 	return huge_enabled;
 }

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1199,7 +1199,7 @@ malloc_init_hard(void) {
 	 * than LARGE_MINCLASS.  It could only happen if some constants
 	 * are configured miserably wrong.
 	 */
-	assert(SC_LG_TINY_MAXCLASS <= (size_t)1ULL << (LG_PAGE + SC_LG_NGROUP));
+	assert(SC_NTINY == 0 || SC_LG_TINY_MAXCLASS <= SC_LG_LARGE_MINCLASS);
 
 #if defined(_WIN32) && _WIN32_WINNT < 0x0600
 	_init_init_lock();


### PR DESCRIPTION
1. fixing the assertion on the fact that tiny size maxclass is smaller than large minclass is fixed and also considers cases where tiny size class does not exist (`SC_NTINY == 0`).
2. Make sure a0's per-arena oversize_threshold is updated properly when huge arena is disabled.