### PR TITLE
Restore errno save/restore in pages_purge_process_madvise_impl

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -662,6 +662,7 @@ pages_purge_process_madvise_impl(
 		return true;
 	}
 
+	int    saved_errno = get_errno();
 	size_t purged_bytes = (size_t)syscall(JE_SYS_PROCESS_MADVISE_NR,
 	    PIDFD_SELF, (struct iovec *)vec, vec_len, MADV_DONTNEED, 0);
 	if (purged_bytes == (size_t)-1) {
@@ -671,6 +672,7 @@ pages_purge_process_madvise_impl(
 			atomic_store_b(
 			    &process_madvise_gate, false, ATOMIC_RELAXED);
 		}
+		set_errno(saved_errno);
 	}
 
 	return purged_bytes != total_bytes;


### PR DESCRIPTION
TODO comment focused on free only, but this function is reachable via other public calls and it is safer to restore errno preservation here (without restoring incorrect comment).  

Covering errno preservation for malloc/calloc/realloc success cases was out of scope of pr #2906 