### PR TITLE
Allow resuming per-CPU arena selection via thread.arena

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -276,6 +276,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/pack.c \
 	$(srcroot)test/unit/pages.c \
 	$(srcroot)test/unit/peak.c \
+	$(srcroot)test/unit/percpu_arena_resume.c \
 	$(srcroot)test/unit/ph.c \
 	$(srcroot)test/unit/prng.c \
 	$(srcroot)test/unit/prof_accum.c \

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2374,10 +2374,18 @@ thread_arena_ctl(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 	if (have_percpu_arena && PERCPU_ARENA_ENABLED(opt_percpu_arena)) {
 		if (newind < percpu_arena_ind_limit(opt_percpu_arena)) {
 			/*
-			 * If perCPU arena is enabled, thread_arena control is
-			 * not allowed for the auto arena range.
+			 * Setting thread.arena to an arena in the auto range
+			 * means "resume automatic per-CPU selection" rather than
+			 * pinning to a specific per-CPU arena. This lets a caller
+			 * that temporarily switched to a manually managed arena
+			 * (e.g. a scoped guard) hand the thread back to per-CPU
+			 * management. It is otherwise impossible: a thread bound
+			 * to a manual arena is never reclaimed by percpu (see
+			 * arena_choose_impl), so without this it would stay
+			 * pinned forever.
 			 */
-			return EPERM;
+			percpu_arena_update(tsd, percpu_arena_choose());
+			return 0;
 		}
 	}
 

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -764,12 +764,17 @@ TEST_BEGIN(test_thread_arena) {
 		    0, "Unexpected mallctl() failure");
 		new_arena_ind = percpu_arena_ind_limit(opt_percpu_arena) - 1;
 		if (old_arena_ind != new_arena_ind) {
+			/*
+			 * Setting thread.arena to an index within the per-CPU
+			 * range resumes automatic per-CPU selection rather than
+			 * failing (see test/unit/percpu_arena_resume.c).
+			 */
 			expect_d_eq(
 			    mallctl("thread.arena", (void *)&old_arena_ind, &sz,
 			        (void *)&new_arena_ind, sizeof(unsigned)),
-			    EPERM,
-			    "thread.arena ctl "
-			    "should not be allowed with percpu arena");
+			    0,
+			    "thread.arena within the per-CPU range should "
+			    "resume per-CPU selection");
 		}
 	}
 }

--- a/test/unit/percpu_arena_resume.c
+++ b/test/unit/percpu_arena_resume.c
@@ -1,0 +1,74 @@
+#include "test/jemalloc_test.h"
+
+/*
+ * When percpu_arena is enabled a thread is bound to a manually created arena
+ * (an index at or above the per-CPU auto range) to route a bounded region of
+ * work to a dedicated arena, then handed back to automatic per-CPU selection.
+ *
+ * Setting thread.arena to an index within the per-CPU auto range is the signal
+ * to resume per-CPU management. Without it a thread bound to a manual arena is
+ * never reclaimed by percpu (see arena_choose_impl), so it would stay pinned to
+ * the manual arena forever and its later allocations would land there instead
+ * of following the CPU.
+ */
+TEST_BEGIN(test_thread_arena_resume_percpu) {
+	test_skip_if(!have_percpu_arena
+	    || !PERCPU_ARENA_ENABLED(opt_percpu_arena));
+
+	unsigned limit = percpu_arena_ind_limit(opt_percpu_arena);
+
+	/* Force the thread to be bound to its current CPU's arena. */
+	void *p = mallocx(1, 0);
+	expect_ptr_not_null(p, "Unexpected mallocx() failure");
+
+	unsigned cur;
+	size_t sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_lt(cur, limit,
+	    "Thread should start bound to a per-CPU (auto) arena");
+
+	/* Create a dedicated arena, which is always outside the auto range. */
+	unsigned manual;
+	sz = sizeof(manual);
+	expect_d_eq(mallctl("arenas.create", (void *)&manual, &sz, NULL, 0), 0,
+	    "Unexpected arenas.create() failure");
+	expect_u_ge(manual, limit,
+	    "A manually created arena must be outside the per-CPU range");
+
+	/* Binding to a manual arena is allowed and takes effect. */
+	unsigned old;
+	sz = sizeof(old);
+	expect_d_eq(mallctl("thread.arena", (void *)&old, &sz, (void *)&manual,
+	    sizeof(manual)), 0,
+	    "Binding to a manual arena should be allowed under percpu");
+	sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_eq(cur, manual, "Thread should be bound to the manual arena");
+
+	/*
+	 * Setting thread.arena to an index in the per-CPU range resumes
+	 * automatic per-CPU selection instead of returning EPERM.
+	 */
+	unsigned resume = 0;
+	expect_d_eq(mallctl("thread.arena", NULL, NULL, (void *)&resume,
+	    sizeof(resume)), 0,
+	    "Setting thread.arena within the per-CPU range should resume "
+	    "per-CPU selection, not fail");
+
+	sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_lt(cur, limit,
+	    "Thread should be back under per-CPU management after resuming");
+
+	dallocx(p, 0);
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_thread_arena_resume_percpu);
+}

