### PR TITLE
Preserve errno across free, free_sized, and free_aligned_sized

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2042,6 +2042,7 @@ void
 free_default(void *ptr) {
 	UTRACE(ptr, 0, 0);
 	if (likely(ptr != NULL)) {
+		int saved_errno = get_errno();
 		/*
 		 * We avoid setting up tsd fully (e.g. tcache, arena binding)
 		 * based on only free() calls -- other activities trigger the
@@ -2068,6 +2069,7 @@ free_default(void *ptr) {
 		}
 
 		check_entry_exit_locking(tsd_tsdn(tsd));
+		set_errno(saved_errno);
 	}
 }
 
@@ -2903,6 +2905,7 @@ inallocx(tsdn_t *tsdn, size_t size, int flags) {
 
 JEMALLOC_NOINLINE void
 sdallocx_default(void *ptr, size_t size, int flags) {
+	int saved_errno = get_errno();
 	assert(ptr != NULL);
 	assert(malloc_initialized() || IS_INITIALIZER);
 
@@ -2925,6 +2928,7 @@ sdallocx_default(void *ptr, size_t size, int flags) {
 		isfree(tsd, ptr, usize, tcache, true);
 	}
 	check_entry_exit_locking(tsd_tsdn(tsd));
+	set_errno(saved_errno);
 }
 
 JEMALLOC_EXPORT void JEMALLOC_NOTHROW

--- a/src/pages.c
+++ b/src/pages.c
@@ -662,11 +662,6 @@ pages_purge_process_madvise_impl(
 		return true;
 	}
 
-	/*
-	 * TODO: remove this save/restore of errno after supporting errno
-	 * preservation for free() call properly.
-	 */
-	int    saved_errno = get_errno();
 	size_t purged_bytes = (size_t)syscall(JE_SYS_PROCESS_MADVISE_NR,
 	    PIDFD_SELF, (struct iovec *)vec, vec_len, MADV_DONTNEED, 0);
 	if (purged_bytes == (size_t)-1) {
@@ -676,7 +671,6 @@ pages_purge_process_madvise_impl(
 			atomic_store_b(
 			    &process_madvise_gate, false, ATOMIC_RELAXED);
 		}
-		set_errno(saved_errno);
 	}
 
 	return purged_bytes != total_bytes;


### PR DESCRIPTION
Preserve errno across free, free_sized, and free_aligned_sized
    
The slow path of free can invoke syscalls that may set errno on failure. Save and restore errno around the body of the slow-path entry points so the user-visible contract is preserved without adding any instructions to the inline fast path, which is syscall-free.
    
The inner save/restore around process_madvise in pages.c is no longer needed: the outer wrap covers user-thread purge, and background-thread purge does not require errno preservation.


Fastpath free looks the same before and after
```
/tmp/hotpath_afterhjxzA4gZBa:   file format elf64-x86-64

Disassembly of section .text:

<_Z6myfreeP5Point>:
                push    rbp
                mov     rbp, rsp
                test    rdi, rdi
                je       <L1>
                mov     rax, rdi
                shl     rax, 0x34
                je       <L0>
                mov     rax, qword ptr fs:[-0x410]
                add     rax, 0x20
                cmp     rax, qword ptr fs:[-0x408]
                jae      <L0>
                mov     rcx, qword ptr fs:[-0x3c8]
                cmp     word ptr fs:[-0x3b6], cx
                je       <L0>
                lea     rdx, [rcx - 0x8]
                mov     qword ptr fs:[-0x3c8], rdx
                mov     qword ptr [rcx - 0x8], rdi
                mov     qword ptr fs:[-0x410], rax
                pop     rbp
                ret
<L0>:
                mov     esi, 0x18
                xor     edx, edx
                call     <jemalloc_je_sdallocx_default>
<L1>:
                pop     rbp
                ret
                mov     rdi, rax
                call     <__clang_call_terminate>
```