### PR TITLE
Fix malloc_getcpu on macOS to read the current CPU number correctly

### DIFF
--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -19,9 +19,17 @@ malloc_getcpu(void) {
 #elif defined(JEMALLOC_HAVE_SCHED_GETCPU)
 	return (malloc_cpuid_t)sched_getcpu();
 #elif defined(__APPLE__)
-	/* No sched_getcpu() on macOS; read the CPU number like _os_cpu_number(), see
+	/*
+	 * No sched_getcpu() on macOS; read the CPU number like _os_cpu_number()
+	 * does, from the low 12 bits of tpidr_el0 (arm64) or the IDT base (x86).
+	 * The 0xfff mask is xnu's __TPIDR_CPU_NUM_MASK, kept in sync with
+	 * _os_cpu_number in libsyscall/os/tsd.h (the kernel counterpart is
+	 * MACHDEP_TPIDR_CPUNUM_MASK in osfmk/arm64/machine_machdep.h):
 	 * https://github.com/apple-oss-distributions/xnu/blob/main/libsyscall/os/tsd.h
-	 * (it is no longer in tpidrro_el0's low bits on Apple Silicon). */
+	 * This requires macOS 12+: on macOS 11 and earlier arm64 kept the CPU
+	 * number in tpidrro_el0's low 3 bits instead, so it would be misread here.
+	 * Those releases are retired by Apple, so only the current layout is handled.
+	 */
 #  if defined(__aarch64__)
 	uint64_t cpu;
 	__asm__ __volatile__("mrs %0, tpidr_el0" : "=r"(cpu));

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -18,15 +18,26 @@ malloc_getcpu(void) {
 	return GetCurrentProcessorNumber();
 #elif defined(JEMALLOC_HAVE_SCHED_GETCPU)
 	return (malloc_cpuid_t)sched_getcpu();
+#elif defined(__APPLE__)
+	/* No sched_getcpu() on macOS; read the CPU number like _os_cpu_number(), see
+	 * https://github.com/apple-oss-distributions/xnu/blob/main/libsyscall/os/tsd.h
+	 * (it is no longer in tpidrro_el0's low bits on Apple Silicon). */
+#  if defined(__aarch64__)
+	uint64_t cpu;
+	__asm__ __volatile__("mrs %0, tpidr_el0" : "=r"(cpu));
+	return (malloc_cpuid_t)(cpu & 0xfff);
+#  elif defined(__x86_64__) || defined(__i386__)
+	struct { uintptr_t p1, p2; } idtr;
+	__asm__ __volatile__("sidt %0" : "=m"(idtr));
+	return (malloc_cpuid_t)(idtr.p1 & 0xfff);
+#  else
+	not_reached();
+	return -1;
+#  endif
 #elif defined(JEMALLOC_HAVE_RDTSCP)
 	unsigned int ecx;
 	asm volatile("rdtscp" : "=c"(ecx)::"eax", "edx");
 	return (malloc_cpuid_t)(ecx & 0xfff);
-#elif defined(__aarch64__) && defined(__APPLE__)
-	/* Other oses most likely use tpidr_el0 instead */
-	uintptr_t c;
-	asm volatile("mrs %x0, tpidrro_el0" : "=r"(c)::"memory");
-	return (malloc_cpuid_t)(c & (1 << 3) - 1);
 #else
 	not_reached();
 	return -1;


### PR DESCRIPTION
On macOS `malloc_getcpu` reads the CPU number from the low 3 bits of
`tpidrro_el0`. That layout no longer holds on Apple Silicon: those bits read
back as 0, so `malloc_getcpu` returns 0 for every thread. With
`percpu_arena:percpu` this either funnels all allocations into arena 0, or the
arena is disabled at init via the `malloc_getcpu() < 0` guard.

### Fix

Read the CPU number the same way as libplatform's `_os_cpu_number`:
- arm64: low 12 bits of `tpidr_el0`
- x86: low 12 bits of the IDT base, read with `sidt`

The `__APPLE__` branch is also moved ahead of the `rdtscp` branch, so Apple x86
uses `sidt` (what `_os_cpu_number` relies on) rather than `rdtscp`.

Reference: https://github.com/apple-oss-distributions/xnu/blob/main/libsyscall/os/tsd.h

### Verification

On a 12-CPU Apple M2 Pro, with `MALLOC_CONF="percpu_arena:percpu"`:

| | before | after |
|---|---|---|
| `opt.percpu_arena` | `disabled` | `percpu` |
| distinct `thread.arena` | `{0}` | `{0,1,…,11}` |

Before the fix every thread mapped to arena 0; after it, allocations spread
across all 12 per-CPU arenas.