### PR TITLE
Fix `--enable-prof-frameptr` when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1511,8 +1511,8 @@ if test "x$backtrace_method" = "x" -a "x$enable_prof_libunwind" = "x1" ; then
   fi
 fi
 
-if test `uname -s` = "Linux"
-then
+case "${host_os}" in
+  linux*)
   AC_ARG_ENABLE([prof-frameptr],
     [AS_HELP_STRING([--enable-prof-frameptr], [Use optimized frame pointer unwinder for backtracing (Linux only)])],
   [if test "x$enable_prof_frameptr" = "xno" ; then
@@ -1534,9 +1534,11 @@ then
   else
     enable_prof_frameptr="0"
   fi
-else
+  ;;
+  *)
   enable_prof_frameptr="0"
-fi
+  ;;
+esac
 
 AC_ARG_ENABLE([prof-libgcc],
   [AS_HELP_STRING([--disable-prof-libgcc],


### PR DESCRIPTION
Gate `--enable-prof-frameptr` behind `${host_os}` instead of `uname -s`. The latter reflects only the build machine, so cross-compiling for Linux from a non-Linux host (for example Darwin -> x86_64-unknown-linux-gnu) didn't work.