### PR TITLE
Set SEC_MAX_NALLOCS to 8.

### DIFF
--- a/include/jemalloc/internal/sec.h
+++ b/include/jemalloc/internal/sec.h
@@ -101,7 +101,7 @@ sec_size_supported(sec_t *sec, size_t size) {
 #define SEC_MIN_NALLOCS 2
 
 /* Max number of extents we will allocate out of a single huge page. */
-#define SEC_MAX_NALLOCS 4
+#define SEC_MAX_NALLOCS 8
 
 /* Attempt to fill the SEC up to max_bytes / SEC_MAX_BYTES_DIV */
 #define SEC_MAX_BYTES_DIV 4


### PR DESCRIPTION
Increase SEC_MAX_NALLOCS from 4 to 8. From our testing it looks as if 8 (compared to 4) increases hugepage-backed memory further and decreases hpa locking ops/sec further.