--- a/test/unit/percpu_arena_resume.c
+++ b/test/unit/percpu_arena_resume.c
@@ -1,69 +1,76 @@
 #include "test/jemalloc_test.h"
 
 /*
- * When percpu_arena is enabled a thread is bound to a manually created arena
- * (an index at or above the per-CPU auto range) to route a bounded region of
- * work to a dedicated arena, then handed back to automatic per-CPU selection.
- *
- * Setting thread.arena to an index within the per-CPU auto range is the signal
- * to resume per-CPU management. Without it a thread bound to a manual arena is
- * never reclaimed by percpu (see arena_choose_impl), so it would stay pinned to
- * the manual arena forever and its later allocations would land there instead
- * of following the CPU.
+ * Under percpu_arena, binding a thread to a manual arena (an index at or above
+ * the per-CPU auto range) is one-way: percpu never reclaims it (see
+ * arena_choose_impl). Setting thread.arena back to an index in the auto range
+ * resumes per-CPU selection instead of failing with EPERM.
  */
 TEST_BEGIN(test_thread_arena_resume_percpu) {
 	test_skip_if(!have_percpu_arena
 	    || !PERCPU_ARENA_ENABLED(opt_percpu_arena));
 
 	unsigned limit = percpu_arena_ind_limit(opt_percpu_arena);
+	/* Bypass the tcache so every allocation and free hits the arena. */
+	const int flags = MALLOCX_TCACHE_NONE;
 
-	/* Force the thread to be bound to its current CPU's arena. */
-	void *p = mallocx(1, 0);
-	expect_ptr_not_null(p, "Unexpected mallocx() failure");
+	void *warm = mallocx(1, 0);
+	expect_ptr_not_null(warm, "Unexpected mallocx() failure");
+	dallocx(warm, 0);
 
 	unsigned cur;
 	size_t sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
-	expect_u_lt(cur, limit,
-	    "Thread should start bound to a per-CPU (auto) arena");
+	expect_u_lt(cur, limit, "Thread should start on a per-CPU arena");
 
-	/* Create a dedicated arena, which is always outside the auto range. */
 	unsigned manual;
 	sz = sizeof(manual);
 	expect_d_eq(mallctl("arenas.create", (void *)&manual, &sz, NULL, 0), 0,
 	    "Unexpected arenas.create() failure");
-	expect_u_ge(manual, limit,
-	    "A manually created arena must be outside the per-CPU range");
+	expect_u_ge(manual, limit, "A manual arena is outside the per-CPU range");
 
-	/* Binding to a manual arena is allowed and takes effect. */
 	unsigned old;
 	sz = sizeof(old);
 	expect_d_eq(mallctl("thread.arena", (void *)&old, &sz, (void *)&manual,
-	    sizeof(manual)), 0,
-	    "Binding to a manual arena should be allowed under percpu");
+	    sizeof(manual)), 0, "Binding to a manual arena should be allowed");
 	sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 	expect_u_eq(cur, manual, "Thread should be bound to the manual arena");
 
