### PR TITLE
Keep pac last in pa_shard_s to fix SEC-in-PAC layout regression

### DIFF
--- a/include/jemalloc/internal/pa.h
+++ b/include/jemalloc/internal/pa.h
@@ -91,9 +91,6 @@ struct pa_shard_s {
 	 */
 	bool ever_used_hpa;
 
-	/* Allocates from a PAC. */
-	pac_t pac;
-
 	hpa_shard_t hpa;
 
 	/* The source of edata_t objects. */
@@ -109,6 +106,9 @@ struct pa_shard_s {
 
 	/* The base from which we get the ehooks and allocate metadat. */
 	base_t *base;
+
+	/* Allocates from a PAC. */
+	pac_t pac;
 };
 
 static inline bool


### PR DESCRIPTION
[9c1a484e](https://github.com/jemalloc/jemalloc/pull/2907) embedded `sec_t` in `pac_t` (+~48B). Since pac sits before the hot hpa/edata_cache fields in pa_shard_s, the larger pac_t shifts them and regresses the free/extent paths ~2% on the fill-flush microbenchmark -- even though SEC is disabled by default and no SEC code runs; it is purely a struct-layout effect.

Move pac to the last field so its growth shifts only the trailing all_bins[] flex array. Pure reorder, no functional change.

Tested on two architectures (one that has regression confirmed on two different hosts).  The one without regression is flat before and after the change

mimalloc-bench fill-flush (500 threads, 256 B, MALLOC_CONF=tcache:true,prof:true), CPU freq pinned, interleaved, medians:
  
` AMD EPYC 9D64  (x86-64, 88C/176T, 2 hosts):  bad +~2% vs good; fix == good (recovered)`
` ARM Neoverse-V2 (aarch64, 72C/72T):          good == bad == fix (no regression; fix neutral)`
