### PR TITLE
arena_s: Replace bin_t all_bins[0] by [] for C99 or newer

### DIFF
--- a/include/jemalloc/internal/arena_structs.h
+++ b/include/jemalloc/internal/arena_structs.h
@@ -104,7 +104,11 @@ struct arena_s {
 	    "Do not use this field directly. "
 	    "Use `arena_get_bin` instead.")
 	JEMALLOC_ALIGNED(CACHELINE)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+	bin_t all_bins[];
+#else
 	bin_t all_bins[0];
+#endif
 };
 
 #endif /* JEMALLOC_INTERNAL_ARENA_STRUCTS_H */


### PR DESCRIPTION
Zero-sized arrays are not allowed by ISO C.
Type-checking fails, because all_bins is asigned malloced storage of length > 0.
Found by GCC and Clang (-Wpedantic).