### PR TITLE
[EASY] Hide methods from jemalloc_init.h that are not used in other units

### DIFF
--- a/include/jemalloc/internal/jemalloc_init.h
+++ b/include/jemalloc/internal/jemalloc_init.h
@@ -12,8 +12,6 @@ typedef enum malloc_init_e malloc_init_t;
 extern malloc_init_t malloc_init_state;
 
 bool malloc_is_initializer(void);
-bool malloc_initializer_is_set(void);
-void malloc_initializer_set(void);
 
 bool malloc_init_hard_a0(void);
 bool malloc_init_hard(void);

--- a/src/jemalloc_init.c
+++ b/src/jemalloc_init.c
@@ -39,12 +39,14 @@ malloc_is_initializer(void) {
 #endif
 }
 
-bool
+#ifdef JEMALLOC_THREADED_INIT
+static bool
 malloc_initializer_is_set(void) {
 	return malloc_initializer != NO_INITIALIZER;
 }
+#endif
 
-void
+static void
 malloc_initializer_set(void) {
 	malloc_initializer = INITIALIZER;
 }

--- a/test/unit/jemalloc_init.c
+++ b/test/unit/jemalloc_init.c
@@ -11,19 +11,6 @@ TEST_BEGIN(test_malloc_init_hard_idempotent) {
 }
 TEST_END
 
-TEST_BEGIN(test_malloc_initializer_set_idempotent_on_main) {
-	test_skip_if(!malloc_is_initializer());
-
-	malloc_initializer_set();
-
-	expect_true(malloc_is_initializer(),
-	    "malloc_is_initializer should still be true after re-setting "
-	    "from the same thread");
-	expect_true(malloc_initializer_is_set(),
-	    "malloc_initializer_is_set should still be true after re-setting");
-}
-TEST_END
-
 #ifdef JEMALLOC_THREADED_INIT
 static atomic_b_t initializer_worker_done;
 static atomic_b_t initializer_worker_result;
@@ -69,6 +56,5 @@ TEST_END
 int
 main(void) {
 	return test(test_malloc_init_hard_idempotent,
-	    test_malloc_initializer_set_idempotent_on_main,
 	    test_malloc_is_initializer_false_in_worker);
 }


### PR DESCRIPTION
Two methods in this header could be private to translation unit.  They are anyway executed and tested in every test because we must init malloc, so keeping them public is more noise than actual value.