### PR TITLE
Fix rdtscp detection with --with-lg-vaddr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -600,9 +600,10 @@ typedef unsigned __int32 uint32_t;
       else
         AC_MSG_ERROR([cannot determine number of significant virtual address bits])
       fi
-      AC_CACHE_CHECK([rdtscp support],
-		     [je_cv_rdtscp],
-		     AC_RUN_IFELSE([AC_LANG_PROGRAM(
+    fi
+    AC_CACHE_CHECK([rdtscp support],
+		   [je_cv_rdtscp],
+		   AC_RUN_IFELSE([AC_LANG_PROGRAM(
 [[
 #include <stdint.h>
 ]],
@@ -611,12 +612,11 @@ typedef unsigned __int32 uint32_t;
       asm volatile("rdtscp" : "=d"(dx) ::);
       return 0;
 ]])],
-      [je_cv_rdtscp=yes],
-      [je_cv_rdtscp=no],
-      [je_cv_rdtscp=no]))
-      if test "x${je_cv_rdtscp}" = "xyes"; then
-        AC_DEFINE([JEMALLOC_HAVE_RDTSCP], [ ], [ ])
-      fi
+    [je_cv_rdtscp=yes],
+    [je_cv_rdtscp=no],
+    [je_cv_rdtscp=no]))
+    if test "x${je_cv_rdtscp}" = "xyes"; then
+      AC_DEFINE([JEMALLOC_HAVE_RDTSCP], [ ], [ ])
     fi
     ;;
   *)


### PR DESCRIPTION
The rdtscp configure probe was nested inside the x86_64 LG_VADDR auto-detection block. This meant that passing `--with-lg-vaddr` skipped the probe and left `JEMALLOC_HAVE_RDTSCP` undefined even when rdtscp was available.

Keep the probe in the x86_64 branch, but run it independently from LG_VADDR auto-detection.

Testing:
- `autoconf -o /tmp/jemalloc-configure-rdtscp-fix configure.ac`
- Configured with and without `--with-lg-vaddr=48` and verified both run the rdtscp check
- `git diff --check`
- `make -C /tmp/jemalloc-conf-lg48-fix -j2`