-	/*
-	 * Setting thread.arena to an index in the per-CPU range resumes
-	 * automatic per-CPU selection instead of returning EPERM.
-	 */
+	void *p_manual = mallocx(1024, flags);
+	expect_ptr_not_null(p_manual, "Unexpected mallocx() failure");
+	unsigned found;
+	sz = sizeof(found);
+	expect_d_eq(mallctl("arenas.lookup", (void *)&found, &sz,
+	    (void *)&p_manual, sizeof(p_manual)), 0,
+	    "Unexpected arenas.lookup() failure");
+	expect_u_eq(found, manual, "Allocation should come from the manual arena");
+
+	void *scratch = mallocx(1024, flags);
+	expect_ptr_not_null(scratch, "Unexpected mallocx() failure");
+	dallocx(scratch, flags);
+
 	unsigned resume = 0;
 	expect_d_eq(mallctl("thread.arena", NULL, NULL, (void *)&resume,
-	    sizeof(resume)), 0,
-	    "Setting thread.arena within the per-CPU range should resume "
-	    "per-CPU selection, not fail");
-
+	    sizeof(resume)), 0, "Should resume per-CPU selection, not fail");
 	sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
-	expect_u_lt(cur, limit,
-	    "Thread should be back under per-CPU management after resuming");
+	expect_u_lt(cur, limit, "Thread should be back on a per-CPU arena");
 
-	dallocx(p, 0);
+	void *p_percpu = mallocx(1024, flags);
+	expect_ptr_not_null(p_percpu, "Unexpected mallocx() failure");
+	sz = sizeof(found);
+	expect_d_eq(mallctl("arenas.lookup", (void *)&found, &sz,
+	    (void *)&p_percpu, sizeof(p_percpu)), 0,
+	    "Unexpected arenas.lookup() failure");
+	expect_u_lt(found, limit, "Allocation should come from a per-CPU arena");
+	dallocx(p_percpu, flags);
+
+	/* Free the manual-arena region while bound to a different arena. */
+	dallocx(p_manual, flags);
 }
 TEST_END
 

--- a/test/unit/percpu_arena_resume.sh
+++ b/test/unit/percpu_arena_resume.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="percpu_arena:percpu"


### PR DESCRIPTION
## Motivation

`percpu_arena` binds each thread to the arena for the CPU it currently runs on, keeping allocations CPU-local and avoiding cross-CPU contention. Some workloads want to combine this with a small number of manually created, long-lived arenas: general allocation stays on the per-CPU arenas, but a bounded region of work routes its allocations into a dedicated arena. This isolates that memory (typically longer-lived and with a different allocation pattern) from the general per-CPU churn, so it can be purged or accounted for as a unit and does not fragment the per-CPU arenas. After that region, the thread should return to normal per-CPU allocation.

Individual allocations can already be directed to a specific arena with `mallocx(..., MALLOCX_ARENA(a))`. That is enough when every allocation call is under your control. It does not cover a whole region of code that performs many allocations, especially when they go through plain `malloc` / `operator new` or through existing library code that you do not want to (or cannot) modify to pass `MALLOCX_ARENA`. For that, the natural tool is to switch the calling thread's arena for the duration of the region, so every allocation in it, including in unmodified code, lands in the dedicated arena.

`thread.arena` is that tool, but under `percpu_arena` it is one-directional. A thread can bind to a manually created arena (an index at or above the per-CPU auto range), but there is no way back:

- `thread_arena_ctl` returns `EPERM` for any index within the per-CPU auto range when `percpu_arena` is enabled.
- `arena_choose_impl` only re-selects a per-CPU arena for threads whose current arena is already within the auto range, so a thread bound to a manual arena is never reclaimed by percpu.

Once a thread touches a manual arena it stays pinned to it for its whole life, and every later allocation lands in that arena instead of following the CPU. On a thread pool this is especially harmful: any worker that ever runs the dedicated-arena region is permanently removed from per-CPU management.

## Change

When `percpu_arena` is enabled, treat setting `thread.arena` to an index within the per-CPU auto range as a request to resume automatic per-CPU selection, instead of returning `EPERM`. The thread is handed back to percpu management (rebound to its current CPU's arena via `percpu_arena_update`) and the call returns 0.

Binding to a manual arena (index at or above the auto range) is unchanged. The requested index is advisory: under `percpu` the thread is governed by the CPU it runs on, so it resumes on the current CPU's arena regardless of the value passed. This is migration safe. If the thread moved CPUs between switching to the manual arena and resuming, it lands on the arena for the CPU it is actually running on.

## Tests

- New `test/unit/percpu_arena_resume` (with a `.sh` setting `percpu_arena:percpu`) exercises the round trip: bind to a manual arena, resume, and assert the thread is back in the per-CPU range. It skips when percpu is disabled.
- `test_thread_arena` in `test/unit/mallctl.c` asserted the old `EPERM`; it now asserts the resume succeeds.

Closes #1236
