### PR TITLE
[tech debt] Stats refactor - emit row by row using data descriptors

### DIFF
--- a/include/jemalloc/internal/emitter.h
+++ b/include/jemalloc/internal/emitter.h
@@ -590,6 +590,99 @@ emitter_sparse_row(emitter_t *emitter, emitter_row_t *row, bool is_gap) {
 	}
 }
 
+/*
+ * Descriptor-driven column tables.  A descriptor array defines table order;
+ * callers provide a separate index array when JSON requires a different
+ * subset or ordering.  The getter lets one engine serve different row types
+ * while keeping derived values (rates, utilization, and so on) with the
+ * table-specific code.  A column is active when all its required_flags are
+ * present in the active_flags supplied by the caller; the emitter assigns no
+ * domain-specific meaning to those bits.
+ */
+typedef struct emitter_col_desc_s emitter_col_desc_t;
+struct emitter_col_desc_s {
+	const char       *json_key;
+	const char       *table_label;
+	emitter_justify_t justify;
+	int               width;
+	emitter_type_t    type;
+	unsigned          required_flags;
+	void            (*get)(const void *row, emitter_col_t *col);
+};
+
+static inline bool
+emitter_col_desc_active(const emitter_col_desc_t *desc,
+    unsigned active_flags) {
+	return (desc->required_flags & ~active_flags) == 0;
+}
+
+static inline void
+emitter_col_table_build(const emitter_col_desc_t *descs, size_t ndescs,
+    unsigned active_flags, emitter_row_t *row, emitter_col_t *cols,
+    emitter_row_t *header_row, emitter_col_t *header_cols) {
+	emitter_row_init(row);
+	emitter_row_init(header_row);
+	for (size_t i = 0; i < ndescs; i++) {
+		if (!emitter_col_desc_active(&descs[i], active_flags)) {
+			continue;
+		}
+
+		emitter_col_init(&cols[i], row);
+		cols[i].justify = descs[i].justify;
+		cols[i].width = descs[i].width;
+		cols[i].type = descs[i].type;
+
+		emitter_col_init(&header_cols[i], header_row);
+		header_cols[i].justify = descs[i].justify;
+		header_cols[i].width = descs[i].width;
+		header_cols[i].type = emitter_type_title;
+		header_cols[i].str_val = descs[i].table_label != NULL
+		    ? descs[i].table_label : descs[i].json_key;
+	}
+}
+
+static inline void
+emitter_col_table_header(emitter_t *emitter, emitter_row_t *header_row,
+    emitter_col_t *first_header_col, const char *table_prefix,
+    const char *json_key) {
+	first_header_col->width -= (int)strlen(table_prefix);
+	emitter_table_printf(emitter, "%s", table_prefix);
+	emitter_table_row(emitter, header_row);
+	emitter_json_array_kv_begin(emitter, json_key);
+}
+
+static inline void
+emitter_col_table_fill(const emitter_col_desc_t *descs, size_t ndescs,
+    unsigned active_flags, emitter_col_t *cols, const void *row) {
+	for (size_t i = 0; i < ndescs; i++) {
+		if (!emitter_col_desc_active(&descs[i], active_flags)) {
+			continue;
+		}
+		cols[i].type = descs[i].type;
+		descs[i].get(row, &cols[i]);
+	}
+}
+
+static inline void
+emitter_col_table_emit_json(emitter_t *emitter,
+    const emitter_col_desc_t *descs, size_t ndescs, unsigned active_flags,
+    emitter_col_t *cols, const unsigned *json_order, size_t json_order_len) {
+	if (!emitter_outputs_json(emitter)) {
+		return;
+	}
+	for (size_t i = 0; i < json_order_len; i++) {
+		unsigned col_ind = json_order[i];
+		assert(col_ind < ndescs);
+		const emitter_col_desc_t *desc = &descs[col_ind];
+		if (!emitter_col_desc_active(desc, active_flags)) {
+			continue;
+		}
+		assert(desc->json_key != NULL);
+		emitter_json_kv(emitter, desc->json_key, cols[col_ind].type,
+		    (const void *)&cols[col_ind].bool_val);
+	}
+}
+
 static inline void
 emitter_begin(emitter_t *emitter) {
 	if (emitter_outputs_json(emitter)) {

--- a/include/jemalloc/internal/emitter.h
+++ b/include/jemalloc/internal/emitter.h
@@ -591,13 +591,12 @@ emitter_sparse_row(emitter_t *emitter, emitter_row_t *row, bool is_gap) {
 }
 
 /*
- * Descriptor-driven column tables.  A descriptor array defines table order;
- * callers provide a separate index array when JSON requires a different
- * subset or ordering.  The getter lets one engine serve different row types
- * while keeping derived values (rates, utilization, and so on) with the
- * table-specific code.  A column is active when all its required_flags are
- * present in the active_flags supplied by the caller; the emitter assigns no
- * domain-specific meaning to those bits.
+ * Descriptor-driven column tables.  A descriptor array defines table and JSON
+ * order; columns with a NULL json_key are table-only.  The getter lets one
+ * engine serve different row types while keeping derived values (rates,
+ * utilization, and so on) with the table-specific code.  A column is active
+ * when all its required_flags are present in the active_flags supplied by the
+ * caller; the emitter assigns no domain-specific meaning to those bits.
  */
 typedef struct emitter_col_desc_s emitter_col_desc_t;
 struct emitter_col_desc_s {
@@ -666,20 +665,21 @@ emitter_col_table_fill(const emitter_col_desc_t *descs, size_t ndescs,
 static inline void
 emitter_col_table_emit_json(emitter_t *emitter,
     const emitter_col_desc_t *descs, size_t ndescs, unsigned active_flags,
-    emitter_col_t *cols, const unsigned *json_order, size_t json_order_len) {
+    emitter_col_t *cols) {
 	if (!emitter_outputs_json(emitter)) {
 		return;
 	}
-	for (size_t i = 0; i < json_order_len; i++) {
-		unsigned col_ind = json_order[i];
-		assert(col_ind < ndescs);
-		const emitter_col_desc_t *desc = &descs[col_ind];
+	for (size_t i = 0; i < ndescs; i++) {
+		const emitter_col_desc_t *desc = &descs[i];
 		if (!emitter_col_desc_active(desc, active_flags)) {
 			continue;
 		}
-		assert(desc->json_key != NULL);
-		emitter_json_kv(emitter, desc->json_key, cols[col_ind].type,
-		    (const void *)&cols[col_ind].bool_val);
+		if (desc->json_key != NULL) {
+			emitter_type_t json_type = cols[i].type == emitter_type_title
+			    ? emitter_type_string : cols[i].type;
+			emitter_json_kv(emitter, desc->json_key, json_type,
+			    (const void *)&cols[i].bool_val);
+		}
 	}
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -695,18 +695,223 @@ stats_size_col_set(emitter_col_t *col, size_t size, size_t prev_size, char *buf,
 	}
 }
 
+enum {
+	STATS_COL_FLAG_NONE = 0,
+	STATS_COL_FLAG_PROF = 1U << 0,
+};
+
+static unsigned
+stats_col_active_flags(bool prof_stats_on) {
+	return prof_stats_on ? STATS_COL_FLAG_PROF : STATS_COL_FLAG_NONE;
+}
+
+typedef struct {
+	const stats_arena_bin_t *bin;
+	unsigned                 ind;
+	size_t                   page;
+	uint64_t                 uptime;
+	const char              *util;
+} stats_arena_bin_emit_row_t;
+
+#define BIN_COL_GET(name, value_member, field)                                \
+	static void                                                            \
+	stats_bin_col_get_##name(const void *vrow, emitter_col_t *col) {        \
+		const stats_arena_bin_emit_row_t *row = vrow;                    \
+		col->value_member = row->bin->field;                              \
+	}
+#define BIN_COL_GET_RATE(name, field)                                         \
+	static void                                                            \
+	stats_bin_col_get_##name(const void *vrow, emitter_col_t *col) {        \
+		const stats_arena_bin_emit_row_t *row = vrow;                    \
+		col->uint64_val = rate_per_second(                               \
+		    row->bin->field, row->uptime);                                \
+	}
+BIN_COL_GET(size, size_val, reg_size)
+BIN_COL_GET(nmalloc, uint64_val, nmalloc)
+BIN_COL_GET(ndalloc, uint64_val, ndalloc)
+BIN_COL_GET(nrequests, uint64_val, nrequests)
+BIN_COL_GET(prof_live_requested, uint64_val, prof_live.req_sum)
+BIN_COL_GET(prof_live_count, uint64_val, prof_live.count)
+BIN_COL_GET(prof_accum_requested, uint64_val, prof_accum.req_sum)
+BIN_COL_GET(prof_accum_count, uint64_val, prof_accum.count)
+BIN_COL_GET(nshards, unsigned_val, nshards)
+BIN_COL_GET(curregs, size_val, curregs)
+BIN_COL_GET(curslabs, size_val, curslabs)
+BIN_COL_GET(nonfull_slabs, size_val, nonfull_slabs)
+BIN_COL_GET(regs, unsigned_val, nregs)
+BIN_COL_GET(nfills, uint64_val, nfills)
+BIN_COL_GET(nflushes, uint64_val, nflushes)
+BIN_COL_GET(nslabs, uint64_val, nslabs)
+BIN_COL_GET(nreslabs, uint64_val, nreslabs)
+BIN_COL_GET_RATE(nmalloc_ps, nmalloc)
+BIN_COL_GET_RATE(ndalloc_ps, ndalloc)
+BIN_COL_GET_RATE(nrequests_ps, nrequests)
+BIN_COL_GET_RATE(nfills_ps, nfills)
+BIN_COL_GET_RATE(nflushes_ps, nflushes)
+BIN_COL_GET_RATE(nreslabs_ps, nreslabs)
+#undef BIN_COL_GET
+#undef BIN_COL_GET_RATE
+
+static void
+stats_bin_col_get_ind(const void *vrow, emitter_col_t *col) {
+	const stats_arena_bin_emit_row_t *row = vrow;
+	col->unsigned_val = row->ind;
+}
+
+static void
+stats_bin_col_get_allocated(const void *vrow, emitter_col_t *col) {
+	const stats_arena_bin_emit_row_t *row = vrow;
+	col->size_val = row->bin->curregs * row->bin->reg_size;
+}
+
+static void
+stats_bin_col_get_pgs(const void *vrow, emitter_col_t *col) {
+	const stats_arena_bin_emit_row_t *row = vrow;
+	col->size_val = row->bin->slab_size / row->page;
+}
+
+static void
+stats_bin_col_get_spacer(const void *vrow, emitter_col_t *col) {
+	(void)vrow;
+	col->str_val = " ";
+}
+
+static void
+stats_bin_col_get_util(const void *vrow, emitter_col_t *col) {
+	const stats_arena_bin_emit_row_t *row = vrow;
+	col->str_val = row->util;
+}
+
+enum {
+	BIN_COL_SIZE,
+	BIN_COL_IND,
+	BIN_COL_ALLOCATED,
+	BIN_COL_NMALLOC,
+	BIN_COL_NMALLOC_PS,
+	BIN_COL_NDALLOC,
+	BIN_COL_NDALLOC_PS,
+	BIN_COL_NREQUESTS,
+	BIN_COL_NREQUESTS_PS,
+	BIN_COL_PROF_LIVE_REQUESTED,
+	BIN_COL_PROF_LIVE_COUNT,
+	BIN_COL_PROF_ACCUM_REQUESTED,
+	BIN_COL_PROF_ACCUM_COUNT,
+	BIN_COL_NSHARDS,
+	BIN_COL_CURREGS,
+	BIN_COL_CURSLABS,
+	BIN_COL_NONFULL_SLABS,
+	BIN_COL_REGS,
+	BIN_COL_PGS,
+	BIN_COL_SPACER,
+	BIN_COL_UTIL,
+	BIN_COL_NFILLS,
+	BIN_COL_NFILLS_PS,
+	BIN_COL_NFLUSHES,
+	BIN_COL_NFLUSHES_PS,
+	BIN_COL_NSLABS,
+	BIN_COL_NRESLABS,
+	BIN_COL_NRESLABS_PS,
+	BIN_COL_COUNT
+};
+
+#define BIN_DESC(key, label, width, type, flags, name)                        \
+	{key, label, emitter_justify_right, width, emitter_type_##type, flags,   \
+	    stats_bin_col_get_##name}
+static const emitter_col_desc_t stats_bin_cols[] = {
+	BIN_DESC(NULL, "size", 20, size, STATS_COL_FLAG_NONE, size),
+	BIN_DESC(NULL, "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
+	BIN_DESC(NULL, "allocated", 14, size, STATS_COL_FLAG_NONE, allocated),
+	BIN_DESC("nmalloc", "nmalloc", 14, uint64, STATS_COL_FLAG_NONE,
+	    nmalloc),
+	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, nmalloc_ps),
+	BIN_DESC("ndalloc", "ndalloc", 14, uint64, STATS_COL_FLAG_NONE,
+	    ndalloc),
+	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, ndalloc_ps),
+	BIN_DESC("nrequests", "nrequests", 15, uint64, STATS_COL_FLAG_NONE,
+	    nrequests),
+	BIN_DESC(NULL, "(#/sec)", 10, uint64, STATS_COL_FLAG_NONE,
+	    nrequests_ps),
+	BIN_DESC("prof_live_requested", "prof_live_requested", 21, uint64,
+	    STATS_COL_FLAG_PROF, prof_live_requested),
+	BIN_DESC("prof_live_count", "prof_live_count", 17, uint64,
+	    STATS_COL_FLAG_PROF, prof_live_count),
+	BIN_DESC("prof_accum_requested", "prof_accum_requested", 21, uint64,
+	    STATS_COL_FLAG_PROF, prof_accum_requested),
+	BIN_DESC("prof_accum_count", "prof_accum_count", 17, uint64,
+	    STATS_COL_FLAG_PROF, prof_accum_count),
+	BIN_DESC(NULL, "nshards", 9, unsigned, STATS_COL_FLAG_NONE, nshards),
+	BIN_DESC("curregs", "curregs", 13, size, STATS_COL_FLAG_NONE, curregs),
+	BIN_DESC("curslabs", "curslabs", 13, size, STATS_COL_FLAG_NONE,
+	    curslabs),
+	BIN_DESC("nonfull_slabs", "nonfull_slabs", 15, size,
+	    STATS_COL_FLAG_NONE,
+	    nonfull_slabs),
+	BIN_DESC(NULL, "regs", 5, unsigned, STATS_COL_FLAG_NONE, regs),
+	BIN_DESC(NULL, "pgs", 4, size, STATS_COL_FLAG_NONE, pgs),
+	BIN_DESC(NULL, " ", 1, title, STATS_COL_FLAG_NONE, spacer),
+	BIN_DESC(NULL, "util", 6, title, STATS_COL_FLAG_NONE, util),
+	BIN_DESC("nfills", "nfills", 13, uint64, STATS_COL_FLAG_NONE, nfills),
+	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, nfills_ps),
+	BIN_DESC("nflushes", "nflushes", 13, uint64, STATS_COL_FLAG_NONE,
+	    nflushes),
+	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nflushes_ps),
+	BIN_DESC(NULL, "nslabs", 13, uint64, STATS_COL_FLAG_NONE, nslabs),
+	BIN_DESC("nreslabs", "nreslabs", 13, uint64, STATS_COL_FLAG_NONE,
+	    nreslabs),
+	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nreslabs_ps),
+};
+#undef BIN_DESC
+_Static_assert(sizeof(stats_bin_cols) / sizeof(stats_bin_cols[0]) ==
+    BIN_COL_COUNT, "stats_bin_cols must match BIN_COL_COUNT");
+
+static const unsigned stats_bin_json_order[] = {
+	BIN_COL_NMALLOC,
+	BIN_COL_NDALLOC,
+	BIN_COL_CURREGS,
+	BIN_COL_NREQUESTS,
+	BIN_COL_PROF_LIVE_REQUESTED,
+	BIN_COL_PROF_LIVE_COUNT,
+	BIN_COL_PROF_ACCUM_REQUESTED,
+	BIN_COL_PROF_ACCUM_COUNT,
+	BIN_COL_NFILLS,
+	BIN_COL_NFLUSHES,
+	BIN_COL_NRESLABS,
+	BIN_COL_CURSLABS,
+	BIN_COL_NONFULL_SLABS,
+};
+
+static void
+stats_emit_arena_bin_row(emitter_t *emitter, emitter_row_t *table_row,
+    emitter_col_t *cols, const stats_arena_bin_emit_row_t *row,
+    bool prof_stats_on, bool mutex, emitter_col_t *mutex64,
+    emitter_col_t *mutex32, bool is_gap) {
+	unsigned active_flags = stats_col_active_flags(prof_stats_on);
+	emitter_col_table_fill(
+	    stats_bin_cols, BIN_COL_COUNT, active_flags, cols, row);
+	emitter_json_object_begin(emitter);
+	emitter_col_table_emit_json(emitter, stats_bin_cols, BIN_COL_COUNT,
+	    active_flags, cols, stats_bin_json_order,
+	    sizeof(stats_bin_json_order) / sizeof(stats_bin_json_order[0]));
+	if (mutex) {
+		emitter_json_object_kv_begin(emitter, "mutex");
+		mutex_stats_emit(emitter, NULL, mutex64, mutex32);
+		emitter_json_object_end(emitter);
+	}
+	emitter_json_object_end(emitter);
+	emitter_table_sparse_row(emitter, table_row, is_gap);
+}
+
 JEMALLOC_COLD
 static void
 stats_arena_bins_print(
     emitter_t *emitter, bool mutex, unsigned i, uint64_t uptime) {
 	/*
-	 * Streaming table (deviates from the gather/emit split): the SC_NBINS
-	 * rows are gathered and emitted one at a time (stats_gather_arena_bin
-	 * per row + inline emit, with all-zero runs collapsed to "---").  This
-	 * preserves O(1) memory.  Full gather-all-rows-before-emit separation
-	 * would require buffering the table; a separate per-row emit helper
-	 * would not.  The lextents / extents / hpa-nonfull tables follow the
-	 * same pattern.
+	 * Process one size-class row at a time to preserve O(1) memory.  Full
+	 * gather-all-rows-before-emit separation would require buffering the
+	 * table, so gathering and emission remain interleaved across rows.  The
+	 * lextents, extents, and HPA nonfull tables follow the same pattern.
 	 */
 	size_t   page;
 	unsigned nbins, j;
@@ -715,54 +920,13 @@ stats_arena_bins_print(
 
 	CTL_GET("arenas.nbins", &nbins, unsigned);
 
-	emitter_row_t header_row;
-	emitter_row_init(&header_row);
-
-	emitter_row_t row;
-	emitter_row_init(&row);
-
 	bool prof_stats_on = config_prof && opt_prof && opt_prof_stats
 	    && i == MALLCTL_ARENAS_ALL;
-
-	COL_HDR(row, size, NULL, right, 20, size)
-	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, allocated, NULL, right, 14, size)
-	COL_HDR(row, nmalloc, NULL, right, 14, uint64)
-	COL_HDR(row, nmalloc_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, ndalloc, NULL, right, 14, uint64)
-	COL_HDR(row, ndalloc_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, nrequests, NULL, right, 15, uint64)
-	COL_HDR(row, nrequests_ps, "(#/sec)", right, 10, uint64)
-	COL_HDR_DECLARE(prof_live_requested);
-	COL_HDR_DECLARE(prof_live_count);
-	COL_HDR_DECLARE(prof_accum_requested);
-	COL_HDR_DECLARE(prof_accum_count);
-	if (prof_stats_on) {
-		COL_HDR_INIT(row, prof_live_requested, NULL, right, 21, uint64)
-		COL_HDR_INIT(row, prof_live_count, NULL, right, 17, uint64)
-		COL_HDR_INIT(row, prof_accum_requested, NULL, right, 21, uint64)
-		COL_HDR_INIT(row, prof_accum_count, NULL, right, 17, uint64)
-	}
-	COL_HDR(row, nshards, NULL, right, 9, unsigned)
-	COL_HDR(row, curregs, NULL, right, 13, size)
-	COL_HDR(row, curslabs, NULL, right, 13, size)
-	COL_HDR(row, nonfull_slabs, NULL, right, 15, size)
-	COL_HDR(row, regs, NULL, right, 5, unsigned)
-	COL_HDR(row, pgs, NULL, right, 4, size)
-	/* To buffer a right- and left-justified column. */
-	COL_HDR(row, justify_spacer, NULL, right, 1, title)
-	COL_HDR(row, util, NULL, right, 6, title)
-	COL_HDR(row, nfills, NULL, right, 13, uint64)
-	COL_HDR(row, nfills_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, nflushes, NULL, right, 13, uint64)
-	COL_HDR(row, nflushes_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, nslabs, NULL, right, 13, uint64)
-	COL_HDR(row, nreslabs, NULL, right, 13, uint64)
-	COL_HDR(row, nreslabs_ps, "(#/sec)", right, 8, uint64)
-
-	/* Don't want to actually print the name. */
-	header_justify_spacer.str_val = " ";
-	col_justify_spacer.str_val = " ";
+	emitter_row_t row, header_row;
+	emitter_col_t cols[BIN_COL_COUNT], header_cols[BIN_COL_COUNT];
+	emitter_col_table_build(stats_bin_cols, BIN_COL_COUNT,
+	    stats_col_active_flags(prof_stats_on), &row, cols, &header_row,
+	    header_cols);
 
 	emitter_col_t col_mutex64[mutex_prof_num_uint64_t_counters];
 	emitter_col_t col_mutex32[mutex_prof_num_uint32_t_counters];
@@ -777,14 +941,8 @@ stats_arena_bins_print(
 		    &header_row, NULL, NULL, header_mutex64, header_mutex32);
 	}
 
-	/*
-	 * We print a "bins:" header as part of the table row; we need to adjust
-	 * the header size column to compensate.
-	 */
-	header_size.width -= 5;
-	emitter_table_printf(emitter, "bins:");
-	emitter_table_row(emitter, &header_row);
-	emitter_json_array_kv_begin(emitter, "bins");
+	emitter_col_table_header(emitter, &header_row,
+	    &header_cols[BIN_COL_SIZE], "bins:", "bins");
 
 	size_t stats_arenas_mib[CTL_MAX_DEPTH];
 	CTL_LEAF_PREPARE(stats_arenas_mib, 0, "stats.arenas");
@@ -827,58 +985,13 @@ stats_arena_bins_print(
 			continue;
 		}
 
-		/*
-		 * Per-size-class tables stream: gather one row, emit it, reuse
-		 * buffers.  Full gather-all-rows-before-emit separation would
-		 * require table-sized storage, so gathering and emission remain
-		 * interleaved across rows.  In particular the per-bin mutex
-		 * counters are read here (the mutex subsystem reads straight into
-		 * emitter columns) rather than up front.  A separate per-row emit
-		 * helper could further decouple the code without buffering.
-		 */
+		/* Mutex counters still gather directly into their emitter columns. */
 		stats_gather_arena_bin(stats_arenas_mib, arenas_bin_mib, &bin);
 
 		if (mutex) {
 			mutex_stats_read_arena_bin(stats_arenas_mib, 5,
 			    col_mutex64, col_mutex32, uptime);
 		}
-
-		emitter_json_object_begin(emitter);
-		emitter_json_kv(
-		    emitter, "nmalloc", emitter_type_uint64, &bin.nmalloc);
-		emitter_json_kv(
-		    emitter, "ndalloc", emitter_type_uint64, &bin.ndalloc);
-		emitter_json_kv(
-		    emitter, "curregs", emitter_type_size, &bin.curregs);
-		emitter_json_kv(
-		    emitter, "nrequests", emitter_type_uint64, &bin.nrequests);
-		if (prof_stats_on) {
-			emitter_json_kv(emitter, "prof_live_requested",
-			    emitter_type_uint64, &bin.prof_live.req_sum);
-			emitter_json_kv(emitter, "prof_live_count",
-			    emitter_type_uint64, &bin.prof_live.count);
-			emitter_json_kv(emitter, "prof_accum_requested",
-			    emitter_type_uint64, &bin.prof_accum.req_sum);
-			emitter_json_kv(emitter, "prof_accum_count",
-			    emitter_type_uint64, &bin.prof_accum.count);
-		}
-		emitter_json_kv(
-		    emitter, "nfills", emitter_type_uint64, &bin.nfills);
-		emitter_json_kv(
-		    emitter, "nflushes", emitter_type_uint64, &bin.nflushes);
-		emitter_json_kv(
-		    emitter, "nreslabs", emitter_type_uint64, &bin.nreslabs);
-		emitter_json_kv(
-		    emitter, "curslabs", emitter_type_size, &bin.curslabs);
-		emitter_json_kv(emitter, "nonfull_slabs", emitter_type_size,
-		    &bin.nonfull_slabs);
-		if (mutex) {
-			emitter_json_object_kv_begin(emitter, "mutex");
-			mutex_stats_emit(
-			    emitter, NULL, col_mutex64, col_mutex32);
-			emitter_json_object_end(emitter);
-		}
-		emitter_json_object_end(emitter);
 
 		size_t availregs = bin.nregs * bin.curslabs;
 		char   util[6];
@@ -899,48 +1012,138 @@ stats_arena_bins_print(
 			}
 		}
 
-		col_size.size_val = bin.reg_size;
-		col_ind.unsigned_val = j;
-		col_allocated.size_val = bin.curregs * bin.reg_size;
-		col_nmalloc.uint64_val = bin.nmalloc;
-		col_nmalloc_ps.uint64_val = rate_per_second(bin.nmalloc, uptime);
-		col_ndalloc.uint64_val = bin.ndalloc;
-		col_ndalloc_ps.uint64_val = rate_per_second(bin.ndalloc, uptime);
-		col_nrequests.uint64_val = bin.nrequests;
-		col_nrequests_ps.uint64_val = rate_per_second(
-		    bin.nrequests, uptime);
-		if (prof_stats_on) {
-			col_prof_live_requested.uint64_val = bin.prof_live.req_sum;
-			col_prof_live_count.uint64_val = bin.prof_live.count;
-			col_prof_accum_requested.uint64_val =
-			    bin.prof_accum.req_sum;
-			col_prof_accum_count.uint64_val = bin.prof_accum.count;
-		}
-		col_nshards.unsigned_val = bin.nshards;
-		col_curregs.size_val = bin.curregs;
-		col_curslabs.size_val = bin.curslabs;
-		col_nonfull_slabs.size_val = bin.nonfull_slabs;
-		col_regs.unsigned_val = bin.nregs;
-		col_pgs.size_val = bin.slab_size / page;
-		col_util.str_val = util;
-		col_nfills.uint64_val = bin.nfills;
-		col_nfills_ps.uint64_val = rate_per_second(bin.nfills, uptime);
-		col_nflushes.uint64_val = bin.nflushes;
-		col_nflushes_ps.uint64_val = rate_per_second(bin.nflushes, uptime);
-		col_nslabs.uint64_val = bin.nslabs;
-		col_nreslabs.uint64_val = bin.nreslabs;
-		col_nreslabs_ps.uint64_val = rate_per_second(bin.nreslabs, uptime);
-
-		/*
-		 * Note that mutex columns were initialized above, if mutex ==
-		 * true.
-		 */
-
-		emitter_table_sparse_row(emitter, &row, is_gap);
+		stats_arena_bin_emit_row_t emit_row = {
+		    &bin, j, page, uptime, util};
+		stats_emit_arena_bin_row(emitter, &row, cols, &emit_row,
+		    prof_stats_on, mutex, col_mutex64, col_mutex32, is_gap);
 	}
 	emitter_json_array_end(emitter); /* Close "bins". */
 
 	emitter_table_sparse_end(emitter);
+}
+
+typedef struct {
+	const stats_arena_lextent_t *lextent;
+	unsigned                     ind;
+	uint64_t                     uptime;
+} stats_arena_lextent_emit_row_t;
+
+#define LEXTENT_COL_GET(name, value_member, field)                            \
+	static void                                                            \
+	stats_lextent_col_get_##name(const void *vrow, emitter_col_t *col) {    \
+		const stats_arena_lextent_emit_row_t *row = vrow;                \
+		col->value_member = row->lextent->field;                          \
+	}
+#define LEXTENT_COL_GET_RATE(name, field)                                     \
+	static void                                                            \
+	stats_lextent_col_get_##name(const void *vrow, emitter_col_t *col) {    \
+		const stats_arena_lextent_emit_row_t *row = vrow;                \
+		col->uint64_val = rate_per_second(                               \
+		    row->lextent->field, row->uptime);                            \
+	}
+LEXTENT_COL_GET(size, size_val, lextent_size)
+LEXTENT_COL_GET(nmalloc, uint64_val, nmalloc)
+LEXTENT_COL_GET(ndalloc, uint64_val, ndalloc)
+LEXTENT_COL_GET(nrequests, uint64_val, nrequests)
+LEXTENT_COL_GET(prof_live_requested, uint64_val, prof_live.req_sum)
+LEXTENT_COL_GET(prof_live_count, uint64_val, prof_live.count)
+LEXTENT_COL_GET(prof_accum_requested, uint64_val, prof_accum.req_sum)
+LEXTENT_COL_GET(prof_accum_count, uint64_val, prof_accum.count)
+LEXTENT_COL_GET(curlextents, size_val, curlextents)
+LEXTENT_COL_GET_RATE(nmalloc_ps, nmalloc)
+LEXTENT_COL_GET_RATE(ndalloc_ps, ndalloc)
+LEXTENT_COL_GET_RATE(nrequests_ps, nrequests)
+#undef LEXTENT_COL_GET
+#undef LEXTENT_COL_GET_RATE
+
+static void
+stats_lextent_col_get_ind(const void *vrow, emitter_col_t *col) {
+	const stats_arena_lextent_emit_row_t *row = vrow;
+	col->unsigned_val = row->ind;
+}
+
+static void
+stats_lextent_col_get_allocated(const void *vrow, emitter_col_t *col) {
+	const stats_arena_lextent_emit_row_t *row = vrow;
+	col->size_val = row->lextent->curlextents * row->lextent->lextent_size;
+}
+
+enum {
+	LEXTENT_COL_SIZE,
+	LEXTENT_COL_IND,
+	LEXTENT_COL_ALLOCATED,
+	LEXTENT_COL_NMALLOC,
+	LEXTENT_COL_NMALLOC_PS,
+	LEXTENT_COL_NDALLOC,
+	LEXTENT_COL_NDALLOC_PS,
+	LEXTENT_COL_NREQUESTS,
+	LEXTENT_COL_NREQUESTS_PS,
+	LEXTENT_COL_PROF_LIVE_REQUESTED,
+	LEXTENT_COL_PROF_LIVE_COUNT,
+	LEXTENT_COL_PROF_ACCUM_REQUESTED,
+	LEXTENT_COL_PROF_ACCUM_COUNT,
+	LEXTENT_COL_CURLEXTENTS,
+	LEXTENT_COL_COUNT
+};
+
+#define LEXTENT_DESC(key, label, width, type, flags, name)                    \
+	{key, label, emitter_justify_right, width, emitter_type_##type, flags,   \
+	    stats_lextent_col_get_##name}
+static const emitter_col_desc_t stats_lextent_cols[] = {
+	LEXTENT_DESC(NULL, "size", 20, size, STATS_COL_FLAG_NONE, size),
+	LEXTENT_DESC(NULL, "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
+	LEXTENT_DESC(NULL, "allocated", 13, size, STATS_COL_FLAG_NONE,
+	    allocated),
+	LEXTENT_DESC(NULL, "nmalloc", 13, uint64, STATS_COL_FLAG_NONE, nmalloc),
+	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nmalloc_ps),
+	LEXTENT_DESC(NULL, "ndalloc", 13, uint64, STATS_COL_FLAG_NONE, ndalloc),
+	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    ndalloc_ps),
+	LEXTENT_DESC(NULL, "nrequests", 13, uint64, STATS_COL_FLAG_NONE,
+	    nrequests),
+	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nrequests_ps),
+	LEXTENT_DESC("prof_live_requested", "prof_live_requested", 21, uint64,
+	    STATS_COL_FLAG_PROF, prof_live_requested),
+	LEXTENT_DESC("prof_live_count", "prof_live_count", 17, uint64,
+	    STATS_COL_FLAG_PROF, prof_live_count),
+	LEXTENT_DESC("prof_accum_requested", "prof_accum_requested", 21,
+	    uint64, STATS_COL_FLAG_PROF, prof_accum_requested),
+	LEXTENT_DESC("prof_accum_count", "prof_accum_count", 17, uint64,
+	    STATS_COL_FLAG_PROF, prof_accum_count),
+	LEXTENT_DESC("curlextents", "curlextents", 13, size,
+	    STATS_COL_FLAG_NONE, curlextents),
+};
+#undef LEXTENT_DESC
+_Static_assert(sizeof(stats_lextent_cols) / sizeof(stats_lextent_cols[0]) ==
+    LEXTENT_COL_COUNT, "stats_lextent_cols must match LEXTENT_COL_COUNT");
+
+static const unsigned stats_lextent_json_order[] = {
+	LEXTENT_COL_PROF_LIVE_REQUESTED,
+	LEXTENT_COL_PROF_LIVE_COUNT,
+	LEXTENT_COL_PROF_ACCUM_REQUESTED,
+	LEXTENT_COL_PROF_ACCUM_COUNT,
+	LEXTENT_COL_CURLEXTENTS,
+};
+
+static void
+stats_emit_arena_lextent_row(emitter_t *emitter, emitter_row_t *table_row,
+    emitter_col_t *cols, const stats_arena_lextent_emit_row_t *row,
+    bool prof_stats_on, size_t prev_size, char *size_buf,
+    size_t size_buf_size, bool is_gap) {
+	unsigned active_flags = stats_col_active_flags(prof_stats_on);
+	emitter_col_table_fill(stats_lextent_cols, LEXTENT_COL_COUNT,
+	    active_flags, cols, row);
+	stats_size_col_set(&cols[LEXTENT_COL_SIZE], row->lextent->lextent_size,
+	    prev_size, size_buf, size_buf_size);
+	emitter_json_object_begin(emitter);
+	emitter_col_table_emit_json(emitter, stats_lextent_cols,
+	    LEXTENT_COL_COUNT, active_flags, cols, stats_lextent_json_order,
+	    sizeof(stats_lextent_json_order) /
+	        sizeof(stats_lextent_json_order[0]));
+	emitter_table_sparse_row(emitter, table_row, is_gap);
+	emitter_json_object_end(emitter);
 }
 
 JEMALLOC_COLD
@@ -952,45 +1155,16 @@ stats_arena_lextents_print(emitter_t *emitter, unsigned i, uint64_t uptime) {
 	CTL_GET("arenas.nbins", &nbins, unsigned);
 	CTL_GET("arenas.nlextents", &nlextents, unsigned);
 
-	emitter_row_t header_row;
-	emitter_row_init(&header_row);
-	emitter_row_t row;
-	emitter_row_init(&row);
-
 	bool prof_stats_on = config_prof && opt_prof && opt_prof_stats
 	    && i == MALLCTL_ARENAS_ALL;
-
-	COL_HDR(row, size, NULL, right, 20, size)
-	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, allocated, NULL, right, 13, size)
-	COL_HDR(row, nmalloc, NULL, right, 13, uint64)
-	COL_HDR(row, nmalloc_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, ndalloc, NULL, right, 13, uint64)
-	COL_HDR(row, ndalloc_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR(row, nrequests, NULL, right, 13, uint64)
-	COL_HDR(row, nrequests_ps, "(#/sec)", right, 8, uint64)
-	COL_HDR_DECLARE(prof_live_requested)
-	COL_HDR_DECLARE(prof_live_count)
-	COL_HDR_DECLARE(prof_accum_requested)
-	COL_HDR_DECLARE(prof_accum_count)
-	if (prof_stats_on) {
-		COL_HDR_INIT(row, prof_live_requested, NULL, right, 21, uint64)
-		COL_HDR_INIT(row, prof_live_count, NULL, right, 17, uint64)
-		COL_HDR_INIT(row, prof_accum_requested, NULL, right, 21, uint64)
-		COL_HDR_INIT(row, prof_accum_count, NULL, right, 17, uint64)
-		col_prof_live_requested.json_key = "prof_live_requested";
-		col_prof_live_count.json_key = "prof_live_count";
-		col_prof_accum_requested.json_key = "prof_accum_requested";
-		col_prof_accum_count.json_key = "prof_accum_count";
-	}
-	COL_HDR(row, curlextents, NULL, right, 13, size)
-	col_curlextents.json_key = "curlextents";
-
-	/* As with bins, we label the large extents table. */
-	header_size.width -= 6;
-	emitter_table_printf(emitter, "large:");
-	emitter_table_row(emitter, &header_row);
-	emitter_json_array_kv_begin(emitter, "lextents");
+	emitter_row_t row, header_row;
+	emitter_col_t cols[LEXTENT_COL_COUNT], header_cols[LEXTENT_COL_COUNT];
+	char size_buf[48];
+	emitter_col_table_build(stats_lextent_cols, LEXTENT_COL_COUNT,
+	    stats_col_active_flags(prof_stats_on), &row, cols, &header_row,
+	    header_cols);
+	emitter_col_table_header(emitter, &header_row,
+	    &header_cols[LEXTENT_COL_SIZE], "large:", "lextents");
 
 	size_t stats_arenas_mib[CTL_MAX_DEPTH];
 	CTL_LEAF_PREPARE(stats_arenas_mib, 0, "stats.arenas");
@@ -1022,34 +1196,117 @@ stats_arena_lextents_print(emitter_t *emitter, unsigned i, uint64_t uptime) {
 
 		bool is_gap = (lext.nrequests == 0);
 
-		char size_buf[48];
-		stats_size_col_set(&col_size, lext.lextent_size, prev_size,
-		    size_buf, sizeof(size_buf));
+		stats_arena_lextent_emit_row_t emit_row = {
+		    &lext, nbins + j, uptime};
+		stats_emit_arena_lextent_row(emitter, &row, cols, &emit_row,
+		    prof_stats_on, prev_size, size_buf, sizeof(size_buf), is_gap);
 		prev_size = lext.lextent_size;
-		col_ind.unsigned_val = nbins + j;
-		col_allocated.size_val = lext.curlextents * lext.lextent_size;
-		col_nmalloc.uint64_val = lext.nmalloc;
-		col_nmalloc_ps.uint64_val = rate_per_second(lext.nmalloc, uptime);
-		col_ndalloc.uint64_val = lext.ndalloc;
-		col_ndalloc_ps.uint64_val = rate_per_second(lext.ndalloc, uptime);
-		col_nrequests.uint64_val = lext.nrequests;
-		col_nrequests_ps.uint64_val = rate_per_second(
-		    lext.nrequests, uptime);
-		if (prof_stats_on) {
-			col_prof_live_requested.uint64_val = lext.prof_live.req_sum;
-			col_prof_live_count.uint64_val = lext.prof_live.count;
-			col_prof_accum_requested.uint64_val =
-			    lext.prof_accum.req_sum;
-			col_prof_accum_count.uint64_val = lext.prof_accum.count;
-		}
-		col_curlextents.size_val = lext.curlextents;
-
-		emitter_json_object_begin(emitter);
-		emitter_sparse_row(emitter, &row, is_gap);
-		emitter_json_object_end(emitter);
 	}
 	emitter_json_array_end(emitter); /* Close "lextents". */
 	emitter_table_sparse_end(emitter);
+}
+
+typedef struct {
+	const stats_arena_extent_t *extent;
+	unsigned                    ind;
+	size_t                      size;
+} stats_arena_extent_emit_row_t;
+
+#define EXTENT_COL_GET(name, field)                                           \
+	static void                                                            \
+	stats_extent_col_get_##name(const void *vrow, emitter_col_t *col) {     \
+		const stats_arena_extent_emit_row_t *row = vrow;                 \
+		col->size_val = row->extent->field;                              \
+	}
+EXTENT_COL_GET(ndirty, ndirty)
+EXTENT_COL_GET(dirty, dirty_bytes)
+EXTENT_COL_GET(nmuzzy, nmuzzy)
+EXTENT_COL_GET(muzzy, muzzy_bytes)
+EXTENT_COL_GET(nretained, nretained)
+EXTENT_COL_GET(retained, retained_bytes)
+EXTENT_COL_GET(npinned, npinned)
+EXTENT_COL_GET(pinned, pinned_bytes)
+EXTENT_COL_GET(ntotal, ntotal)
+EXTENT_COL_GET(total, total_bytes)
+#undef EXTENT_COL_GET
+
+static void
+stats_extent_col_get_size(const void *vrow, emitter_col_t *col) {
+	const stats_arena_extent_emit_row_t *row = vrow;
+	col->size_val = row->size;
+}
+
+static void
+stats_extent_col_get_ind(const void *vrow, emitter_col_t *col) {
+	const stats_arena_extent_emit_row_t *row = vrow;
+	col->unsigned_val = row->ind;
+}
+
+enum {
+	EXTENT_COL_SIZE,
+	EXTENT_COL_IND,
+	EXTENT_COL_NDIRTY,
+	EXTENT_COL_DIRTY,
+	EXTENT_COL_NMUZZY,
+	EXTENT_COL_MUZZY,
+	EXTENT_COL_NRETAINED,
+	EXTENT_COL_RETAINED,
+	EXTENT_COL_NPINNED,
+	EXTENT_COL_PINNED,
+	EXTENT_COL_NTOTAL,
+	EXTENT_COL_TOTAL,
+	EXTENT_COL_COUNT
+};
+
+#define EXTENT_DESC(key, label, name)                                         \
+	{key, label, emitter_justify_right, 13, emitter_type_size,               \
+	    STATS_COL_FLAG_NONE, stats_extent_col_get_##name}
+static const emitter_col_desc_t stats_extent_cols[] = {
+	{NULL, "size", emitter_justify_right, 20, emitter_type_size,
+	    STATS_COL_FLAG_NONE, stats_extent_col_get_size},
+	{NULL, "ind", emitter_justify_right, 4, emitter_type_unsigned,
+	    STATS_COL_FLAG_NONE, stats_extent_col_get_ind},
+	EXTENT_DESC("ndirty", "ndirty", ndirty),
+	EXTENT_DESC("dirty_bytes", "dirty", dirty),
+	EXTENT_DESC("nmuzzy", "nmuzzy", nmuzzy),
+	EXTENT_DESC("muzzy_bytes", "muzzy", muzzy),
+	EXTENT_DESC("nretained", "nretained", nretained),
+	EXTENT_DESC("retained_bytes", "retained", retained),
+	EXTENT_DESC("npinned", "npinned", npinned),
+	EXTENT_DESC("pinned_bytes", "pinned", pinned),
+	EXTENT_DESC(NULL, "ntotal", ntotal),
+	EXTENT_DESC(NULL, "total", total),
+};
+#undef EXTENT_DESC
+_Static_assert(sizeof(stats_extent_cols) / sizeof(stats_extent_cols[0]) ==
+    EXTENT_COL_COUNT, "stats_extent_cols must match EXTENT_COL_COUNT");
+
+static const unsigned stats_extent_json_order[] = {
+	EXTENT_COL_NDIRTY,
+	EXTENT_COL_NMUZZY,
+	EXTENT_COL_NRETAINED,
+	EXTENT_COL_NPINNED,
+	EXTENT_COL_DIRTY,
+	EXTENT_COL_MUZZY,
+	EXTENT_COL_RETAINED,
+	EXTENT_COL_PINNED,
+};
+
+static void
+stats_emit_arena_extent_row(emitter_t *emitter, emitter_row_t *table_row,
+    emitter_col_t *cols, const stats_arena_extent_emit_row_t *row,
+    size_t prev_size, char *size_buf, size_t size_buf_size, bool is_gap) {
+	emitter_col_table_fill(stats_extent_cols, EXTENT_COL_COUNT,
+	    STATS_COL_FLAG_NONE, cols, row);
+	stats_size_col_set(&cols[EXTENT_COL_SIZE], row->size, prev_size,
+	    size_buf, size_buf_size);
+	emitter_json_object_begin(emitter);
+	emitter_col_table_emit_json(emitter, stats_extent_cols, EXTENT_COL_COUNT,
+	    STATS_COL_FLAG_NONE, cols, stats_extent_json_order,
+	    sizeof(stats_extent_json_order) /
+	        sizeof(stats_extent_json_order[0]));
+	emitter_json_object_end(emitter);
+	emitter_table_sparse_row(emitter, table_row, is_gap);
 }
 
 JEMALLOC_COLD
@@ -1057,29 +1314,13 @@ static void
 stats_arena_extents_print(emitter_t *emitter, unsigned i) {
 	/* Streaming table; see stats_arena_bins_print for the rationale. */
 	unsigned      j;
-	emitter_row_t header_row;
-	emitter_row_init(&header_row);
-	emitter_row_t row;
-	emitter_row_init(&row);
-
-	COL_HDR(row, size, NULL, right, 20, size)
-	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, ndirty, NULL, right, 13, size)
-	COL_HDR(row, dirty, NULL, right, 13, size)
-	COL_HDR(row, nmuzzy, NULL, right, 13, size)
-	COL_HDR(row, muzzy, NULL, right, 13, size)
-	COL_HDR(row, nretained, NULL, right, 13, size)
-	COL_HDR(row, retained, NULL, right, 13, size)
-	COL_HDR(row, npinned, NULL, right, 13, size)
-	COL_HDR(row, pinned, NULL, right, 13, size)
-	COL_HDR(row, ntotal, NULL, right, 13, size)
-	COL_HDR(row, total, NULL, right, 13, size)
-
-	/* Label this section. */
-	header_size.width -= 8;
-	emitter_table_printf(emitter, "extents:");
-	emitter_table_row(emitter, &header_row);
-	emitter_json_array_kv_begin(emitter, "extents");
+	emitter_row_t row, header_row;
+	emitter_col_t cols[EXTENT_COL_COUNT], header_cols[EXTENT_COL_COUNT];
+	char size_buf[48];
+	emitter_col_table_build(stats_extent_cols, EXTENT_COL_COUNT,
+	    STATS_COL_FLAG_NONE, &row, cols, &header_row, header_cols);
+	emitter_col_table_header(emitter, &header_row,
+	    &header_cols[EXTENT_COL_SIZE], "extents:", "extents");
 
 	size_t stats_arenas_mib[CTL_MAX_DEPTH];
 	CTL_LEAF_PREPARE(stats_arenas_mib, 0, "stats.arenas");
@@ -1093,40 +1334,10 @@ stats_arena_extents_print(emitter_t *emitter, unsigned i) {
 
 		bool is_gap = (e.ntotal == 0);
 
-		emitter_json_object_begin(emitter);
-		emitter_json_kv(emitter, "ndirty", emitter_type_size, &e.ndirty);
-		emitter_json_kv(emitter, "nmuzzy", emitter_type_size, &e.nmuzzy);
-		emitter_json_kv(
-		    emitter, "nretained", emitter_type_size, &e.nretained);
-		emitter_json_kv(
-		    emitter, "npinned", emitter_type_size, &e.npinned);
-
-		emitter_json_kv(
-		    emitter, "dirty_bytes", emitter_type_size, &e.dirty_bytes);
-		emitter_json_kv(
-		    emitter, "muzzy_bytes", emitter_type_size, &e.muzzy_bytes);
-		emitter_json_kv(emitter, "retained_bytes", emitter_type_size,
-		    &e.retained_bytes);
-		emitter_json_kv(emitter, "pinned_bytes", emitter_type_size,
-		    &e.pinned_bytes);
-		emitter_json_object_end(emitter);
-
-		char size_buf[48];
-		stats_size_col_set(&col_size, sz_pind2sz(j),
-		    j > 0 ? sz_pind2sz(j - 1) : 0, size_buf, sizeof(size_buf));
-		col_ind.unsigned_val = j;
-		col_ndirty.size_val = e.ndirty;
-		col_dirty.size_val = e.dirty_bytes;
-		col_nmuzzy.size_val = e.nmuzzy;
-		col_muzzy.size_val = e.muzzy_bytes;
-		col_nretained.size_val = e.nretained;
-		col_retained.size_val = e.retained_bytes;
-		col_npinned.size_val = e.npinned;
-		col_pinned.size_val = e.pinned_bytes;
-		col_ntotal.size_val = e.ntotal;
-		col_total.size_val = e.total_bytes;
-
-		emitter_table_sparse_row(emitter, &row, is_gap);
+		stats_arena_extent_emit_row_t emit_row = {&e, j, sz_pind2sz(j)};
+		stats_emit_arena_extent_row(emitter, &row, cols, &emit_row,
+		    j > 0 ? sz_pind2sz(j - 1) : 0, size_buf, sizeof(size_buf),
+		    is_gap);
 	}
 	emitter_json_array_end(emitter); /* Close "extents". */
 	emitter_table_sparse_end(emitter);
@@ -1319,59 +1530,133 @@ stats_arena_hpa_shard_counters_print(
 	emitter_json_array_end(emitter); /* End "alloc_batch" */
 }
 
+typedef struct {
+	const stats_arena_hpa_slab_t *slab;
+	const char                   *size_title;
+	size_t                        size;
+	size_t                        prev_size;
+	unsigned                      ind;
+} stats_arena_hpa_slab_emit_row_t;
+
+#define HPA_SLAB_COL_GET(name)                                                \
+	static void                                                            \
+	stats_hpa_slab_col_get_##name(const void *vrow, emitter_col_t *col) {   \
+		const stats_arena_hpa_slab_emit_row_t *row = vrow;               \
+		col->size_val = row->slab->name;                                 \
+	}
+HPA_SLAB_COL_GET(npageslabs_huge)
+HPA_SLAB_COL_GET(nactive_huge)
+HPA_SLAB_COL_GET(ndirty_huge)
+HPA_SLAB_COL_GET(npageslabs_nonhuge)
+HPA_SLAB_COL_GET(nactive_nonhuge)
+HPA_SLAB_COL_GET(ndirty_nonhuge)
+HPA_SLAB_COL_GET(nretained_nonhuge)
+#undef HPA_SLAB_COL_GET
+
 static void
-stats_emit_arena_hpa_slab_json(emitter_t *emitter,
-    const stats_arena_hpa_slab_t *s, const char *json_key) {
-	emitter_json_object_kv_begin(emitter, json_key);
-	emitter_json_kv(
-	    emitter, "npageslabs_huge", emitter_type_size, &s->npageslabs_huge);
-	emitter_json_kv(
-	    emitter, "nactive_huge", emitter_type_size, &s->nactive_huge);
-	emitter_json_kv(
-	    emitter, "ndirty_huge", emitter_type_size, &s->ndirty_huge);
-	emitter_json_kv(emitter, "npageslabs_nonhuge", emitter_type_size,
-	    &s->npageslabs_nonhuge);
-	emitter_json_kv(
-	    emitter, "nactive_nonhuge", emitter_type_size, &s->nactive_nonhuge);
-	emitter_json_kv(
-	    emitter, "ndirty_nonhuge", emitter_type_size, &s->ndirty_nonhuge);
-	emitter_json_kv(emitter, "nretained_nonhuge", emitter_type_size,
-	    &s->nretained_nonhuge);
-	emitter_json_object_end(emitter);
+stats_hpa_slab_col_get_size(const void *vrow, emitter_col_t *col) {
+	const stats_arena_hpa_slab_emit_row_t *row = vrow;
+	if (row->size_title != NULL) {
+		col->type = emitter_type_title;
+		col->str_val = row->size_title;
+	} else {
+		col->size_val = row->size;
+	}
 }
 
-/* Fill the shared count columns of one pageslab row from s. */
 static void
-stats_hpa_slab_cols_set(const stats_arena_hpa_slab_t *s,
-    emitter_col_t *npageslabs_huge, emitter_col_t *nactive_huge,
-    emitter_col_t *ndirty_huge, emitter_col_t *npageslabs_nonhuge,
-    emitter_col_t *nactive_nonhuge, emitter_col_t *ndirty_nonhuge,
-    emitter_col_t *nretained_nonhuge) {
-	npageslabs_huge->size_val = s->npageslabs_huge;
-	nactive_huge->size_val = s->nactive_huge;
-	ndirty_huge->size_val = s->ndirty_huge;
-	npageslabs_nonhuge->size_val = s->npageslabs_nonhuge;
-	nactive_nonhuge->size_val = s->nactive_nonhuge;
-	ndirty_nonhuge->size_val = s->ndirty_nonhuge;
-	nretained_nonhuge->size_val = s->nretained_nonhuge;
+stats_hpa_slab_col_get_ind(const void *vrow, emitter_col_t *col) {
+	const stats_arena_hpa_slab_emit_row_t *row = vrow;
+	if (row->size_title != NULL) {
+		col->type = emitter_type_title;
+		col->str_val = "-";
+	} else {
+		col->unsigned_val = row->ind;
+	}
+}
+
+enum {
+	HPA_SLAB_COL_SIZE,
+	HPA_SLAB_COL_IND,
+	HPA_SLAB_COL_NPAGESLABS_HUGE,
+	HPA_SLAB_COL_NACTIVE_HUGE,
+	HPA_SLAB_COL_NDIRTY_HUGE,
+	HPA_SLAB_COL_NPAGESLABS_NONHUGE,
+	HPA_SLAB_COL_NACTIVE_NONHUGE,
+	HPA_SLAB_COL_NDIRTY_NONHUGE,
+	HPA_SLAB_COL_NRETAINED_NONHUGE,
+	HPA_SLAB_COL_COUNT
+};
+
+#define HPA_SLAB_DESC(name, width)                                            \
+	{#name, #name, emitter_justify_right, width, emitter_type_size,          \
+	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_##name}
+static const emitter_col_desc_t stats_hpa_slab_cols[] = {
+	{NULL, "size", emitter_justify_right, 20, emitter_type_size,
+	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_size},
+	{NULL, "ind", emitter_justify_right, 4, emitter_type_unsigned,
+	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_ind},
+	HPA_SLAB_DESC(npageslabs_huge, 16),
+	HPA_SLAB_DESC(nactive_huge, 16),
+	HPA_SLAB_DESC(ndirty_huge, 16),
+	HPA_SLAB_DESC(npageslabs_nonhuge, 20),
+	HPA_SLAB_DESC(nactive_nonhuge, 20),
+	HPA_SLAB_DESC(ndirty_nonhuge, 20),
+	HPA_SLAB_DESC(nretained_nonhuge, 20),
+};
+#undef HPA_SLAB_DESC
+_Static_assert(
+    sizeof(stats_hpa_slab_cols) / sizeof(stats_hpa_slab_cols[0]) ==
+    HPA_SLAB_COL_COUNT,
+    "stats_hpa_slab_cols must match HPA_SLAB_COL_COUNT");
+
+static const unsigned stats_hpa_slab_json_order[] = {
+	HPA_SLAB_COL_NPAGESLABS_HUGE,
+	HPA_SLAB_COL_NACTIVE_HUGE,
+	HPA_SLAB_COL_NDIRTY_HUGE,
+	HPA_SLAB_COL_NPAGESLABS_NONHUGE,
+	HPA_SLAB_COL_NACTIVE_NONHUGE,
+	HPA_SLAB_COL_NDIRTY_NONHUGE,
+	HPA_SLAB_COL_NRETAINED_NONHUGE,
+};
+
+static void
+stats_emit_arena_hpa_slab_row(emitter_t *emitter,
+    emitter_row_t *table_row, emitter_col_t *cols,
+    const stats_arena_hpa_slab_emit_row_t *row, const char *json_key,
+    char *size_buf, size_t size_buf_size, bool sparse, bool is_gap) {
+	emitter_col_table_fill(stats_hpa_slab_cols, HPA_SLAB_COL_COUNT,
+	    STATS_COL_FLAG_NONE, cols, row);
+	if (row->size_title == NULL) {
+		stats_size_col_set(&cols[HPA_SLAB_COL_SIZE], row->size,
+		    row->prev_size, size_buf, size_buf_size);
+	}
+	if (json_key != NULL) {
+		emitter_json_object_kv_begin(emitter, json_key);
+	} else {
+		emitter_json_object_begin(emitter);
+	}
+	emitter_col_table_emit_json(emitter, stats_hpa_slab_cols,
+	    HPA_SLAB_COL_COUNT, STATS_COL_FLAG_NONE, cols,
+	    stats_hpa_slab_json_order,
+	    sizeof(stats_hpa_slab_json_order) /
+	        sizeof(stats_hpa_slab_json_order[0]));
+	emitter_json_object_end(emitter);
+	if (sparse) {
+		emitter_table_sparse_row(emitter, table_row, is_gap);
+	} else {
+		emitter_table_row(emitter, table_row);
+	}
 }
 
 static void
 stats_arena_hpa_shard_slabs_print(emitter_t *emitter, unsigned i) {
-	emitter_row_t header_row;
-	emitter_row_init(&header_row);
-	emitter_row_t row;
-	emitter_row_init(&row);
-
-	COL_HDR(row, size, NULL, right, 20, size)
-	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, npageslabs_huge, NULL, right, 16, size)
-	COL_HDR(row, nactive_huge, NULL, right, 16, size)
-	COL_HDR(row, ndirty_huge, NULL, right, 16, size)
-	COL_HDR(row, npageslabs_nonhuge, NULL, right, 20, size)
-	COL_HDR(row, nactive_nonhuge, NULL, right, 20, size)
-	COL_HDR(row, ndirty_nonhuge, NULL, right, 20, size)
-	COL_HDR(row, nretained_nonhuge, NULL, right, 20, size)
+	emitter_row_t row, header_row;
+	emitter_col_t cols[HPA_SLAB_COL_COUNT];
+	emitter_col_t header_cols[HPA_SLAB_COL_COUNT];
+	char size_buf[48];
+	emitter_col_table_build(stats_hpa_slab_cols, HPA_SLAB_COL_COUNT,
+	    STATS_COL_FLAG_NONE, &row, cols, &header_row, header_cols);
 
 	emitter_table_printf(emitter, "pageslabs:\n");
 	emitter_table_row(emitter, &header_row);
@@ -1381,31 +1666,19 @@ stats_arena_hpa_shard_slabs_print(emitter_t *emitter, unsigned i) {
 	 * "full"/"empty", no size-class index) at the top of the table; their
 	 * JSON stays in the separate full_slabs / empty_slabs objects.
 	 */
-	col_ind.type = emitter_type_title;
-	col_ind.str_val = "-";
-	col_size.type = emitter_type_title;
-
 	stats_arena_hpa_slab_t sfull;
 	stats_gather_arena_hpa_slab(i, "full_slabs", &sfull);
-	stats_emit_arena_hpa_slab_json(emitter, &sfull, "full_slabs");
-	col_size.str_val = "full";
-	stats_hpa_slab_cols_set(&sfull, &col_npageslabs_huge, &col_nactive_huge,
-	    &col_ndirty_huge, &col_npageslabs_nonhuge, &col_nactive_nonhuge,
-	    &col_ndirty_nonhuge, &col_nretained_nonhuge);
-	emitter_table_row(emitter, &row);
+	stats_arena_hpa_slab_emit_row_t full_row = {
+	    &sfull, "full", 0, 0, 0};
+	stats_emit_arena_hpa_slab_row(emitter, &row, cols, &full_row,
+	    "full_slabs", size_buf, sizeof(size_buf), false, false);
 
 	stats_arena_hpa_slab_t sempty;
 	stats_gather_arena_hpa_slab(i, "empty_slabs", &sempty);
-	stats_emit_arena_hpa_slab_json(emitter, &sempty, "empty_slabs");
-	col_size.str_val = "empty";
-	stats_hpa_slab_cols_set(&sempty, &col_npageslabs_huge, &col_nactive_huge,
-	    &col_ndirty_huge, &col_npageslabs_nonhuge, &col_nactive_nonhuge,
-	    &col_ndirty_nonhuge, &col_nretained_nonhuge);
-	emitter_table_row(emitter, &row);
-
-	/* Numeric size/ind for the per-size-class rows below. */
-	col_size.type = emitter_type_size;
-	col_ind.type = emitter_type_unsigned;
+	stats_arena_hpa_slab_emit_row_t empty_row = {
+	    &sempty, "empty", 0, 0, 0};
+	stats_emit_arena_hpa_slab_row(emitter, &row, cols, &empty_row,
+	    "empty_slabs", size_buf, sizeof(size_buf), false, false);
 
 	size_t stats_arenas_mib[CTL_MAX_DEPTH];
 	CTL_LEAF_PREPARE(stats_arenas_mib, 0, "stats.arenas");
@@ -1420,35 +1693,11 @@ stats_arena_hpa_shard_slabs_print(emitter_t *emitter, unsigned i) {
 
 		bool is_gap = (s.npageslabs_huge == 0 && s.npageslabs_nonhuge == 0);
 
-		char size_buf[48];
-		stats_size_col_set(&col_size, sz_pind2sz(j),
-		    j > 0 ? sz_pind2sz(j - 1) : 0, size_buf, sizeof(size_buf));
-		col_ind.unsigned_val = j;
-		col_npageslabs_huge.size_val = s.npageslabs_huge;
-		col_nactive_huge.size_val = s.nactive_huge;
-		col_ndirty_huge.size_val = s.ndirty_huge;
-		col_npageslabs_nonhuge.size_val = s.npageslabs_nonhuge;
-		col_nactive_nonhuge.size_val = s.nactive_nonhuge;
-		col_ndirty_nonhuge.size_val = s.ndirty_nonhuge;
-		col_nretained_nonhuge.size_val = s.nretained_nonhuge;
-		emitter_table_sparse_row(emitter, &row, is_gap);
-
-		emitter_json_object_begin(emitter);
-		emitter_json_kv(emitter, "npageslabs_huge", emitter_type_size,
-		    &s.npageslabs_huge);
-		emitter_json_kv(
-		    emitter, "nactive_huge", emitter_type_size, &s.nactive_huge);
-		emitter_json_kv(
-		    emitter, "ndirty_huge", emitter_type_size, &s.ndirty_huge);
-		emitter_json_kv(emitter, "npageslabs_nonhuge",
-		    emitter_type_size, &s.npageslabs_nonhuge);
-		emitter_json_kv(emitter, "nactive_nonhuge", emitter_type_size,
-		    &s.nactive_nonhuge);
-		emitter_json_kv(emitter, "ndirty_nonhuge", emitter_type_size,
-		    &s.ndirty_nonhuge);
-		emitter_json_kv(emitter, "nretained_nonhuge", emitter_type_size,
-		    &s.nretained_nonhuge);
-		emitter_json_object_end(emitter);
+		stats_arena_hpa_slab_emit_row_t emit_row = {
+		    &s, NULL, sz_pind2sz(j),
+		    j > 0 ? sz_pind2sz(j - 1) : 0, j};
+		stats_emit_arena_hpa_slab_row(emitter, &row, cols, &emit_row,
+		    NULL, size_buf, sizeof(size_buf), true, is_gap);
 	}
 	emitter_json_array_end(emitter); /* End "nonfull_slabs" */
 	emitter_table_sparse_end(emitter);

--- a/src/stats.c
+++ b/src/stats.c
@@ -782,54 +782,27 @@ stats_bin_col_get_util(const void *vrow, emitter_col_t *col) {
 	col->str_val = row->util;
 }
 
-enum {
-	BIN_COL_SIZE,
-	BIN_COL_IND,
-	BIN_COL_ALLOCATED,
-	BIN_COL_NMALLOC,
-	BIN_COL_NMALLOC_PS,
-	BIN_COL_NDALLOC,
-	BIN_COL_NDALLOC_PS,
-	BIN_COL_NREQUESTS,
-	BIN_COL_NREQUESTS_PS,
-	BIN_COL_PROF_LIVE_REQUESTED,
-	BIN_COL_PROF_LIVE_COUNT,
-	BIN_COL_PROF_ACCUM_REQUESTED,
-	BIN_COL_PROF_ACCUM_COUNT,
-	BIN_COL_NSHARDS,
-	BIN_COL_CURREGS,
-	BIN_COL_CURSLABS,
-	BIN_COL_NONFULL_SLABS,
-	BIN_COL_REGS,
-	BIN_COL_PGS,
-	BIN_COL_SPACER,
-	BIN_COL_UTIL,
-	BIN_COL_NFILLS,
-	BIN_COL_NFILLS_PS,
-	BIN_COL_NFLUSHES,
-	BIN_COL_NFLUSHES_PS,
-	BIN_COL_NSLABS,
-	BIN_COL_NRESLABS,
-	BIN_COL_NRESLABS_PS,
-	BIN_COL_COUNT
-};
+#define BIN_COL_SIZE 0
 
 #define BIN_DESC(key, label, width, type, flags, name)                        \
 	{key, label, emitter_justify_right, width, emitter_type_##type, flags,   \
 	    stats_bin_col_get_##name}
 static const emitter_col_desc_t stats_bin_cols[] = {
-	BIN_DESC(NULL, "size", 20, size, STATS_COL_FLAG_NONE, size),
-	BIN_DESC(NULL, "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
-	BIN_DESC(NULL, "allocated", 14, size, STATS_COL_FLAG_NONE, allocated),
+	BIN_DESC("size", "size", 20, size, STATS_COL_FLAG_NONE, size),
+	BIN_DESC("ind", "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
+	BIN_DESC("allocated", "allocated", 14, size, STATS_COL_FLAG_NONE,
+	    allocated),
 	BIN_DESC("nmalloc", "nmalloc", 14, uint64, STATS_COL_FLAG_NONE,
 	    nmalloc),
-	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, nmalloc_ps),
+	BIN_DESC("nmalloc_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nmalloc_ps),
 	BIN_DESC("ndalloc", "ndalloc", 14, uint64, STATS_COL_FLAG_NONE,
 	    ndalloc),
-	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, ndalloc_ps),
+	BIN_DESC("ndalloc_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    ndalloc_ps),
 	BIN_DESC("nrequests", "nrequests", 15, uint64, STATS_COL_FLAG_NONE,
 	    nrequests),
-	BIN_DESC(NULL, "(#/sec)", 10, uint64, STATS_COL_FLAG_NONE,
+	BIN_DESC("nrequests_ps", "(#/sec)", 10, uint64, STATS_COL_FLAG_NONE,
 	    nrequests_ps),
 	BIN_DESC("prof_live_requested", "prof_live_requested", 21, uint64,
 	    STATS_COL_FLAG_PROF, prof_live_requested),
@@ -839,48 +812,33 @@ static const emitter_col_desc_t stats_bin_cols[] = {
 	    STATS_COL_FLAG_PROF, prof_accum_requested),
 	BIN_DESC("prof_accum_count", "prof_accum_count", 17, uint64,
 	    STATS_COL_FLAG_PROF, prof_accum_count),
-	BIN_DESC(NULL, "nshards", 9, unsigned, STATS_COL_FLAG_NONE, nshards),
+	BIN_DESC("nshards", "nshards", 9, unsigned, STATS_COL_FLAG_NONE,
+	    nshards),
 	BIN_DESC("curregs", "curregs", 13, size, STATS_COL_FLAG_NONE, curregs),
 	BIN_DESC("curslabs", "curslabs", 13, size, STATS_COL_FLAG_NONE,
 	    curslabs),
 	BIN_DESC("nonfull_slabs", "nonfull_slabs", 15, size,
 	    STATS_COL_FLAG_NONE,
 	    nonfull_slabs),
-	BIN_DESC(NULL, "regs", 5, unsigned, STATS_COL_FLAG_NONE, regs),
-	BIN_DESC(NULL, "pgs", 4, size, STATS_COL_FLAG_NONE, pgs),
+	BIN_DESC("regs", "regs", 5, unsigned, STATS_COL_FLAG_NONE, regs),
+	BIN_DESC("pgs", "pgs", 4, size, STATS_COL_FLAG_NONE, pgs),
 	BIN_DESC(NULL, " ", 1, title, STATS_COL_FLAG_NONE, spacer),
-	BIN_DESC(NULL, "util", 6, title, STATS_COL_FLAG_NONE, util),
+	BIN_DESC("util", "util", 6, title, STATS_COL_FLAG_NONE, util),
 	BIN_DESC("nfills", "nfills", 13, uint64, STATS_COL_FLAG_NONE, nfills),
-	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE, nfills_ps),
+	BIN_DESC("nfills_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	    nfills_ps),
 	BIN_DESC("nflushes", "nflushes", 13, uint64, STATS_COL_FLAG_NONE,
 	    nflushes),
-	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	BIN_DESC("nflushes_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
 	    nflushes_ps),
-	BIN_DESC(NULL, "nslabs", 13, uint64, STATS_COL_FLAG_NONE, nslabs),
+	BIN_DESC("nslabs", "nslabs", 13, uint64, STATS_COL_FLAG_NONE, nslabs),
 	BIN_DESC("nreslabs", "nreslabs", 13, uint64, STATS_COL_FLAG_NONE,
 	    nreslabs),
-	BIN_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	BIN_DESC("nreslabs_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
 	    nreslabs_ps),
 };
 #undef BIN_DESC
-_Static_assert(sizeof(stats_bin_cols) / sizeof(stats_bin_cols[0]) ==
-    BIN_COL_COUNT, "stats_bin_cols must match BIN_COL_COUNT");
-
-static const unsigned stats_bin_json_order[] = {
-	BIN_COL_NMALLOC,
-	BIN_COL_NDALLOC,
-	BIN_COL_CURREGS,
-	BIN_COL_NREQUESTS,
-	BIN_COL_PROF_LIVE_REQUESTED,
-	BIN_COL_PROF_LIVE_COUNT,
-	BIN_COL_PROF_ACCUM_REQUESTED,
-	BIN_COL_PROF_ACCUM_COUNT,
-	BIN_COL_NFILLS,
-	BIN_COL_NFLUSHES,
-	BIN_COL_NRESLABS,
-	BIN_COL_CURSLABS,
-	BIN_COL_NONFULL_SLABS,
-};
+#define BIN_COL_COUNT (sizeof(stats_bin_cols) / sizeof(stats_bin_cols[0]))
 
 static void
 stats_emit_arena_bin_row(emitter_t *emitter, emitter_row_t *table_row,
@@ -892,8 +850,7 @@ stats_emit_arena_bin_row(emitter_t *emitter, emitter_row_t *table_row,
 	    stats_bin_cols, BIN_COL_COUNT, active_flags, cols, row);
 	emitter_json_object_begin(emitter);
 	emitter_col_table_emit_json(emitter, stats_bin_cols, BIN_COL_COUNT,
-	    active_flags, cols, stats_bin_json_order,
-	    sizeof(stats_bin_json_order) / sizeof(stats_bin_json_order[0]));
+	    active_flags, cols);
 	if (mutex) {
 		emitter_json_object_kv_begin(emitter, "mutex");
 		mutex_stats_emit(emitter, NULL, mutex64, mutex32);
@@ -1068,41 +1025,29 @@ stats_lextent_col_get_allocated(const void *vrow, emitter_col_t *col) {
 	col->size_val = row->lextent->curlextents * row->lextent->lextent_size;
 }
 
-enum {
-	LEXTENT_COL_SIZE,
-	LEXTENT_COL_IND,
-	LEXTENT_COL_ALLOCATED,
-	LEXTENT_COL_NMALLOC,
-	LEXTENT_COL_NMALLOC_PS,
-	LEXTENT_COL_NDALLOC,
-	LEXTENT_COL_NDALLOC_PS,
-	LEXTENT_COL_NREQUESTS,
-	LEXTENT_COL_NREQUESTS_PS,
-	LEXTENT_COL_PROF_LIVE_REQUESTED,
-	LEXTENT_COL_PROF_LIVE_COUNT,
-	LEXTENT_COL_PROF_ACCUM_REQUESTED,
-	LEXTENT_COL_PROF_ACCUM_COUNT,
-	LEXTENT_COL_CURLEXTENTS,
-	LEXTENT_COL_COUNT
-};
+#define LEXTENT_COL_SIZE 0
 
 #define LEXTENT_DESC(key, label, width, type, flags, name)                    \
 	{key, label, emitter_justify_right, width, emitter_type_##type, flags,   \
 	    stats_lextent_col_get_##name}
 static const emitter_col_desc_t stats_lextent_cols[] = {
-	LEXTENT_DESC(NULL, "size", 20, size, STATS_COL_FLAG_NONE, size),
-	LEXTENT_DESC(NULL, "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
-	LEXTENT_DESC(NULL, "allocated", 13, size, STATS_COL_FLAG_NONE,
+	LEXTENT_DESC("size", "size", 20, size, STATS_COL_FLAG_NONE, size),
+	LEXTENT_DESC("ind", "ind", 4, unsigned, STATS_COL_FLAG_NONE, ind),
+	LEXTENT_DESC("allocated", "allocated", 13, size, STATS_COL_FLAG_NONE,
 	    allocated),
-	LEXTENT_DESC(NULL, "nmalloc", 13, uint64, STATS_COL_FLAG_NONE, nmalloc),
-	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	LEXTENT_DESC("nmalloc", "nmalloc", 13, uint64, STATS_COL_FLAG_NONE,
+	    nmalloc),
+	LEXTENT_DESC("nmalloc_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
 	    nmalloc_ps),
-	LEXTENT_DESC(NULL, "ndalloc", 13, uint64, STATS_COL_FLAG_NONE, ndalloc),
-	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	LEXTENT_DESC("ndalloc", "ndalloc", 13, uint64, STATS_COL_FLAG_NONE,
+	    ndalloc),
+	LEXTENT_DESC("ndalloc_ps", "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
 	    ndalloc_ps),
-	LEXTENT_DESC(NULL, "nrequests", 13, uint64, STATS_COL_FLAG_NONE,
+	LEXTENT_DESC("nrequests", "nrequests", 13, uint64,
+	    STATS_COL_FLAG_NONE,
 	    nrequests),
-	LEXTENT_DESC(NULL, "(#/sec)", 8, uint64, STATS_COL_FLAG_NONE,
+	LEXTENT_DESC("nrequests_ps", "(#/sec)", 8, uint64,
+	    STATS_COL_FLAG_NONE,
 	    nrequests_ps),
 	LEXTENT_DESC("prof_live_requested", "prof_live_requested", 21, uint64,
 	    STATS_COL_FLAG_PROF, prof_live_requested),
@@ -1116,16 +1061,8 @@ static const emitter_col_desc_t stats_lextent_cols[] = {
 	    STATS_COL_FLAG_NONE, curlextents),
 };
 #undef LEXTENT_DESC
-_Static_assert(sizeof(stats_lextent_cols) / sizeof(stats_lextent_cols[0]) ==
-    LEXTENT_COL_COUNT, "stats_lextent_cols must match LEXTENT_COL_COUNT");
-
-static const unsigned stats_lextent_json_order[] = {
-	LEXTENT_COL_PROF_LIVE_REQUESTED,
-	LEXTENT_COL_PROF_LIVE_COUNT,
-	LEXTENT_COL_PROF_ACCUM_REQUESTED,
-	LEXTENT_COL_PROF_ACCUM_COUNT,
-	LEXTENT_COL_CURLEXTENTS,
-};
+#define LEXTENT_COL_COUNT                                                      \
+	(sizeof(stats_lextent_cols) / sizeof(stats_lextent_cols[0]))
 
 static void
 stats_emit_arena_lextent_row(emitter_t *emitter, emitter_row_t *table_row,
@@ -1135,15 +1072,13 @@ stats_emit_arena_lextent_row(emitter_t *emitter, emitter_row_t *table_row,
 	unsigned active_flags = stats_col_active_flags(prof_stats_on);
 	emitter_col_table_fill(stats_lextent_cols, LEXTENT_COL_COUNT,
 	    active_flags, cols, row);
-	stats_size_col_set(&cols[LEXTENT_COL_SIZE], row->lextent->lextent_size,
-	    prev_size, size_buf, size_buf_size);
 	emitter_json_object_begin(emitter);
 	emitter_col_table_emit_json(emitter, stats_lextent_cols,
-	    LEXTENT_COL_COUNT, active_flags, cols, stats_lextent_json_order,
-	    sizeof(stats_lextent_json_order) /
-	        sizeof(stats_lextent_json_order[0]));
-	emitter_table_sparse_row(emitter, table_row, is_gap);
+	    LEXTENT_COL_COUNT, active_flags, cols);
 	emitter_json_object_end(emitter);
+	stats_size_col_set(&cols[LEXTENT_COL_SIZE], row->lextent->lextent_size,
+	    prev_size, size_buf, size_buf_size);
+	emitter_table_sparse_row(emitter, table_row, is_gap);
 }
 
 JEMALLOC_COLD
@@ -1242,29 +1177,15 @@ stats_extent_col_get_ind(const void *vrow, emitter_col_t *col) {
 	col->unsigned_val = row->ind;
 }
 
-enum {
-	EXTENT_COL_SIZE,
-	EXTENT_COL_IND,
-	EXTENT_COL_NDIRTY,
-	EXTENT_COL_DIRTY,
-	EXTENT_COL_NMUZZY,
-	EXTENT_COL_MUZZY,
-	EXTENT_COL_NRETAINED,
-	EXTENT_COL_RETAINED,
-	EXTENT_COL_NPINNED,
-	EXTENT_COL_PINNED,
-	EXTENT_COL_NTOTAL,
-	EXTENT_COL_TOTAL,
-	EXTENT_COL_COUNT
-};
+#define EXTENT_COL_SIZE 0
 
 #define EXTENT_DESC(key, label, name)                                         \
 	{key, label, emitter_justify_right, 13, emitter_type_size,               \
 	    STATS_COL_FLAG_NONE, stats_extent_col_get_##name}
 static const emitter_col_desc_t stats_extent_cols[] = {
-	{NULL, "size", emitter_justify_right, 20, emitter_type_size,
+	{"size", "size", emitter_justify_right, 20, emitter_type_size,
 	    STATS_COL_FLAG_NONE, stats_extent_col_get_size},
-	{NULL, "ind", emitter_justify_right, 4, emitter_type_unsigned,
+	{"ind", "ind", emitter_justify_right, 4, emitter_type_unsigned,
 	    STATS_COL_FLAG_NONE, stats_extent_col_get_ind},
 	EXTENT_DESC("ndirty", "ndirty", ndirty),
 	EXTENT_DESC("dirty_bytes", "dirty", dirty),
@@ -1274,23 +1195,12 @@ static const emitter_col_desc_t stats_extent_cols[] = {
 	EXTENT_DESC("retained_bytes", "retained", retained),
 	EXTENT_DESC("npinned", "npinned", npinned),
 	EXTENT_DESC("pinned_bytes", "pinned", pinned),
-	EXTENT_DESC(NULL, "ntotal", ntotal),
-	EXTENT_DESC(NULL, "total", total),
+	EXTENT_DESC("ntotal", "ntotal", ntotal),
+	EXTENT_DESC("total_bytes", "total", total),
 };
 #undef EXTENT_DESC
-_Static_assert(sizeof(stats_extent_cols) / sizeof(stats_extent_cols[0]) ==
-    EXTENT_COL_COUNT, "stats_extent_cols must match EXTENT_COL_COUNT");
-
-static const unsigned stats_extent_json_order[] = {
-	EXTENT_COL_NDIRTY,
-	EXTENT_COL_NMUZZY,
-	EXTENT_COL_NRETAINED,
-	EXTENT_COL_NPINNED,
-	EXTENT_COL_DIRTY,
-	EXTENT_COL_MUZZY,
-	EXTENT_COL_RETAINED,
-	EXTENT_COL_PINNED,
-};
+#define EXTENT_COL_COUNT                                                       \
+	(sizeof(stats_extent_cols) / sizeof(stats_extent_cols[0]))
 
 static void
 stats_emit_arena_extent_row(emitter_t *emitter, emitter_row_t *table_row,
@@ -1298,14 +1208,12 @@ stats_emit_arena_extent_row(emitter_t *emitter, emitter_row_t *table_row,
     size_t prev_size, char *size_buf, size_t size_buf_size, bool is_gap) {
 	emitter_col_table_fill(stats_extent_cols, EXTENT_COL_COUNT,
 	    STATS_COL_FLAG_NONE, cols, row);
-	stats_size_col_set(&cols[EXTENT_COL_SIZE], row->size, prev_size,
-	    size_buf, size_buf_size);
 	emitter_json_object_begin(emitter);
 	emitter_col_table_emit_json(emitter, stats_extent_cols, EXTENT_COL_COUNT,
-	    STATS_COL_FLAG_NONE, cols, stats_extent_json_order,
-	    sizeof(stats_extent_json_order) /
-	        sizeof(stats_extent_json_order[0]));
+	    STATS_COL_FLAG_NONE, cols);
 	emitter_json_object_end(emitter);
+	stats_size_col_set(&cols[EXTENT_COL_SIZE], row->size, prev_size,
+	    size_buf, size_buf_size);
 	emitter_table_sparse_row(emitter, table_row, is_gap);
 }
 
@@ -1575,26 +1483,15 @@ stats_hpa_slab_col_get_ind(const void *vrow, emitter_col_t *col) {
 	}
 }
 
-enum {
-	HPA_SLAB_COL_SIZE,
-	HPA_SLAB_COL_IND,
-	HPA_SLAB_COL_NPAGESLABS_HUGE,
-	HPA_SLAB_COL_NACTIVE_HUGE,
-	HPA_SLAB_COL_NDIRTY_HUGE,
-	HPA_SLAB_COL_NPAGESLABS_NONHUGE,
-	HPA_SLAB_COL_NACTIVE_NONHUGE,
-	HPA_SLAB_COL_NDIRTY_NONHUGE,
-	HPA_SLAB_COL_NRETAINED_NONHUGE,
-	HPA_SLAB_COL_COUNT
-};
+#define HPA_SLAB_COL_SIZE 0
 
 #define HPA_SLAB_DESC(name, width)                                            \
 	{#name, #name, emitter_justify_right, width, emitter_type_size,          \
 	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_##name}
 static const emitter_col_desc_t stats_hpa_slab_cols[] = {
-	{NULL, "size", emitter_justify_right, 20, emitter_type_size,
+	{"size", "size", emitter_justify_right, 20, emitter_type_size,
 	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_size},
-	{NULL, "ind", emitter_justify_right, 4, emitter_type_unsigned,
+	{"ind", "ind", emitter_justify_right, 4, emitter_type_unsigned,
 	    STATS_COL_FLAG_NONE, stats_hpa_slab_col_get_ind},
 	HPA_SLAB_DESC(npageslabs_huge, 16),
 	HPA_SLAB_DESC(nactive_huge, 16),
@@ -1605,20 +1502,8 @@ static const emitter_col_desc_t stats_hpa_slab_cols[] = {
 	HPA_SLAB_DESC(nretained_nonhuge, 20),
 };
 #undef HPA_SLAB_DESC
-_Static_assert(
-    sizeof(stats_hpa_slab_cols) / sizeof(stats_hpa_slab_cols[0]) ==
-    HPA_SLAB_COL_COUNT,
-    "stats_hpa_slab_cols must match HPA_SLAB_COL_COUNT");
-
-static const unsigned stats_hpa_slab_json_order[] = {
-	HPA_SLAB_COL_NPAGESLABS_HUGE,
-	HPA_SLAB_COL_NACTIVE_HUGE,
-	HPA_SLAB_COL_NDIRTY_HUGE,
-	HPA_SLAB_COL_NPAGESLABS_NONHUGE,
-	HPA_SLAB_COL_NACTIVE_NONHUGE,
-	HPA_SLAB_COL_NDIRTY_NONHUGE,
-	HPA_SLAB_COL_NRETAINED_NONHUGE,
-};
+#define HPA_SLAB_COL_COUNT                                                     \
+	(sizeof(stats_hpa_slab_cols) / sizeof(stats_hpa_slab_cols[0]))
 
 static void
 stats_emit_arena_hpa_slab_row(emitter_t *emitter,
@@ -1627,21 +1512,18 @@ stats_emit_arena_hpa_slab_row(emitter_t *emitter,
     char *size_buf, size_t size_buf_size, bool sparse, bool is_gap) {
 	emitter_col_table_fill(stats_hpa_slab_cols, HPA_SLAB_COL_COUNT,
 	    STATS_COL_FLAG_NONE, cols, row);
-	if (row->size_title == NULL) {
-		stats_size_col_set(&cols[HPA_SLAB_COL_SIZE], row->size,
-		    row->prev_size, size_buf, size_buf_size);
-	}
 	if (json_key != NULL) {
 		emitter_json_object_kv_begin(emitter, json_key);
 	} else {
 		emitter_json_object_begin(emitter);
 	}
 	emitter_col_table_emit_json(emitter, stats_hpa_slab_cols,
-	    HPA_SLAB_COL_COUNT, STATS_COL_FLAG_NONE, cols,
-	    stats_hpa_slab_json_order,
-	    sizeof(stats_hpa_slab_json_order) /
-	        sizeof(stats_hpa_slab_json_order[0]));
+	    HPA_SLAB_COL_COUNT, STATS_COL_FLAG_NONE, cols);
 	emitter_json_object_end(emitter);
+	if (row->size_title == NULL) {
+		stats_size_col_set(&cols[HPA_SLAB_COL_SIZE], row->size,
+		    row->prev_size, size_buf, size_buf_size);
+	}
 	if (sparse) {
 		emitter_table_sparse_row(emitter, table_row, is_gap);
 	} else {

--- a/test/unit/emitter.c
+++ b/test/unit/emitter.c
@@ -668,6 +668,111 @@ static const char *sparse_row_table =
     "     2\n"
     "                     ---\n";
 
+typedef struct {
+	size_t   size;
+	uint64_t count;
+	uint64_t prof_count;
+	uint64_t requests;
+} col_table_test_row_t;
+
+#define COL_TABLE_TEST_GETTER(name, member, value_member)                     \
+	static void                                                            \
+	col_table_test_get_##name(const void *vrow, emitter_col_t *col) {       \
+		const col_table_test_row_t *row = vrow;                          \
+		col->value_member = row->member;                                 \
+	}
+COL_TABLE_TEST_GETTER(size, size, size_val)
+COL_TABLE_TEST_GETTER(count, count, uint64_val)
+COL_TABLE_TEST_GETTER(prof_count, prof_count, uint64_val)
+COL_TABLE_TEST_GETTER(requests, requests, uint64_val)
+#undef COL_TABLE_TEST_GETTER
+
+enum {
+	COL_TABLE_TEST_SIZE,
+	COL_TABLE_TEST_COUNT,
+	COL_TABLE_TEST_PROF_COUNT,
+	COL_TABLE_TEST_REQUESTS,
+	COL_TABLE_TEST_NCOLS
+};
+
+#define COL_TABLE_TEST_FLAG_PROF (1U << 0)
+
+static const emitter_col_desc_t col_table_test_descs[] = {
+	{NULL, "size", emitter_justify_right, 8, emitter_type_size, 0,
+	    col_table_test_get_size},
+	{"count", "count", emitter_justify_right, 8, emitter_type_uint64,
+	    0, col_table_test_get_count},
+	{"prof_count", "prof", emitter_justify_right, 6, emitter_type_uint64,
+	    COL_TABLE_TEST_FLAG_PROF, col_table_test_get_prof_count},
+	{"requests", "requests", emitter_justify_right, 10,
+	    emitter_type_uint64, 0, col_table_test_get_requests},
+};
+_Static_assert(
+    sizeof(col_table_test_descs) / sizeof(col_table_test_descs[0]) ==
+    COL_TABLE_TEST_NCOLS,
+    "col_table_test_descs must match COL_TABLE_TEST_NCOLS");
+
+TEST_BEGIN(test_col_desc_flags) {
+	expect_true(emitter_col_desc_active(
+	    &col_table_test_descs[COL_TABLE_TEST_COUNT], 0),
+	    "A column without requirements should always be active");
+	expect_false(emitter_col_desc_active(
+	    &col_table_test_descs[COL_TABLE_TEST_PROF_COUNT], 0),
+	    "A column with an unmet requirement should be inactive");
+	expect_true(emitter_col_desc_active(
+	    &col_table_test_descs[COL_TABLE_TEST_PROF_COUNT],
+	    COL_TABLE_TEST_FLAG_PROF),
+	    "A column with a satisfied requirement should be active");
+}
+TEST_END
+
+static const unsigned col_table_test_json_order[] = {
+	COL_TABLE_TEST_REQUESTS,
+	COL_TABLE_TEST_PROF_COUNT,
+	COL_TABLE_TEST_COUNT,
+};
+
+static void
+emit_col_table(emitter_t *emitter) {
+	col_table_test_row_t value = {42, 7, 100, 9};
+	emitter_row_t row, header_row;
+	emitter_col_t cols[COL_TABLE_TEST_NCOLS];
+	emitter_col_t header_cols[COL_TABLE_TEST_NCOLS];
+
+	emitter_begin(emitter);
+	emitter_col_table_build(col_table_test_descs, COL_TABLE_TEST_NCOLS,
+	    COL_TABLE_TEST_FLAG_PROF, &row, cols, &header_row, header_cols);
+	emitter_col_table_header(
+	    emitter, &header_row, &header_cols[0], "mock:", "rows");
+	emitter_col_table_fill(col_table_test_descs, COL_TABLE_TEST_NCOLS,
+	    COL_TABLE_TEST_FLAG_PROF, cols, &value);
+	emitter_json_object_begin(emitter);
+	emitter_col_table_emit_json(emitter, col_table_test_descs,
+	    COL_TABLE_TEST_NCOLS, COL_TABLE_TEST_FLAG_PROF, cols,
+	    col_table_test_json_order, sizeof(col_table_test_json_order) /
+	        sizeof(col_table_test_json_order[0]));
+	emitter_json_object_end(emitter);
+	emitter_table_row(emitter, &row);
+	emitter_json_array_end(emitter);
+	emitter_end(emitter);
+}
+
+static const char *col_table_json =
+    "{\n"
+    "\t\"rows\": [\n"
+    "\t\t{\n"
+    "\t\t\t\"requests\": 9,\n"
+    "\t\t\t\"prof_count\": 100,\n"
+    "\t\t\t\"count\": 7\n"
+    "\t\t}\n"
+    "\t]\n"
+    "}\n";
+static const char *col_table_json_compact =
+    "{\"rows\":[{\"requests\":9,\"prof_count\":100,\"count\":7}]}";
+static const char *col_table_table =
+    "mock:size   count  prof  requests\n"
+    "      42       7   100         9\n";
+
 #define GENERATE_TEST(feature)                                                 \
 	TEST_BEGIN(test_##feature) {                                           \
 		expect_emit_output(emit_##feature, feature##_json,             \
@@ -685,10 +790,12 @@ GENERATE_TEST(json_nested_array)
 GENERATE_TEST(table_row)
 GENERATE_TEST(row)
 GENERATE_TEST(sparse_row)
+GENERATE_TEST(col_table)
 
 int
 main(void) {
 	return test_no_reentrancy(test_dict, test_table_printf,
 	    test_nested_dict, test_types, test_modal, test_json_array,
-	    test_json_nested_array, test_table_row, test_row, test_sparse_row);
+	    test_json_nested_array, test_table_row, test_row, test_sparse_row,
+	    test_col_table, test_col_desc_flags);
 }

--- a/test/unit/emitter.c
+++ b/test/unit/emitter.c
@@ -669,10 +669,11 @@ static const char *sparse_row_table =
     "                     ---\n";
 
 typedef struct {
-	size_t   size;
-	uint64_t count;
-	uint64_t prof_count;
-	uint64_t requests;
+	size_t      size;
+	uint64_t    count;
+	uint64_t    prof_count;
+	const char *label;
+	uint64_t    requests;
 } col_table_test_row_t;
 
 #define COL_TABLE_TEST_GETTER(name, member, value_member)                     \
@@ -684,6 +685,7 @@ typedef struct {
 COL_TABLE_TEST_GETTER(size, size, size_val)
 COL_TABLE_TEST_GETTER(count, count, uint64_val)
 COL_TABLE_TEST_GETTER(prof_count, prof_count, uint64_val)
+COL_TABLE_TEST_GETTER(label, label, str_val)
 COL_TABLE_TEST_GETTER(requests, requests, uint64_val)
 #undef COL_TABLE_TEST_GETTER
 
@@ -691,6 +693,7 @@ enum {
 	COL_TABLE_TEST_SIZE,
 	COL_TABLE_TEST_COUNT,
 	COL_TABLE_TEST_PROF_COUNT,
+	COL_TABLE_TEST_LABEL,
 	COL_TABLE_TEST_REQUESTS,
 	COL_TABLE_TEST_NCOLS
 };
@@ -704,6 +707,8 @@ static const emitter_col_desc_t col_table_test_descs[] = {
 	    0, col_table_test_get_count},
 	{"prof_count", "prof", emitter_justify_right, 6, emitter_type_uint64,
 	    COL_TABLE_TEST_FLAG_PROF, col_table_test_get_prof_count},
+	{"label", "label", emitter_justify_right, 7, emitter_type_title, 0,
+	    col_table_test_get_label},
 	{"requests", "requests", emitter_justify_right, 10,
 	    emitter_type_uint64, 0, col_table_test_get_requests},
 };
@@ -726,15 +731,9 @@ TEST_BEGIN(test_col_desc_flags) {
 }
 TEST_END
 
-static const unsigned col_table_test_json_order[] = {
-	COL_TABLE_TEST_REQUESTS,
-	COL_TABLE_TEST_PROF_COUNT,
-	COL_TABLE_TEST_COUNT,
-};
-
 static void
 emit_col_table(emitter_t *emitter) {
-	col_table_test_row_t value = {42, 7, 100, 9};
+	col_table_test_row_t value = {42, 7, 100, "row", 9};
 	emitter_row_t row, header_row;
 	emitter_col_t cols[COL_TABLE_TEST_NCOLS];
 	emitter_col_t header_cols[COL_TABLE_TEST_NCOLS];
@@ -748,9 +747,7 @@ emit_col_table(emitter_t *emitter) {
 	    COL_TABLE_TEST_FLAG_PROF, cols, &value);
 	emitter_json_object_begin(emitter);
 	emitter_col_table_emit_json(emitter, col_table_test_descs,
-	    COL_TABLE_TEST_NCOLS, COL_TABLE_TEST_FLAG_PROF, cols,
-	    col_table_test_json_order, sizeof(col_table_test_json_order) /
-	        sizeof(col_table_test_json_order[0]));
+	    COL_TABLE_TEST_NCOLS, COL_TABLE_TEST_FLAG_PROF, cols);
 	emitter_json_object_end(emitter);
 	emitter_table_row(emitter, &row);
 	emitter_json_array_end(emitter);
@@ -761,17 +758,19 @@ static const char *col_table_json =
     "{\n"
     "\t\"rows\": [\n"
     "\t\t{\n"
-    "\t\t\t\"requests\": 9,\n"
+    "\t\t\t\"count\": 7,\n"
     "\t\t\t\"prof_count\": 100,\n"
-    "\t\t\t\"count\": 7\n"
+    "\t\t\t\"label\": \"row\",\n"
+    "\t\t\t\"requests\": 9\n"
     "\t\t}\n"
     "\t]\n"
     "}\n";
 static const char *col_table_json_compact =
-    "{\"rows\":[{\"requests\":9,\"prof_count\":100,\"count\":7}]}";
+    "{\"rows\":[{\"count\":7,\"prof_count\":100,\"label\":\"row\","
+    "\"requests\":9}]}";
 static const char *col_table_table =
-    "mock:size   count  prof  requests\n"
-    "      42       7   100         9\n";
+    "mock:size   count  prof  label  requests\n"
+    "      42       7   100    row         9\n";
 
 #define GENERATE_TEST(feature)                                                 \
 	TEST_BEGIN(test_##feature) {                                           \

--- a/test/unit/json_stats.c
+++ b/test/unit/json_stats.c
@@ -442,6 +442,95 @@ expect_json_uint_eq(json_fragment_t object, const char *key,
 	    key);
 }
 
+static void
+expect_json_string_eq(json_fragment_t object, const char *key,
+    const char *expected, const char *name) {
+	json_fragment_t value;
+	bool missing = json_object_member(object, key, &value);
+	expect_false(missing, "%s is missing %s", name, key);
+	if (missing) {
+		return;
+	}
+	expect_true(json_fragment_string_eq(value, expected),
+	    "%s.%s has an unexpected value", name, key);
+}
+
+static uint64_t
+expected_rate(uint64_t value, uint64_t uptime_ns) {
+	const uint64_t billion = 1000000000;
+	if (uptime_ns == 0 || value == 0) {
+		return 0;
+	}
+	return uptime_ns < billion ? value : value / (uptime_ns / billion);
+}
+
+static void
+expected_utilization(size_t curregs, size_t availregs, char result[6]) {
+	if (availregs == 0) {
+		malloc_snprintf(result, 6, "1");
+		return;
+	}
+	assert_zu_le(curregs, availregs, "Cached bin stats should be consistent");
+	unsigned n = (unsigned)(((uint64_t)curregs * 1000) / availregs);
+	if (n < 10) {
+		malloc_snprintf(result, 6, "0.00%u", n);
+	} else if (n < 100) {
+		malloc_snprintf(result, 6, "0.0%u", n);
+	} else if (n < 1000) {
+		malloc_snprintf(result, 6, "0.%u", n);
+	} else {
+		malloc_snprintf(result, 6, "1");
+	}
+}
+
+static size_t
+read_size_ctl(const char *name) {
+	size_t value;
+	size_t sz = sizeof(value);
+	assert_d_eq(mallctl(name, &value, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", name);
+	return value;
+}
+
+static uint64_t
+read_uint64_ctl(const char *name) {
+	uint64_t value;
+	size_t sz = sizeof(value);
+	assert_d_eq(mallctl(name, &value, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", name);
+	return value;
+}
+
+static uint32_t
+read_uint32_ctl(const char *name) {
+	uint32_t value;
+	size_t sz = sizeof(value);
+	assert_d_eq(mallctl(name, &value, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", name);
+	return value;
+}
+
+static size_t
+read_size_field(const char *prefix, const char *suffix) {
+	char name[192];
+	malloc_snprintf(name, sizeof(name), "%s.%s", prefix, suffix);
+	return read_size_ctl(name);
+}
+
+static uint64_t
+read_uint64_field(const char *prefix, const char *suffix) {
+	char name[192];
+	malloc_snprintf(name, sizeof(name), "%s.%s", prefix, suffix);
+	return read_uint64_ctl(name);
+}
+
+static uint32_t
+read_uint32_field(const char *prefix, const char *suffix) {
+	char name[192];
+	malloc_snprintf(name, sizeof(name), "%s.%s", prefix, suffix);
+	return read_uint32_ctl(name);
+}
+
 static bool
 stats_json_print_opts(stats_buf_t *sbuf, const char *opts,
     json_fragment_t *jemalloc) {
@@ -886,12 +975,20 @@ static const ctl_field_t hpa_slab_fields[] = {
 static const char *const hpa_slab_keys[] = {"npageslabs_huge",
 	"nactive_huge", "ndirty_huge", "npageslabs_nonhuge",
 	"nactive_nonhuge", "ndirty_nonhuge", "nretained_nonhuge"};
+static const char *const hpa_slab_row_keys[] = {"size", "ind"};
 
 static void
 expect_hpa_slab(json_fragment_t slab, const char *ctl_prefix,
-    const char *name) {
-	expect_json_object_keys(
+    const char *name, bool table_row) {
+	expect_zu_eq(json_object_size(slab), ARRAY_COUNT(hpa_slab_keys)
+	        + (table_row ? ARRAY_COUNT(hpa_slab_row_keys) : 0),
+	    "%s has an unexpected number of keys", name);
+	expect_json_object_has_keys(
 	    slab, hpa_slab_keys, ARRAY_COUNT(hpa_slab_keys), name);
+	if (table_row) {
+		expect_json_object_has_keys(slab, hpa_slab_row_keys,
+		    ARRAY_COUNT(hpa_slab_row_keys), name);
+	}
 	expect_json_ctl_fields(slab, ctl_prefix, hpa_slab_fields,
 	    ARRAY_COUNT(hpa_slab_fields));
 
@@ -972,7 +1069,7 @@ TEST_BEGIN(test_json_stats_hpa) {
 	char slab_prefix[128];
 	malloc_snprintf(
 	    slab_prefix, sizeof(slab_prefix), "%s.slabs", hpa_prefix);
-	expect_hpa_slab(slabs, slab_prefix, "hpa_shard.slabs");
+	expect_hpa_slab(slabs, slab_prefix, "hpa_shard.slabs", false);
 
 	const char *const summary_names[] = {"full_slabs", "empty_slabs"};
 	for (size_t i = 0; i < ARRAY_COUNT(summary_names); i++) {
@@ -981,7 +1078,10 @@ TEST_BEGIN(test_json_stats_hpa) {
 		    "hpa_shard is missing %s", summary_names[i]);
 		malloc_snprintf(slab_prefix, sizeof(slab_prefix), "%s.%s",
 		    hpa_prefix, summary_names[i]);
-		expect_hpa_slab(summary, slab_prefix, summary_names[i]);
+		expect_hpa_slab(summary, slab_prefix, summary_names[i], true);
+		expect_json_string_eq(
+		    summary, "size", i == 0 ? "full" : "empty", summary_names[i]);
+		expect_json_string_eq(summary, "ind", "-", summary_names[i]);
 	}
 
 	json_fragment_t nonfull;
@@ -1000,7 +1100,10 @@ TEST_BEGIN(test_json_stats_hpa) {
 		char row_name[64];
 		malloc_snprintf(
 		    row_name, sizeof(row_name), "nonfull_slabs[%zu]", i);
-		expect_hpa_slab(slab, slab_prefix, row_name);
+		expect_hpa_slab(slab, slab_prefix, row_name, true);
+		expect_json_uint_eq(
+		    slab, "size", sz_pind2sz((pszind_t)i), row_name);
+		expect_json_uint_eq(slab, "ind", i, row_name);
 	}
 
 	json_fragment_t distribution;
@@ -1036,18 +1139,26 @@ static const ctl_field_t bin_fields[] = {
 	{"nrequests", "nrequests", ctl_field_uint64},
 	{"nfills", "nfills", ctl_field_uint64},
 	{"nflushes", "nflushes", ctl_field_uint64},
+	{"nslabs", "nslabs", ctl_field_uint64},
 	{"nreslabs", "nreslabs", ctl_field_uint64},
 	{"curslabs", "curslabs", ctl_field_size},
 	{"nonfull_slabs", "nonfull_slabs", ctl_field_size},
 };
-static const char *const bin_keys[] = {"nmalloc", "ndalloc", "curregs",
-	"nrequests", "nfills", "nflushes", "nreslabs", "curslabs",
-	"nonfull_slabs", "mutex"};
+static const char *const bin_keys[] = {"size", "ind", "allocated",
+	"nmalloc", "nmalloc_ps", "ndalloc", "ndalloc_ps", "nrequests",
+	"nrequests_ps", "nshards", "curregs", "curslabs", "nonfull_slabs",
+	"regs", "pgs", "util", "nfills", "nfills_ps", "nflushes",
+	"nflushes_ps", "nslabs", "nreslabs", "nreslabs_ps", "mutex"};
 
 static const ctl_field_t lextent_fields[] = {
+	{"nmalloc", "nmalloc", ctl_field_uint64},
+	{"ndalloc", "ndalloc", ctl_field_uint64},
+	{"nrequests", "nrequests", ctl_field_uint64},
 	{"curlextents", "curlextents", ctl_field_size},
 };
-static const char *const lextent_keys[] = {"curlextents"};
+static const char *const lextent_keys[] = {"size", "ind", "allocated",
+	"nmalloc", "nmalloc_ps", "ndalloc", "ndalloc_ps", "nrequests",
+	"nrequests_ps", "curlextents"};
 
 static const ctl_field_t extent_fields[] = {
 	{"ndirty", "ndirty", ctl_field_size},
@@ -1059,9 +1170,10 @@ static const ctl_field_t extent_fields[] = {
 	{"retained_bytes", "retained_bytes", ctl_field_size},
 	{"pinned_bytes", "pinned_bytes", ctl_field_size},
 };
-static const char *const extent_keys[] = {"ndirty", "nmuzzy", "nretained",
-	"npinned", "dirty_bytes", "muzzy_bytes", "retained_bytes",
-	"pinned_bytes"};
+static const char *const extent_keys[] = {"size", "ind", "ndirty",
+	"dirty_bytes", "nmuzzy", "muzzy_bytes", "nretained",
+	"retained_bytes", "npinned", "pinned_bytes", "ntotal",
+	"total_bytes"};
 
 static const char *const prof_keys[] = {"prof_live_requested",
 	"prof_live_count", "prof_accum_requested", "prof_accum_count"};
@@ -1109,6 +1221,10 @@ TEST_BEGIN(test_json_stats_arena_tables) {
 	sz = sizeof(nlextents);
 	expect_d_eq(mallctl("arenas.nlextents", &nlextents, &sz, NULL, 0), 0,
 	    "mallctl failed for arenas.nlextents");
+	char arena_prefix[64];
+	malloc_snprintf(arena_prefix, sizeof(arena_prefix), "stats.arenas.%u",
+	    MALLCTL_ARENAS_ALL);
+	uint64_t uptime = read_uint64_field(arena_prefix, "uptime");
 
 	json_fragment_t bins;
 	expect_false(json_object_member(merged, "bins", &bins),
@@ -1136,6 +1252,44 @@ TEST_BEGIN(test_json_stats_arena_tables) {
 		    "stats.arenas.%u.bins.%u", MALLCTL_ARENAS_ALL, i);
 		expect_json_ctl_fields(
 		    bin, ctl_prefix, bin_fields, ARRAY_COUNT(bin_fields));
+
+		char meta_prefix[64];
+		malloc_snprintf(
+		    meta_prefix, sizeof(meta_prefix), "arenas.bin.%u", i);
+		size_t bin_size = read_size_field(meta_prefix, "size");
+		uint32_t nregs = read_uint32_field(meta_prefix, "nregs");
+		size_t slab_size = read_size_field(meta_prefix, "slab_size");
+		uint32_t nshards = read_uint32_field(meta_prefix, "nshards");
+		size_t curregs = read_size_field(ctl_prefix, "curregs");
+		size_t curslabs = read_size_field(ctl_prefix, "curslabs");
+		uint64_t nmalloc = read_uint64_field(ctl_prefix, "nmalloc");
+		uint64_t ndalloc = read_uint64_field(ctl_prefix, "ndalloc");
+		uint64_t nrequests = read_uint64_field(ctl_prefix, "nrequests");
+		uint64_t nfills = read_uint64_field(ctl_prefix, "nfills");
+		uint64_t nflushes = read_uint64_field(ctl_prefix, "nflushes");
+		uint64_t nreslabs = read_uint64_field(ctl_prefix, "nreslabs");
+		expect_json_uint_eq(bin, "size", bin_size, row_name);
+		expect_json_uint_eq(bin, "ind", i, row_name);
+		expect_json_uint_eq(
+		    bin, "allocated", curregs * bin_size, row_name);
+		expect_json_uint_eq(bin, "nmalloc_ps",
+		    expected_rate(nmalloc, uptime), row_name);
+		expect_json_uint_eq(bin, "ndalloc_ps",
+		    expected_rate(ndalloc, uptime), row_name);
+		expect_json_uint_eq(bin, "nrequests_ps",
+		    expected_rate(nrequests, uptime), row_name);
+		expect_json_uint_eq(bin, "nshards", nshards, row_name);
+		expect_json_uint_eq(bin, "regs", nregs, row_name);
+		expect_json_uint_eq(bin, "pgs", slab_size / PAGE, row_name);
+		expect_json_uint_eq(bin, "nfills_ps",
+		    expected_rate(nfills, uptime), row_name);
+		expect_json_uint_eq(bin, "nflushes_ps",
+		    expected_rate(nflushes, uptime), row_name);
+		expect_json_uint_eq(bin, "nreslabs_ps",
+		    expected_rate(nreslabs, uptime), row_name);
+		char util[6];
+		expected_utilization(curregs, nregs * curslabs, util);
+		expect_json_string_eq(bin, "util", util, row_name);
 		if (prof_stats_present) {
 			expect_json_object_has_keys(
 			    bin, prof_keys, ARRAY_COUNT(prof_keys), row_name);
@@ -1175,6 +1329,24 @@ TEST_BEGIN(test_json_stats_arena_tables) {
 		    "stats.arenas.%u.lextents.%u", MALLCTL_ARENAS_ALL, i);
 		expect_json_ctl_fields(lextent, ctl_prefix, lextent_fields,
 		    ARRAY_COUNT(lextent_fields));
+		char meta_prefix[64];
+		malloc_snprintf(meta_prefix, sizeof(meta_prefix),
+		    "arenas.lextent.%u", i);
+		size_t lextent_size = read_size_field(meta_prefix, "size");
+		size_t curlextents = read_size_field(ctl_prefix, "curlextents");
+		uint64_t nmalloc = read_uint64_field(ctl_prefix, "nmalloc");
+		uint64_t ndalloc = read_uint64_field(ctl_prefix, "ndalloc");
+		uint64_t nrequests = read_uint64_field(ctl_prefix, "nrequests");
+		expect_json_uint_eq(lextent, "size", lextent_size, row_name);
+		expect_json_uint_eq(lextent, "ind", nbins + i, row_name);
+		expect_json_uint_eq(lextent, "allocated",
+		    curlextents * lextent_size, row_name);
+		expect_json_uint_eq(lextent, "nmalloc_ps",
+		    expected_rate(nmalloc, uptime), row_name);
+		expect_json_uint_eq(lextent, "ndalloc_ps",
+		    expected_rate(ndalloc, uptime), row_name);
+		expect_json_uint_eq(lextent, "nrequests_ps",
+		    expected_rate(nrequests, uptime), row_name);
 		if (prof_stats_present) {
 			expect_json_object_has_keys(lextent, prof_keys,
 			    ARRAY_COUNT(prof_keys), row_name);
@@ -1203,6 +1375,22 @@ TEST_BEGIN(test_json_stats_arena_tables) {
 		    "stats.arenas.%u.extents.%u", MALLCTL_ARENAS_ALL, i);
 		expect_json_ctl_fields(extent, ctl_prefix, extent_fields,
 		    ARRAY_COUNT(extent_fields));
+		size_t ndirty = read_size_field(ctl_prefix, "ndirty");
+		size_t nmuzzy = read_size_field(ctl_prefix, "nmuzzy");
+		size_t nretained = read_size_field(ctl_prefix, "nretained");
+		size_t npinned = read_size_field(ctl_prefix, "npinned");
+		size_t dirty_bytes = read_size_field(ctl_prefix, "dirty_bytes");
+		size_t muzzy_bytes = read_size_field(ctl_prefix, "muzzy_bytes");
+		size_t retained_bytes = read_size_field(
+		    ctl_prefix, "retained_bytes");
+		size_t pinned_bytes = read_size_field(ctl_prefix, "pinned_bytes");
+		expect_json_uint_eq(extent, "size", sz_pind2sz(i), row_name);
+		expect_json_uint_eq(extent, "ind", i, row_name);
+		expect_json_uint_eq(extent, "ntotal",
+		    ndirty + nmuzzy + nretained + npinned, row_name);
+		expect_json_uint_eq(extent, "total_bytes",
+		    dirty_bytes + muzzy_bytes + retained_bytes + pinned_bytes,
+		    row_name);
 	}
 
 	stats_buf_fini(&sbuf);

--- a/test/unit/json_stats.c
+++ b/test/unit/json_stats.c
@@ -1,4 +1,5 @@
 #include "test/jemalloc_test.h"
+#include "jemalloc/internal/prof_stats.h"
 
 typedef struct {
 	char  *buf;
@@ -8,7 +9,7 @@ typedef struct {
 
 static void
 stats_buf_init(stats_buf_t *sbuf) {
-	/* 1MB buffer should be enough since per-arena stats are omitted. */
+	/* 1MB is enough for the small number of arenas used by these tests. */
 	sbuf->capacity = 1 << 20;
 	sbuf->buf = mallocx(sbuf->capacity, MALLOCX_TCACHE_NONE);
 	assert_ptr_not_null(sbuf->buf, "Failed to allocate stats buffer");
@@ -33,145 +34,6 @@ stats_buf_write_cb(void *opaque, const char *str) {
 	sbuf->len += slen;
 }
 
-static bool
-json_extract_uint64(const char *json, const char *key, uint64_t *result) {
-	char   search_key[128];
-	size_t key_len;
-
-	key_len = snprintf(search_key, sizeof(search_key), "\"%s\":", key);
-	if (key_len >= sizeof(search_key)) {
-		return true;
-	}
-
-	const char *pos = strstr(json, search_key);
-	if (pos == NULL) {
-		return true;
-	}
-
-	pos += key_len;
-	while (*pos == ' ' || *pos == '\t' || *pos == '\n') {
-		pos++;
-	}
-
-	char    *endptr;
-	uint64_t value = strtoull(pos, &endptr, 10);
-	if (endptr == pos) {
-		return true;
-	}
-
-	*result = value;
-	return false;
-}
-
-static const char *
-json_find_section(const char *json, const char *section_name) {
-	char   search_pattern[128];
-	size_t pattern_len;
-
-	pattern_len = snprintf(
-	    search_pattern, sizeof(search_pattern), "\"%s\":", section_name);
-	if (pattern_len >= sizeof(search_pattern)) {
-		return NULL;
-	}
-
-	return strstr(json, search_pattern);
-}
-
-static void
-verify_mutex_json(const char *mutexes_section, const char *mallctl_prefix,
-    const char *mutex_name) {
-	char   mallctl_path[128];
-	size_t sz;
-
-	const char *mutex_section = json_find_section(
-	    mutexes_section, mutex_name);
-	expect_ptr_not_null(mutex_section,
-	    "Could not find %s mutex section in JSON", mutex_name);
-
-	uint64_t ctl_num_ops, ctl_num_wait, ctl_num_spin_acq;
-	uint64_t ctl_num_owner_switch, ctl_total_wait_time, ctl_max_wait_time;
-	uint32_t ctl_max_num_thds;
-
-	sz = sizeof(uint64_t);
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.num_ops",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_num_ops, &sz, NULL, 0), 0,
-	    "Unexpected mallctl() failure for %s", mallctl_path);
-
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.num_wait",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_num_wait, &sz, NULL, 0), 0,
-	    "Unexpected mallctl() failure for %s", mallctl_path);
-
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.num_spin_acq",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_num_spin_acq, &sz, NULL, 0), 0,
-	    "Unexpected mallctl() failure for %s", mallctl_path);
-
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.num_owner_switch",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_num_owner_switch, &sz, NULL, 0),
-	    0, "Unexpected mallctl() failure for %s", mallctl_path);
-
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.total_wait_time",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_total_wait_time, &sz, NULL, 0),
-	    0, "Unexpected mallctl() failure for %s", mallctl_path);
-
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.max_wait_time",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_max_wait_time, &sz, NULL, 0), 0,
-	    "Unexpected mallctl() failure for %s", mallctl_path);
-
-	sz = sizeof(uint32_t);
-	snprintf(mallctl_path, sizeof(mallctl_path), "%s.%s.max_num_thds",
-	    mallctl_prefix, mutex_name);
-	expect_d_eq(mallctl(mallctl_path, &ctl_max_num_thds, &sz, NULL, 0), 0,
-	    "Unexpected mallctl() failure for %s", mallctl_path);
-
-	uint64_t json_num_ops, json_num_wait, json_num_spin_acq;
-	uint64_t json_num_owner_switch, json_total_wait_time,
-	    json_max_wait_time;
-	uint64_t json_max_num_thds;
-
-	expect_false(
-	    json_extract_uint64(mutex_section, "num_ops", &json_num_ops),
-	    "%s: num_ops not found in JSON", mutex_name);
-	expect_false(
-	    json_extract_uint64(mutex_section, "num_wait", &json_num_wait),
-	    "%s: num_wait not found in JSON", mutex_name);
-	expect_false(json_extract_uint64(
-	                 mutex_section, "num_spin_acq", &json_num_spin_acq),
-	    "%s: num_spin_acq not found in JSON", mutex_name);
-	expect_false(json_extract_uint64(mutex_section, "num_owner_switch",
-	                 &json_num_owner_switch),
-	    "%s: num_owner_switch not found in JSON", mutex_name);
-	expect_false(json_extract_uint64(mutex_section, "total_wait_time",
-	                 &json_total_wait_time),
-	    "%s: total_wait_time not found in JSON", mutex_name);
-	expect_false(json_extract_uint64(
-	                 mutex_section, "max_wait_time", &json_max_wait_time),
-	    "%s: max_wait_time not found in JSON", mutex_name);
-	expect_false(json_extract_uint64(
-	                 mutex_section, "max_num_thds", &json_max_num_thds),
-	    "%s: max_num_thds not found in JSON", mutex_name);
-
-	expect_u64_eq(json_num_ops, ctl_num_ops,
-	    "%s: JSON num_ops doesn't match mallctl", mutex_name);
-	expect_u64_eq(json_num_wait, ctl_num_wait,
-	    "%s: JSON num_wait doesn't match mallctl", mutex_name);
-	expect_u64_eq(json_num_spin_acq, ctl_num_spin_acq,
-	    "%s: JSON num_spin_acq doesn't match mallctl", mutex_name);
-	expect_u64_eq(json_num_owner_switch, ctl_num_owner_switch,
-	    "%s: JSON num_owner_switch doesn't match mallctl", mutex_name);
-	expect_u64_eq(json_total_wait_time, ctl_total_wait_time,
-	    "%s: JSON total_wait_time doesn't match mallctl", mutex_name);
-	expect_u64_eq(json_max_wait_time, ctl_max_wait_time,
-	    "%s: JSON max_wait_time doesn't match mallctl", mutex_name);
-	expect_u32_eq((uint32_t)json_max_num_thds, ctl_max_num_thds,
-	    "%s: JSON max_num_thds doesn't match mallctl", mutex_name);
-}
-
 static const char  *global_mutex_names[] = {"background_thread",
      "max_per_bg_thd", "ctl", "prof", "prof_thds_data", "prof_dump",
      "prof_recent_alloc", "prof_recent_dump", "prof_stats"};
@@ -179,331 +41,1177 @@ static const size_t num_global_mutexes = sizeof(global_mutex_names)
     / sizeof(global_mutex_names[0]);
 
 static const char  *arena_mutex_names[] = {"large", "extent_avail",
-     "extents_dirty", "extents_muzzy", "extents_retained", "decay_dirty",
-     "decay_muzzy", "base", "tcache_list", "hpa_shard", "hpa_shard_grow",
-     "hpa_sec", "pac_sec"};
+     "extents_dirty", "extents_muzzy", "extents_retained", "extents_pinned",
+     "decay_dirty", "decay_muzzy", "base", "tcache_list", "hpa_shard",
+     "hpa_shard_grow", "hpa_sec", "pac_sec"};
 static const size_t num_arena_mutexes = sizeof(arena_mutex_names)
     / sizeof(arena_mutex_names[0]);
 
+typedef struct {
+	const char *begin;
+	const char *end;
+} json_fragment_t;
+
 static const char *
-json_find_object_end(const char *object_begin) {
-	int depth = 0;
-	for (const char *cur = object_begin; *cur != '\0'; cur++) {
-		if (*cur == '{') {
-			depth++;
-		} else if (*cur == '}') {
-			depth--;
-			if (depth == 0) {
-				return cur;
-			}
-			if (depth < 0) {
+json_skip_ws(const char *cur, const char *end) {
+	while (cur < end
+	    && (*cur == ' ' || *cur == '\t' || *cur == '\n' || *cur == '\r')) {
+		cur++;
+	}
+	return cur;
+}
+
+static const char *
+json_string_end(const char *begin, const char *end) {
+	if (begin >= end || *begin != '"') {
+		return NULL;
+	}
+	for (const char *cur = begin + 1; cur < end; cur++) {
+		if (*cur == '\\') {
+			cur++;
+			if (cur >= end) {
 				return NULL;
 			}
+		} else if (*cur == '"') {
+			return cur + 1;
 		}
 	}
 	return NULL;
 }
 
 static const char *
-json_find_array_end(const char *array_begin) {
-	int depth = 0;
-	for (const char *cur = array_begin; *cur != '\0'; cur++) {
-		if (*cur == '[') {
-			depth++;
-		} else if (*cur == ']') {
-			depth--;
-			if (depth == 0) {
-				return cur;
-			}
-			if (depth < 0) {
+json_value_end(const char *begin, const char *end) {
+	begin = json_skip_ws(begin, end);
+	if (begin >= end) {
+		return NULL;
+	}
+	if (*begin == '"') {
+		return json_string_end(begin, end);
+	}
+	if (*begin != '{' && *begin != '[') {
+		const char *cur = begin;
+		while (cur < end && *cur != ',' && *cur != '}' && *cur != ']') {
+			cur++;
+		}
+		while (cur > begin
+		    && (cur[-1] == ' ' || cur[-1] == '\t' || cur[-1] == '\n'
+		        || cur[-1] == '\r')) {
+			cur--;
+		}
+		return cur;
+	}
+
+	char opening = *begin;
+	char closing = opening == '{' ? '}' : ']';
+	unsigned depth = 0;
+	for (const char *cur = begin; cur < end; cur++) {
+		if (*cur == '"') {
+			cur = json_string_end(cur, end);
+			if (cur == NULL) {
 				return NULL;
 			}
+			cur--;
+			continue;
+		}
+		if (*cur == opening) {
+			depth++;
+		} else if (*cur == closing && --depth == 0) {
+			return cur + 1;
 		}
 	}
 	return NULL;
 }
 
-static const char *
-json_find_previous_hpa_shard_object(
-    const char *json, const char *pos, const char **object_end) {
-	*object_end = NULL;
-	const char *found = NULL;
-	const char *cur = json;
-	const char *next;
-
-	while ((next = strstr(cur, "\"hpa_shard\":{")) != NULL && next < pos) {
-		found = strchr(next, '{');
-		cur = next + 1;
+static bool
+json_fragment_init(const char *begin, const char *end, json_fragment_t *out) {
+	begin = json_skip_ws(begin, end);
+	const char *value_end = json_value_end(begin, end);
+	if (value_end == NULL) {
+		return true;
 	}
-	if (found == NULL) {
-		return NULL;
-	}
-	*object_end = json_find_object_end(found);
-	return found;
+	out->begin = begin;
+	out->end = value_end;
+	return false;
 }
 
-static const char *
-json_find_named_object(
-    const char *json, const char *key, const char **object_end) {
-	*object_end = NULL;
-	char   search_key[128];
-	size_t written = malloc_snprintf(
-	    search_key, sizeof(search_key), "\"%s\":{", key);
-	if (written >= sizeof(search_key)) {
-		return NULL;
+static bool
+json_object_member(json_fragment_t object, const char *key,
+    json_fragment_t *value) {
+	if (object.begin >= object.end || *object.begin != '{') {
+		return true;
 	}
-
-	const char *object_begin = strstr(json, search_key);
-	if (object_begin == NULL) {
-		return NULL;
+	const char *cur = object.begin + 1;
+	while (true) {
+		cur = json_skip_ws(cur, object.end);
+		if (cur >= object.end || *cur == '}') {
+			return true;
+		}
+		const char *key_end = json_string_end(cur, object.end);
+		if (key_end == NULL) {
+			return true;
+		}
+		size_t key_len = (size_t)(key_end - cur - 2);
+		bool matches = strlen(key) == key_len
+		    && strncmp(cur + 1, key, key_len) == 0;
+		cur = json_skip_ws(key_end, object.end);
+		if (cur >= object.end || *cur++ != ':') {
+			return true;
+		}
+		cur = json_skip_ws(cur, object.end);
+		const char *value_end = json_value_end(cur, object.end);
+		if (value_end == NULL) {
+			return true;
+		}
+		if (matches) {
+			value->begin = cur;
+			value->end = value_end;
+			return false;
+		}
+		cur = json_skip_ws(value_end, object.end);
+		if (cur < object.end && *cur == ',') {
+			cur++;
+		} else if (cur >= object.end || *cur != '}') {
+			return true;
+		}
 	}
-	object_begin = strchr(object_begin, '{');
-	if (object_begin == NULL) {
-		return NULL;
-	}
-	*object_end = json_find_object_end(object_begin);
-	return object_begin;
 }
 
-static const char *
-json_find_named_array(
-    const char *json, const char *key, const char **array_end) {
-	*array_end = NULL;
-	char   search_key[128];
-	size_t written = malloc_snprintf(
-	    search_key, sizeof(search_key), "\"%s\":[", key);
-	if (written >= sizeof(search_key)) {
-		return NULL;
+static size_t
+json_object_size(json_fragment_t object) {
+	if (object.begin >= object.end || *object.begin != '{') {
+		return SIZE_T_MAX;
 	}
-
-	const char *array_begin = strstr(json, search_key);
-	if (array_begin == NULL) {
-		return NULL;
+	size_t count = 0;
+	const char *cur = object.begin + 1;
+	while (true) {
+		cur = json_skip_ws(cur, object.end);
+		if (cur < object.end && *cur == '}') {
+			return count;
+		}
+		const char *key_end = json_string_end(cur, object.end);
+		if (key_end == NULL) {
+			return SIZE_T_MAX;
+		}
+		cur = json_skip_ws(key_end, object.end);
+		if (cur >= object.end || *cur++ != ':') {
+			return SIZE_T_MAX;
+		}
+		cur = json_skip_ws(cur, object.end);
+		cur = json_value_end(cur, object.end);
+		if (cur == NULL) {
+			return SIZE_T_MAX;
+		}
+		count++;
+		cur = json_skip_ws(cur, object.end);
+		if (cur < object.end && *cur == ',') {
+			cur++;
+		} else if (cur >= object.end || *cur != '}') {
+			return SIZE_T_MAX;
+		}
 	}
-	array_begin = strchr(array_begin, '[');
-	if (array_begin == NULL) {
-		return NULL;
-	}
-	*array_end = json_find_array_end(array_begin);
-	return array_begin;
 }
 
-TEST_BEGIN(test_json_stats_mutexes) {
-	test_skip_if(!config_stats);
-
-	uint64_t epoch;
-	expect_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sizeof(epoch)),
-	    0, "Unexpected mallctl() failure");
-
-	stats_buf_t sbuf;
-	stats_buf_init(&sbuf);
-	/* "J" for JSON format, "a" to omit per-arena stats. */
-	malloc_stats_print(stats_buf_write_cb, &sbuf, "Ja");
-
-	/* Verify global mutexes under stats.mutexes. */
-	const char *global_mutexes_section = json_find_section(
-	    sbuf.buf, "mutexes");
-	expect_ptr_not_null(global_mutexes_section,
-	    "Could not find global mutexes section in JSON output");
-
-	for (size_t i = 0; i < num_global_mutexes; i++) {
-		verify_mutex_json(global_mutexes_section, "stats.mutexes",
-		    global_mutex_names[i]);
+static bool
+json_array_element(json_fragment_t array, size_t ind, json_fragment_t *value) {
+	if (array.begin >= array.end || *array.begin != '[') {
+		return true;
 	}
-
-	/* Verify arena mutexes under stats.arenas.merged.mutexes. */
-	const char *arenas_section = json_find_section(
-	    sbuf.buf, "stats.arenas");
-	expect_ptr_not_null(arenas_section,
-	    "Could not find stats.arenas section in JSON output");
-
-	const char *merged_section = json_find_section(
-	    arenas_section, "merged");
-	expect_ptr_not_null(
-	    merged_section, "Could not find merged section in JSON output");
-
-	const char *arena_mutexes_section = json_find_section(
-	    merged_section, "mutexes");
-	expect_ptr_not_null(arena_mutexes_section,
-	    "Could not find arena mutexes section in JSON output");
-
-	for (size_t i = 0; i < num_arena_mutexes; i++) {
-		/*
-		 * MALLCTL_ARENAS_ALL is 4096 representing all arenas in
-		 * mallctl queries.
-		 */
-		verify_mutex_json(arena_mutexes_section,
-		    "stats.arenas.4096.mutexes", arena_mutex_names[i]);
+	size_t current = 0;
+	const char *cur = array.begin + 1;
+	while (true) {
+		cur = json_skip_ws(cur, array.end);
+		if (cur >= array.end || *cur == ']') {
+			return true;
+		}
+		const char *value_end = json_value_end(cur, array.end);
+		if (value_end == NULL) {
+			return true;
+		}
+		if (current++ == ind) {
+			value->begin = cur;
+			value->end = value_end;
+			return false;
+		}
+		cur = json_skip_ws(value_end, array.end);
+		if (cur < array.end && *cur == ',') {
+			cur++;
+		} else if (cur >= array.end || *cur != ']') {
+			return true;
+		}
 	}
-
-	stats_buf_fini(&sbuf);
 }
-TEST_END
 
-/*
- * Verify that hpa_shard JSON stats contain "ndirty_huge" key in both
- * full_slabs and empty_slabs sections.  A previous bug emitted duplicate
- * "nactive_huge" instead of "ndirty_huge".
- */
-TEST_BEGIN(test_hpa_shard_json_ndirty_huge) {
-	test_skip_if(!config_stats);
-	test_skip_if(!hpa_supported());
+static size_t
+json_array_size(json_fragment_t array) {
+	if (array.begin >= array.end || *array.begin != '[') {
+		return SIZE_T_MAX;
+	}
+	size_t count = 0;
+	const char *cur = array.begin + 1;
+	while (true) {
+		cur = json_skip_ws(cur, array.end);
+		if (cur < array.end && *cur == ']') {
+			return count;
+		}
+		cur = json_value_end(cur, array.end);
+		if (cur == NULL) {
+			return SIZE_T_MAX;
+		}
+		count++;
+		cur = json_skip_ws(cur, array.end);
+		if (cur < array.end && *cur == ',') {
+			cur++;
+		} else if (cur >= array.end || *cur != ']') {
+			return SIZE_T_MAX;
+		}
+	}
+}
 
-	/* Do some allocation to create HPA state. */
-	void *p = mallocx(PAGE, MALLOCX_TCACHE_NONE);
-	expect_ptr_not_null(p, "Unexpected mallocx failure");
+static bool
+json_fragment_uint64(json_fragment_t value, uint64_t *result) {
+	char *end;
+	errno = 0;
+	uint64_t parsed = strtoull(value.begin, &end, 10);
+	if (errno != 0 || end != value.end) {
+		return true;
+	}
+	*result = parsed;
+	return false;
+}
 
-	uint64_t epoch = 1;
-	size_t   sz = sizeof(epoch);
-	expect_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sz), 0,
-	    "Unexpected mallctl() failure");
+static bool
+json_fragment_int64(json_fragment_t value, int64_t *result) {
+	char *end;
+	errno = 0;
+	int64_t parsed = strtoll(value.begin, &end, 10);
+	if (errno != 0 || end != value.end) {
+		return true;
+	}
+	*result = parsed;
+	return false;
+}
 
-	stats_buf_t sbuf;
-	stats_buf_init(&sbuf);
-	/* "J" for JSON, include per-arena HPA stats. */
-	malloc_stats_print(stats_buf_write_cb, &sbuf, "J");
+static bool
+json_fragment_string_eq(json_fragment_t value, const char *expected) {
+	if (value.end - value.begin < 2 || *value.begin != '"'
+	    || value.end[-1] != '"') {
+		return false;
+	}
+	size_t len = (size_t)(value.end - value.begin - 2);
+	return strlen(expected) == len
+	    && strncmp(value.begin + 1, expected, len) == 0;
+}
 
-	/*
-	 * Find "full_slabs" and check it contains "ndirty_huge".
-	 */
-	const char *full_slabs = strstr(sbuf.buf, "\"full_slabs\"");
-	if (full_slabs != NULL) {
-		const char *empty_slabs = strstr(full_slabs, "\"empty_slabs\"");
-		const char *search_end = empty_slabs != NULL
-		    ? empty_slabs
-		    : sbuf.buf + sbuf.len;
-		/*
-		 * Search for "ndirty_huge" between full_slabs and
-		 * empty_slabs.
-		 */
-		const char *ndirty = full_slabs;
-		bool        found = false;
-		while (ndirty < search_end) {
-			ndirty = strstr(ndirty, "\"ndirty_huge\"");
-			if (ndirty != NULL && ndirty < search_end) {
-				found = true;
-				break;
-			}
+static void
+expect_json_object_has_keys(json_fragment_t object, const char *const *keys,
+    size_t nkeys, const char *name) {
+	for (size_t i = 0; i < nkeys; i++) {
+		json_fragment_t ignored;
+		expect_false(json_object_member(object, keys[i], &ignored),
+		    "%s is missing key %s", name, keys[i]);
+	}
+}
+
+static void
+expect_json_object_keys(json_fragment_t object, const char *const *keys,
+    size_t nkeys, const char *name) {
+	expect_zu_eq(json_object_size(object), nkeys,
+	    "%s has an unexpected number of keys", name);
+	expect_json_object_has_keys(object, keys, nkeys, name);
+}
+
+typedef enum {
+	ctl_field_size,
+	ctl_field_uint64,
+	ctl_field_uint32,
+	ctl_field_unsigned,
+	ctl_field_ssize,
+	ctl_field_string,
+} ctl_field_type_t;
+
+typedef struct {
+	const char       *json_key;
+	const char       *ctl_suffix;
+	ctl_field_type_t  type;
+} ctl_field_t;
+
+static void
+expect_json_ctl_fields(json_fragment_t object, const char *ctl_prefix,
+    const ctl_field_t *fields, size_t nfields) {
+	for (size_t i = 0; i < nfields; i++) {
+		const ctl_field_t *field = &fields[i];
+		json_fragment_t value;
+		bool missing = json_object_member(object, field->json_key, &value);
+		expect_false(missing, "JSON is missing %s", field->json_key);
+		if (missing) {
+			continue;
+		}
+
+		char ctl_name[256];
+		size_t written = malloc_snprintf(ctl_name, sizeof(ctl_name),
+		    "%s.%s", ctl_prefix, field->ctl_suffix);
+		expect_zu_lt(written, sizeof(ctl_name), "mallctl name is too long");
+
+		size_t sz;
+		uint64_t json_u64 = 0;
+		int64_t json_i64 = 0;
+		switch (field->type) {
+		case ctl_field_size: {
+			size_t expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_false(json_fragment_uint64(value, &json_u64),
+			    "JSON value for %s is not unsigned", field->json_key);
+			expect_zu_eq((size_t)json_u64, expected,
+			    "JSON value does not match %s", ctl_name);
 			break;
 		}
-		expect_true(
-		    found, "full_slabs section should contain ndirty_huge key");
+		case ctl_field_uint64: {
+			uint64_t expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_false(json_fragment_uint64(value, &json_u64),
+			    "JSON value for %s is not unsigned", field->json_key);
+			expect_u64_eq(json_u64, expected,
+			    "JSON value does not match %s", ctl_name);
+			break;
+		}
+		case ctl_field_uint32: {
+			uint32_t expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_false(json_fragment_uint64(value, &json_u64),
+			    "JSON value for %s is not unsigned", field->json_key);
+			expect_u32_eq((uint32_t)json_u64, expected,
+			    "JSON value does not match %s", ctl_name);
+			break;
+		}
+		case ctl_field_unsigned: {
+			unsigned expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_false(json_fragment_uint64(value, &json_u64),
+			    "JSON value for %s is not unsigned", field->json_key);
+			expect_u_eq((unsigned)json_u64, expected,
+			    "JSON value does not match %s", ctl_name);
+			break;
+		}
+		case ctl_field_ssize: {
+			ssize_t expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_false(json_fragment_int64(value, &json_i64),
+			    "JSON value for %s is not signed", field->json_key);
+			expect_zd_eq((ssize_t)json_i64, expected,
+			    "JSON value does not match %s", ctl_name);
+			break;
+		}
+		case ctl_field_string: {
+			const char *expected;
+			sz = sizeof(expected);
+			expect_d_eq(mallctl(ctl_name, &expected, &sz, NULL, 0), 0,
+			    "mallctl failed for %s", ctl_name);
+			expect_true(json_fragment_string_eq(value, expected),
+			    "JSON value does not match %s", ctl_name);
+			break;
+		}
+		}
+	}
+}
+
+#define ARRAY_COUNT(array) (sizeof(array) / sizeof((array)[0]))
+
+static void
+expect_json_uint_eq(json_fragment_t object, const char *key,
+    uint64_t expected, const char *name) {
+	json_fragment_t value;
+	bool missing = json_object_member(object, key, &value);
+	expect_false(missing, "%s is missing %s", name, key);
+	if (missing) {
+		return;
+	}
+	uint64_t actual = 0;
+	expect_false(json_fragment_uint64(value, &actual),
+	    "%s.%s is not an unsigned integer", name, key);
+	expect_u64_eq(actual, expected, "%s.%s has an unexpected value", name,
+	    key);
+}
+
+static bool
+stats_json_print_opts(stats_buf_t *sbuf, const char *opts,
+    json_fragment_t *jemalloc) {
+	stats_buf_init(sbuf);
+	malloc_stats_print(stats_buf_write_cb, sbuf, opts);
+
+	json_fragment_t root;
+	if (json_fragment_init(sbuf->buf, sbuf->buf + sbuf->len, &root)
+	    || json_object_member(root, "jemalloc", jemalloc)) {
+		return true;
+	}
+	return false;
+}
+
+static bool
+stats_json_print(stats_buf_t *sbuf, json_fragment_t *stats,
+    json_fragment_t *merged) {
+	json_fragment_t jemalloc, stats_arenas;
+	if (stats_json_print_opts(sbuf, "Ja", &jemalloc)
+	    || json_object_member(jemalloc, "stats", stats)
+	    || json_object_member(jemalloc, "stats.arenas", &stats_arenas)
+	    || json_object_member(stats_arenas, "merged", merged)) {
+		return true;
+	}
+	return false;
+}
+
+static const ctl_field_t mutex_fields[] = {
+	{"num_ops", "num_ops", ctl_field_uint64},
+	{"num_wait", "num_wait", ctl_field_uint64},
+	{"num_spin_acq", "num_spin_acq", ctl_field_uint64},
+	{"num_owner_switch", "num_owner_switch", ctl_field_uint64},
+	{"total_wait_time", "total_wait_time", ctl_field_uint64},
+	{"max_wait_time", "max_wait_time", ctl_field_uint64},
+	{"max_num_thds", "max_num_thds", ctl_field_uint32},
+};
+static const char *const mutex_keys[] = {"num_ops", "num_wait",
+	"num_spin_acq", "num_owner_switch", "total_wait_time",
+	"max_wait_time", "max_num_thds"};
+
+static void
+expect_mutex_object(json_fragment_t mutex, const char *ctl_prefix) {
+	expect_json_object_keys(
+	    mutex, mutex_keys, ARRAY_COUNT(mutex_keys), ctl_prefix);
+	expect_json_ctl_fields(
+	    mutex, ctl_prefix, mutex_fields, ARRAY_COUNT(mutex_fields));
+}
+
+static const ctl_field_t global_fields[] = {
+	{"allocated", "allocated", ctl_field_size},
+	{"active", "active", ctl_field_size},
+	{"metadata", "metadata", ctl_field_size},
+	{"metadata_edata", "metadata_edata", ctl_field_size},
+	{"metadata_rtree", "metadata_rtree", ctl_field_size},
+	{"metadata_thp", "metadata_thp", ctl_field_size},
+	{"resident", "resident", ctl_field_size},
+	{"mapped", "mapped", ctl_field_size},
+	{"retained", "retained", ctl_field_size},
+	{"pinned", "pinned", ctl_field_size},
+	{"zero_reallocs", "zero_reallocs", ctl_field_size},
+};
+
+static const ctl_field_t background_thread_fields[] = {
+	{"num_threads", "num_threads", ctl_field_size},
+	{"num_runs", "num_runs", ctl_field_uint64},
+	{"run_interval", "run_interval", ctl_field_uint64},
+};
+
+static const ctl_field_t arena_fields[] = {
+	{"nthreads", "nthreads", ctl_field_unsigned},
+	{"uptime_ns", "uptime", ctl_field_uint64},
+	{"dss", "dss", ctl_field_string},
+	{"dirty_decay_ms", "dirty_decay_ms", ctl_field_ssize},
+	{"muzzy_decay_ms", "muzzy_decay_ms", ctl_field_ssize},
+	{"pactive", "pactive", ctl_field_size},
+	{"pdirty", "pdirty", ctl_field_size},
+	{"pmuzzy", "pmuzzy", ctl_field_size},
+	{"dirty_npurge", "dirty_npurge", ctl_field_uint64},
+	{"dirty_nmadvise", "dirty_nmadvise", ctl_field_uint64},
+	{"dirty_purged", "dirty_purged", ctl_field_uint64},
+	{"muzzy_npurge", "muzzy_npurge", ctl_field_uint64},
+	{"muzzy_nmadvise", "muzzy_nmadvise", ctl_field_uint64},
+	{"muzzy_purged", "muzzy_purged", ctl_field_uint64},
+	{"mapped", "mapped", ctl_field_size},
+	{"retained", "retained", ctl_field_size},
+	{"pinned", "pinned", ctl_field_size},
+	{"base", "base", ctl_field_size},
+	{"internal", "internal", ctl_field_size},
+	{"metadata_edata", "metadata_edata", ctl_field_size},
+	{"metadata_rtree", "metadata_rtree", ctl_field_size},
+	{"metadata_thp", "metadata_thp", ctl_field_size},
+	{"tcache_bytes", "tcache_bytes", ctl_field_size},
+	{"tcache_stashed_bytes", "tcache_stashed_bytes", ctl_field_size},
+	{"resident", "resident", ctl_field_size},
+	{"abandoned_vm", "abandoned_vm", ctl_field_size},
+	{"extent_avail", "extent_avail", ctl_field_size},
+};
+
+static const ctl_field_t arena_alloc_fields[] = {
+	{"allocated", "allocated", ctl_field_size},
+	{"nmalloc", "nmalloc", ctl_field_uint64},
+	{"ndalloc", "ndalloc", ctl_field_uint64},
+	{"nrequests", "nrequests", ctl_field_uint64},
+	{"nfills", "nfills", ctl_field_uint64},
+	{"nflushes", "nflushes", ctl_field_uint64},
+};
+static const char *const arena_alloc_keys[] = {"allocated", "nmalloc",
+	"ndalloc", "nrequests", "nfills", "nflushes"};
+
+static const ctl_field_t pac_sec_fields[] = {
+	{"pac_sec_bytes", "pac_sec_bytes", ctl_field_size},
+	{"pac_sec_hits", "pac_sec_hits", ctl_field_size},
+	{"pac_sec_misses", "pac_sec_misses", ctl_field_size},
+	{"pac_sec_dalloc_noflush", "pac_sec_dalloc_noflush", ctl_field_size},
+	{"pac_sec_dalloc_flush", "pac_sec_dalloc_flush", ctl_field_size},
+};
+
+static const char *const merged_keys[] = {"nthreads", "uptime_ns", "dss",
+	"dirty_decay_ms", "muzzy_decay_ms", "pactive", "pdirty", "pmuzzy",
+	"dirty_npurge", "dirty_nmadvise", "dirty_purged", "muzzy_npurge",
+	"muzzy_nmadvise", "muzzy_purged", "small", "large", "mapped",
+	"retained", "pinned", "base", "internal", "metadata_edata",
+	"metadata_rtree", "metadata_thp", "tcache_bytes",
+	"tcache_stashed_bytes", "resident", "abandoned_vm", "extent_avail",
+	"mutexes", "bins", "lextents", "extents", "hpa_shard"};
+static const char *const pac_sec_keys[] = {"pac_sec_bytes", "pac_sec_hits",
+	"pac_sec_misses", "pac_sec_dalloc_noflush", "pac_sec_dalloc_flush"};
+
+static const ctl_field_t arena_sample_fields[] = {
+	{"nthreads", "nthreads", ctl_field_unsigned},
+	{"dss", "dss", ctl_field_string},
+	{"pactive", "pactive", ctl_field_size},
+	{"mapped", "mapped", ctl_field_size},
+};
+
+static unsigned
+create_manual_arena(void) {
+	unsigned arena_ind = 0;
+	size_t sz = sizeof(arena_ind);
+	assert_d_eq(mallctl("arenas.create", &arena_ind, &sz, NULL, 0), 0,
+	    "Could not create manual arena");
+	return arena_ind;
+}
+
+static void
+destroy_manual_arena(unsigned arena_ind) {
+	size_t mib[3];
+	size_t miblen = ARRAY_COUNT(mib);
+	assert_d_eq(mallctlnametomib("arena.0.destroy", mib, &miblen), 0,
+	    "Could not resolve arena destroy mallctl");
+	mib[1] = arena_ind;
+	assert_d_eq(mallctlbymib(mib, miblen, NULL, NULL, NULL, 0), 0,
+	    "Could not destroy arena %u", arena_ind);
+}
+
+static void
+expect_arena_sample(json_fragment_t stats_arenas, const char *json_key,
+    unsigned ctl_ind, bool has_name) {
+	json_fragment_t arena;
+	bool missing = json_object_member(stats_arenas, json_key, &arena);
+	expect_false(missing, "stats.arenas is missing %s", json_key);
+	if (missing) {
+		return;
 	}
 
-	/*
-	 * Find "empty_slabs" and check it contains "ndirty_huge".
-	 */
-	const char *empty_slabs = strstr(sbuf.buf, "\"empty_slabs\"");
-	if (empty_slabs != NULL) {
-		/* Find the end of the empty_slabs object. */
-		const char *nonfull = strstr(empty_slabs, "\"nonfull_slabs\"");
-		const char *search_end = nonfull != NULL ? nonfull
-		                                         : sbuf.buf + sbuf.len;
-		const char *ndirty = strstr(empty_slabs, "\"ndirty_huge\"");
-		bool        found = (ndirty != NULL && ndirty < search_end);
-		expect_true(found,
-		    "empty_slabs section should contain ndirty_huge key");
+	char ctl_prefix[64];
+	malloc_snprintf(ctl_prefix, sizeof(ctl_prefix), "stats.arenas.%u",
+	    ctl_ind);
+	expect_json_ctl_fields(arena, ctl_prefix, arena_sample_fields,
+	    ARRAY_COUNT(arena_sample_fields));
+
+	json_fragment_t name;
+	bool name_missing = json_object_member(arena, "name", &name);
+	if (has_name) {
+		expect_false(name_missing, "stats.arenas.%s is missing name",
+		    json_key);
+	} else {
+		expect_true(name_missing,
+		    "stats.arenas.%s unexpectedly contains name", json_key);
+	}
+}
+
+typedef enum {
+	option_parent_jemalloc,
+	option_parent_stats,
+	option_parent_arenas,
+	option_parent_merged,
+} option_parent_t;
+
+typedef struct {
+	const char     *opts;
+	option_parent_t parent;
+	const char     *omitted_key;
+} option_case_t;
+
+static void
+expect_option_omits(const option_case_t *test_case) {
+	stats_buf_t sbuf;
+	json_fragment_t jemalloc;
+	bool malformed = stats_json_print_opts(
+	    &sbuf, test_case->opts, &jemalloc);
+	expect_false(malformed, "Malformed JSON for opts=%s", test_case->opts);
+	if (malformed) {
+		stats_buf_fini(&sbuf);
+		return;
 	}
 
+	json_fragment_t stats, stats_arenas, merged;
+	json_fragment_t parent = jemalloc;
+	if (test_case->parent >= option_parent_stats) {
+		assert_false(json_object_member(jemalloc, "stats", &stats),
+		    "opts=%s omitted stats", test_case->opts);
+		parent = stats;
+	}
+	if (test_case->parent >= option_parent_arenas) {
+		assert_false(json_object_member(
+		                 jemalloc, "stats.arenas", &stats_arenas),
+		    "opts=%s omitted stats.arenas", test_case->opts);
+		parent = stats_arenas;
+	}
+	if (test_case->parent >= option_parent_merged) {
+		assert_false(json_object_member(stats_arenas, "merged", &merged),
+		    "opts=%s omitted merged stats", test_case->opts);
+		parent = merged;
+	}
+
+	json_fragment_t ignored;
+	expect_true(json_object_member(
+	                parent, test_case->omitted_key, &ignored),
+	    "opts=%s did not omit %s", test_case->opts,
+	    test_case->omitted_key);
+
+	if (strcmp(test_case->opts, "Jx") == 0) {
+		assert_false(json_object_member(
+		                 jemalloc, "stats.arenas", &stats_arenas),
+		    "opts=Jx omitted stats.arenas");
+		assert_false(json_object_member(stats_arenas, "merged", &merged),
+		    "opts=Jx omitted merged stats");
+		expect_true(json_object_member(merged, "mutexes", &ignored),
+		    "opts=Jx did not omit arena mutexes");
+	}
 	stats_buf_fini(&sbuf);
-	dallocx(p, MALLOCX_TCACHE_NONE);
+}
+
+TEST_BEGIN(test_json_stats_arenas_and_options) {
+	test_skip_if(!config_stats);
+
+	unsigned manual_ind = create_manual_arena();
+	unsigned destroyed_ind = create_manual_arena();
+	void *manual_alloc = mallocx(1,
+	    MALLOCX_ARENA(manual_ind) | MALLOCX_TCACHE_NONE);
+	assert_ptr_not_null(manual_alloc, "Manual arena allocation failed");
+	void *destroyed_alloc = mallocx(1,
+	    MALLOCX_ARENA(destroyed_ind) | MALLOCX_TCACHE_NONE);
+	assert_ptr_not_null(destroyed_alloc,
+	    "Destroyed arena allocation failed");
+	dallocx(destroyed_alloc, MALLOCX_TCACHE_NONE);
+	destroy_manual_arena(destroyed_ind);
+
+	stats_buf_t sbuf;
+	json_fragment_t jemalloc;
+	bool malformed = stats_json_print_opts(&sbuf, "J", &jemalloc);
+	assert_false(malformed, "Malformed default JSON stats");
+	json_fragment_t stats_arenas;
+	assert_false(json_object_member(
+	                 jemalloc, "stats.arenas", &stats_arenas),
+	    "Default JSON stats omitted stats.arenas");
+
+	char manual_key[32];
+	malloc_snprintf(
+	    manual_key, sizeof(manual_key), "%u", manual_ind);
+	expect_arena_sample(stats_arenas, "0", 0, true);
+	expect_arena_sample(
+	    stats_arenas, manual_key, manual_ind, true);
+	expect_arena_sample(stats_arenas, "destroyed",
+	    MALLCTL_ARENAS_DESTROYED, false);
+	stats_buf_fini(&sbuf);
+
+	const option_case_t cases[] = {
+	    {"Jg", option_parent_jemalloc, "version"},
+	    {"Jm", option_parent_arenas, "merged"},
+	    {"Jd", option_parent_arenas, "destroyed"},
+	    {"Ja", option_parent_arenas, manual_key},
+	    {"Jb", option_parent_merged, "bins"},
+	    {"Jl", option_parent_merged, "lextents"},
+	    {"Jx", option_parent_stats, "mutexes"},
+	    {"Je", option_parent_merged, "extents"},
+	    {"Jh", option_parent_merged, "hpa_shard"},
+	    {"Jmda", option_parent_jemalloc, "stats.arenas"},
+	};
+	for (size_t i = 0; i < ARRAY_COUNT(cases); i++) {
+		expect_option_omits(&cases[i]);
+	}
+
+	dallocx(manual_alloc, MALLOCX_TCACHE_NONE);
+	destroy_manual_arena(manual_ind);
 }
 TEST_END
 
-TEST_BEGIN(test_hpa_shard_json_contains_sec_stats) {
+TEST_BEGIN(test_json_stats_global_and_arena) {
 	test_skip_if(!config_stats);
-	test_skip_if(!hpa_supported());
-
-	void *p = mallocx(PAGE, MALLOCX_TCACHE_NONE);
-	expect_ptr_not_null(p, "Unexpected mallocx failure");
-
-	uint64_t epoch = 1;
-	size_t   sz = sizeof(epoch);
-	expect_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sz), 0,
-	    "Unexpected mallctl() failure");
 
 	stats_buf_t sbuf;
-	stats_buf_init(&sbuf);
-	malloc_stats_print(stats_buf_write_cb, &sbuf, "J");
+	json_fragment_t stats, merged;
+	bool malformed = stats_json_print(&sbuf, &stats, &merged);
+	expect_false(malformed, "Could not find runtime stats in JSON output");
+	if (malformed) {
+		stats_buf_fini(&sbuf);
+		return;
+	}
 
-	const char *sec_bytes = strstr(sbuf.buf, "\"sec_bytes\"");
-	expect_ptr_not_null(sec_bytes, "JSON output should contain sec_bytes");
-	const char *hpa_shard_end = NULL;
-	const char *hpa_shard = json_find_previous_hpa_shard_object(
-	    sbuf.buf, sec_bytes, &hpa_shard_end);
-	expect_ptr_not_null(hpa_shard,
-	    "sec_bytes should be associated with an hpa_shard JSON object");
-	expect_ptr_not_null(hpa_shard_end,
-	    "Could not find end of enclosing hpa_shard JSON object");
-	expect_true(sec_bytes != NULL && sec_bytes < hpa_shard_end,
-	    "sec_bytes should be nested inside hpa_shard JSON object");
-	const char *sec_hits = strstr(hpa_shard, "\"sec_hits\"");
-	expect_true(sec_hits != NULL && sec_hits < hpa_shard_end,
-	    "sec_hits should be nested inside hpa_shard JSON object");
-	const char *sec_misses = strstr(hpa_shard, "\"sec_misses\"");
-	expect_true(sec_misses != NULL && sec_misses < hpa_shard_end,
-	    "sec_misses should be nested inside hpa_shard JSON object");
+	const char *const stats_keys[] = {"allocated", "active", "metadata",
+	    "metadata_edata", "metadata_rtree", "metadata_thp", "resident",
+	    "mapped", "retained", "pinned", "zero_reallocs",
+	    "background_thread", "mutexes"};
+	expect_json_object_keys(
+	    stats, stats_keys, ARRAY_COUNT(stats_keys), "stats");
+	expect_json_ctl_fields(
+	    stats, "stats", global_fields, ARRAY_COUNT(global_fields));
+
+	json_fragment_t background_thread;
+	expect_false(json_object_member(
+	                 stats, "background_thread", &background_thread),
+	    "stats is missing background_thread");
+	const char *const background_thread_keys[] = {
+	    "num_threads", "num_runs", "run_interval"};
+	expect_json_object_keys(background_thread, background_thread_keys,
+	    ARRAY_COUNT(background_thread_keys), "stats.background_thread");
+	if (have_background_thread) {
+		expect_json_ctl_fields(background_thread, "stats.background_thread",
+		    background_thread_fields,
+		    ARRAY_COUNT(background_thread_fields));
+	} else {
+		for (size_t i = 0; i < ARRAY_COUNT(background_thread_keys); i++) {
+			expect_json_uint_eq(background_thread,
+			    background_thread_keys[i], 0, "stats.background_thread");
+		}
+	}
+
+	char arena_prefix[64];
+	malloc_snprintf(arena_prefix, sizeof(arena_prefix), "stats.arenas.%u",
+	    MALLCTL_ARENAS_ALL);
+	size_t expected_merged_keys = ARRAY_COUNT(merged_keys);
+	if (opt_pac_sec_opts.nshards > 0) {
+		expected_merged_keys += ARRAY_COUNT(pac_sec_keys);
+	}
+	expect_zu_eq(json_object_size(merged), expected_merged_keys,
+	    "merged arena stats has an unexpected number of keys");
+	expect_json_object_has_keys(merged, merged_keys, ARRAY_COUNT(merged_keys),
+	    "merged arena stats");
+	expect_json_ctl_fields(
+	    merged, arena_prefix, arena_fields, ARRAY_COUNT(arena_fields));
+	if (opt_pac_sec_opts.nshards > 0) {
+		expect_json_object_has_keys(merged, pac_sec_keys,
+		    ARRAY_COUNT(pac_sec_keys), "merged arena stats");
+		expect_json_ctl_fields(merged, arena_prefix, pac_sec_fields,
+		    ARRAY_COUNT(pac_sec_fields));
+	}
+
+	json_fragment_t small, large;
+	expect_false(json_object_member(merged, "small", &small),
+	    "merged arena stats are missing small");
+	expect_false(json_object_member(merged, "large", &large),
+	    "merged arena stats are missing large");
+	expect_json_object_keys(small, arena_alloc_keys,
+	    ARRAY_COUNT(arena_alloc_keys), "stats.arenas.merged.small");
+	expect_json_object_keys(large, arena_alloc_keys,
+	    ARRAY_COUNT(arena_alloc_keys), "stats.arenas.merged.large");
+	char alloc_prefix[96];
+	malloc_snprintf(
+	    alloc_prefix, sizeof(alloc_prefix), "%s.small", arena_prefix);
+	expect_json_ctl_fields(small, alloc_prefix, arena_alloc_fields,
+	    ARRAY_COUNT(arena_alloc_fields));
+	malloc_snprintf(
+	    alloc_prefix, sizeof(alloc_prefix), "%s.large", arena_prefix);
+	expect_json_ctl_fields(large, alloc_prefix, arena_alloc_fields,
+	    ARRAY_COUNT(arena_alloc_fields));
+
+	json_fragment_t mutexes;
+	expect_false(json_object_member(stats, "mutexes", &mutexes),
+	    "stats is missing mutexes");
+	expect_zu_eq(json_object_size(mutexes), num_global_mutexes,
+	    "stats.mutexes has an unexpected number of mutexes");
+	for (size_t i = 0; i < num_global_mutexes; i++) {
+		json_fragment_t mutex;
+		expect_false(json_object_member(
+		                 mutexes, global_mutex_names[i], &mutex),
+		    "stats.mutexes is missing %s", global_mutex_names[i]);
+		char prefix[128];
+		malloc_snprintf(prefix, sizeof(prefix), "stats.mutexes.%s",
+		    global_mutex_names[i]);
+		expect_mutex_object(mutex, prefix);
+	}
+
+	expect_false(json_object_member(merged, "mutexes", &mutexes),
+	    "merged arena stats are missing mutexes");
+	expect_zu_eq(json_object_size(mutexes), num_arena_mutexes,
+	    "merged arena mutexes has an unexpected number of mutexes");
+	for (size_t i = 0; i < num_arena_mutexes; i++) {
+		json_fragment_t mutex;
+		expect_false(json_object_member(
+		                 mutexes, arena_mutex_names[i], &mutex),
+		    "merged arena mutexes is missing %s", arena_mutex_names[i]);
+		char prefix[160];
+		malloc_snprintf(prefix, sizeof(prefix), "%s.mutexes.%s",
+		    arena_prefix, arena_mutex_names[i]);
+		expect_mutex_object(mutex, prefix);
+	}
 
 	stats_buf_fini(&sbuf);
-	dallocx(p, MALLOCX_TCACHE_NONE);
 }
 TEST_END
 
-TEST_BEGIN(test_hpa_shard_json_contains_retained_stats) {
+static const ctl_field_t hpa_fields[] = {
+	{"npageslabs", "npageslabs", ctl_field_size},
+	{"nactive", "nactive", ctl_field_size},
+	{"ndirty", "ndirty", ctl_field_size},
+	{"npurge_passes", "npurge_passes", ctl_field_uint64},
+	{"npurges", "npurges", ctl_field_uint64},
+	{"nhugifies", "nhugifies", ctl_field_uint64},
+	{"nhugify_failures", "nhugify_failures", ctl_field_uint64},
+	{"ndehugifies", "ndehugifies", ctl_field_uint64},
+};
+
+static const ctl_field_t hpa_sec_fields[] = {
+	{"sec_bytes", "hpa_sec_bytes", ctl_field_size},
+	{"sec_hits", "hpa_sec_hits", ctl_field_size},
+	{"sec_misses", "hpa_sec_misses", ctl_field_size},
+	{"sec_dalloc_noflush", "hpa_sec_dalloc_noflush", ctl_field_size},
+	{"sec_dalloc_flush", "hpa_sec_dalloc_flush", ctl_field_size},
+	{"sec_overfills", "hpa_sec_overfills", ctl_field_size},
+};
+
+static const ctl_field_t hpa_slab_fields[] = {
+	{"npageslabs_huge", "npageslabs_huge", ctl_field_size},
+	{"nactive_huge", "nactive_huge", ctl_field_size},
+	{"ndirty_huge", "ndirty_huge", ctl_field_size},
+	{"npageslabs_nonhuge", "npageslabs_nonhuge", ctl_field_size},
+	{"nactive_nonhuge", "nactive_nonhuge", ctl_field_size},
+	{"ndirty_nonhuge", "ndirty_nonhuge", ctl_field_size},
+};
+static const char *const hpa_slab_keys[] = {"npageslabs_huge",
+	"nactive_huge", "ndirty_huge", "npageslabs_nonhuge",
+	"nactive_nonhuge", "ndirty_nonhuge", "nretained_nonhuge"};
+
+static void
+expect_hpa_slab(json_fragment_t slab, const char *ctl_prefix,
+    const char *name) {
+	expect_json_object_keys(
+	    slab, hpa_slab_keys, ARRAY_COUNT(hpa_slab_keys), name);
+	expect_json_ctl_fields(slab, ctl_prefix, hpa_slab_fields,
+	    ARRAY_COUNT(hpa_slab_fields));
+
+	size_t npageslabs, nactive, ndirty;
+	size_t sz = sizeof(size_t);
+	char ctl_name[192];
+	malloc_snprintf(ctl_name, sizeof(ctl_name),
+	    "%s.npageslabs_nonhuge", ctl_prefix);
+	expect_d_eq(mallctl(ctl_name, &npageslabs, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", ctl_name);
+	sz = sizeof(size_t);
+	malloc_snprintf(
+	    ctl_name, sizeof(ctl_name), "%s.nactive_nonhuge", ctl_prefix);
+	expect_d_eq(mallctl(ctl_name, &nactive, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", ctl_name);
+	sz = sizeof(size_t);
+	malloc_snprintf(
+	    ctl_name, sizeof(ctl_name), "%s.ndirty_nonhuge", ctl_prefix);
+	expect_d_eq(mallctl(ctl_name, &ndirty, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", ctl_name);
+	expect_json_uint_eq(slab, "nretained_nonhuge",
+	    npageslabs * HUGEPAGE_PAGES - nactive - ndirty, name);
+}
+
+static const ctl_field_t hpa_alloc_fields[] = {
+	{"min_extents", "min_extents", ctl_field_uint64},
+	{"max_extents", "max_extents", ctl_field_uint64},
+	{"extents", "extents", ctl_field_uint64},
+	{"ps", "ps", ctl_field_uint64},
+	{"pages_per_ps", "pages_per_ps", ctl_field_uint64},
+	{"extents_per_ps", "extents_per_ps", ctl_field_uint64},
+	{"total_elapsed_ns_per_ps", "total_elapsed_ns_per_ps",
+	    ctl_field_uint64},
+};
+static const char *const hpa_alloc_keys[] = {"min_extents", "max_extents",
+	"extents", "ps", "pages_per_ps", "extents_per_ps",
+	"total_elapsed_ns_per_ps"};
+
+TEST_BEGIN(test_json_stats_hpa) {
 	test_skip_if(!config_stats);
 	test_skip_if(!hpa_supported());
 
-	void *p = mallocx(PAGE, MALLOCX_TCACHE_NONE);
-	expect_ptr_not_null(p, "Unexpected mallocx failure");
-
-	uint64_t epoch = 1;
-	size_t   sz = sizeof(epoch);
-	expect_d_eq(mallctl("epoch", NULL, NULL, (void *)&epoch, sz), 0,
-	    "Unexpected mallctl() failure");
-
 	stats_buf_t sbuf;
-	stats_buf_init(&sbuf);
-	malloc_stats_print(stats_buf_write_cb, &sbuf, "J");
+	json_fragment_t stats, merged;
+	bool malformed = stats_json_print(&sbuf, &stats, &merged);
+	expect_false(malformed, "Could not find runtime stats in JSON output");
+	if (malformed) {
+		stats_buf_fini(&sbuf);
+		return;
+	}
 
-	const char *full_slabs_end = NULL;
-	const char *full_slabs = json_find_named_object(
-	    sbuf.buf, "full_slabs", &full_slabs_end);
-	expect_ptr_not_null(
-	    full_slabs, "JSON output should contain full_slabs");
-	const char *full_retained = strstr(full_slabs, "\"nretained_nonhuge\"");
-	expect_true(full_retained != NULL && full_retained < full_slabs_end,
-	    "full_slabs should contain nretained_nonhuge");
+	json_fragment_t hpa;
+	expect_false(json_object_member(merged, "hpa_shard", &hpa),
+	    "merged arena stats are missing hpa_shard");
+	const char *const hpa_keys[] = {"sec_bytes", "sec_hits", "sec_misses",
+	    "sec_dalloc_noflush", "sec_dalloc_flush", "sec_overfills",
+	    "npageslabs", "nactive", "ndirty", "npurge_passes", "npurges",
+	    "nhugifies", "nhugify_failures", "ndehugifies", "slabs",
+	    "extent_allocation_distribution", "full_slabs", "empty_slabs",
+	    "nonfull_slabs"};
+	expect_json_object_keys(
+	    hpa, hpa_keys, ARRAY_COUNT(hpa_keys), "hpa_shard");
 
-	const char *empty_slabs_end = NULL;
-	const char *empty_slabs = json_find_named_object(
-	    sbuf.buf, "empty_slabs", &empty_slabs_end);
-	expect_ptr_not_null(
-	    empty_slabs, "JSON output should contain empty_slabs");
-	const char *empty_retained = strstr(
-	    empty_slabs, "\"nretained_nonhuge\"");
-	expect_true(empty_retained != NULL && empty_retained < empty_slabs_end,
-	    "empty_slabs should contain nretained_nonhuge");
+	char arena_prefix[64];
+	malloc_snprintf(arena_prefix, sizeof(arena_prefix), "stats.arenas.%u",
+	    MALLCTL_ARENAS_ALL);
+	expect_json_ctl_fields(hpa, arena_prefix, hpa_sec_fields,
+	    ARRAY_COUNT(hpa_sec_fields));
+	char hpa_prefix[96];
+	malloc_snprintf(
+	    hpa_prefix, sizeof(hpa_prefix), "%s.hpa_shard", arena_prefix);
+	expect_json_ctl_fields(
+	    hpa, hpa_prefix, hpa_fields, ARRAY_COUNT(hpa_fields));
 
-	const char *nonfull_slabs_end = NULL;
-	const char *nonfull_slabs = json_find_named_array(
-	    sbuf.buf, "nonfull_slabs", &nonfull_slabs_end);
-	expect_ptr_not_null(
-	    nonfull_slabs, "JSON output should contain nonfull_slabs");
-	const char *nonfull_retained = strstr(
-	    nonfull_slabs, "\"nretained_nonhuge\"");
-	expect_true(
-	    nonfull_retained != NULL && nonfull_retained < nonfull_slabs_end,
-	    "nonfull_slabs should contain nretained_nonhuge");
+	json_fragment_t slabs;
+	expect_false(json_object_member(hpa, "slabs", &slabs),
+	    "hpa_shard is missing slabs");
+	char slab_prefix[128];
+	malloc_snprintf(
+	    slab_prefix, sizeof(slab_prefix), "%s.slabs", hpa_prefix);
+	expect_hpa_slab(slabs, slab_prefix, "hpa_shard.slabs");
+
+	const char *const summary_names[] = {"full_slabs", "empty_slabs"};
+	for (size_t i = 0; i < ARRAY_COUNT(summary_names); i++) {
+		json_fragment_t summary;
+		expect_false(json_object_member(hpa, summary_names[i], &summary),
+		    "hpa_shard is missing %s", summary_names[i]);
+		malloc_snprintf(slab_prefix, sizeof(slab_prefix), "%s.%s",
+		    hpa_prefix, summary_names[i]);
+		expect_hpa_slab(summary, slab_prefix, summary_names[i]);
+	}
+
+	json_fragment_t nonfull;
+	expect_false(json_object_member(hpa, "nonfull_slabs", &nonfull),
+	    "hpa_shard is missing nonfull_slabs");
+	size_t nonfull_count = PSSET_NPSIZES < SC_NPSIZES ? PSSET_NPSIZES
+	                                                  : SC_NPSIZES;
+	expect_zu_eq(json_array_size(nonfull), nonfull_count,
+	    "nonfull_slabs has an unexpected number of rows");
+	for (size_t i = 0; i < nonfull_count; i++) {
+		json_fragment_t slab;
+		expect_false(json_array_element(nonfull, i, &slab),
+		    "nonfull_slabs is missing row %zu", i);
+		malloc_snprintf(slab_prefix, sizeof(slab_prefix),
+		    "%s.nonfull_slabs.%zu", hpa_prefix, i);
+		char row_name[64];
+		malloc_snprintf(
+		    row_name, sizeof(row_name), "nonfull_slabs[%zu]", i);
+		expect_hpa_slab(slab, slab_prefix, row_name);
+	}
+
+	json_fragment_t distribution;
+	expect_false(json_object_member(
+	                 hpa, "extent_allocation_distribution", &distribution),
+	    "hpa_shard is missing extent_allocation_distribution");
+	expect_zu_eq(json_array_size(distribution), SEC_MAX_NALLOCS + 1,
+	    "extent_allocation_distribution has an unexpected row count");
+	for (size_t i = 0; i <= SEC_MAX_NALLOCS; i++) {
+		json_fragment_t row;
+		expect_false(json_array_element(distribution, i, &row),
+		    "extent_allocation_distribution is missing row %zu", i);
+		char row_name[80];
+		malloc_snprintf(row_name, sizeof(row_name),
+		    "extent_allocation_distribution[%zu]", i);
+		expect_json_object_keys(row, hpa_alloc_keys,
+		    ARRAY_COUNT(hpa_alloc_keys), row_name);
+		char ctl_prefix[128];
+		malloc_snprintf(ctl_prefix, sizeof(ctl_prefix),
+		    "%s.alloc.%zu", hpa_prefix, i);
+		expect_json_ctl_fields(row, ctl_prefix, hpa_alloc_fields,
+		    ARRAY_COUNT(hpa_alloc_fields));
+	}
 
 	stats_buf_fini(&sbuf);
-	dallocx(p, MALLOCX_TCACHE_NONE);
+}
+TEST_END
+
+static const ctl_field_t bin_fields[] = {
+	{"nmalloc", "nmalloc", ctl_field_uint64},
+	{"ndalloc", "ndalloc", ctl_field_uint64},
+	{"curregs", "curregs", ctl_field_size},
+	{"nrequests", "nrequests", ctl_field_uint64},
+	{"nfills", "nfills", ctl_field_uint64},
+	{"nflushes", "nflushes", ctl_field_uint64},
+	{"nreslabs", "nreslabs", ctl_field_uint64},
+	{"curslabs", "curslabs", ctl_field_size},
+	{"nonfull_slabs", "nonfull_slabs", ctl_field_size},
+};
+static const char *const bin_keys[] = {"nmalloc", "ndalloc", "curregs",
+	"nrequests", "nfills", "nflushes", "nreslabs", "curslabs",
+	"nonfull_slabs", "mutex"};
+
+static const ctl_field_t lextent_fields[] = {
+	{"curlextents", "curlextents", ctl_field_size},
+};
+static const char *const lextent_keys[] = {"curlextents"};
+
+static const ctl_field_t extent_fields[] = {
+	{"ndirty", "ndirty", ctl_field_size},
+	{"nmuzzy", "nmuzzy", ctl_field_size},
+	{"nretained", "nretained", ctl_field_size},
+	{"npinned", "npinned", ctl_field_size},
+	{"dirty_bytes", "dirty_bytes", ctl_field_size},
+	{"muzzy_bytes", "muzzy_bytes", ctl_field_size},
+	{"retained_bytes", "retained_bytes", ctl_field_size},
+	{"pinned_bytes", "pinned_bytes", ctl_field_size},
+};
+static const char *const extent_keys[] = {"ndirty", "nmuzzy", "nretained",
+	"npinned", "dirty_bytes", "muzzy_bytes", "retained_bytes",
+	"pinned_bytes"};
+
+static const char *const prof_keys[] = {"prof_live_requested",
+	"prof_live_count", "prof_accum_requested", "prof_accum_count"};
+
+static void
+expect_prof_stats(json_fragment_t object, const char *ctl_prefix) {
+	prof_stats_t live, accum;
+	size_t sz = sizeof(prof_stats_t);
+	char ctl_name[128];
+	malloc_snprintf(
+	    ctl_name, sizeof(ctl_name), "%s.live", ctl_prefix);
+	expect_d_eq(mallctl(ctl_name, &live, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", ctl_name);
+	sz = sizeof(prof_stats_t);
+	malloc_snprintf(
+	    ctl_name, sizeof(ctl_name), "%s.accum", ctl_prefix);
+	expect_d_eq(mallctl(ctl_name, &accum, &sz, NULL, 0), 0,
+	    "mallctl failed for %s", ctl_name);
+	expect_json_uint_eq(object, "prof_live_requested", live.req_sum,
+	    ctl_prefix);
+	expect_json_uint_eq(
+	    object, "prof_live_count", live.count, ctl_prefix);
+	expect_json_uint_eq(object, "prof_accum_requested", accum.req_sum,
+	    ctl_prefix);
+	expect_json_uint_eq(
+	    object, "prof_accum_count", accum.count, ctl_prefix);
+}
+
+TEST_BEGIN(test_json_stats_arena_tables) {
+	test_skip_if(!config_stats);
+
+	stats_buf_t sbuf;
+	json_fragment_t stats, merged;
+	bool malformed = stats_json_print(&sbuf, &stats, &merged);
+	expect_false(malformed, "Could not find runtime stats in JSON output");
+	if (malformed) {
+		stats_buf_fini(&sbuf);
+		return;
+	}
+
+	unsigned nbins, nlextents;
+	size_t sz = sizeof(nbins);
+	expect_d_eq(mallctl("arenas.nbins", &nbins, &sz, NULL, 0), 0,
+	    "mallctl failed for arenas.nbins");
+	sz = sizeof(nlextents);
+	expect_d_eq(mallctl("arenas.nlextents", &nlextents, &sz, NULL, 0), 0,
+	    "mallctl failed for arenas.nlextents");
+
+	json_fragment_t bins;
+	expect_false(json_object_member(merged, "bins", &bins),
+	    "merged arena stats are missing bins");
+	expect_zu_eq(json_array_size(bins), nbins,
+	    "bins has an unexpected number of rows");
+	json_fragment_t first_bin, ignored;
+	expect_false(json_array_element(bins, 0, &first_bin),
+	    "bins is missing its first row");
+	bool prof_stats_present = !json_object_member(
+	    first_bin, "prof_live_requested", &ignored);
+	for (unsigned i = 0; i < nbins; i++) {
+		json_fragment_t bin;
+		expect_false(json_array_element(bins, i, &bin),
+		    "bins is missing row %u", i);
+		char row_name[64];
+		malloc_snprintf(row_name, sizeof(row_name), "bins[%u]", i);
+		expect_zu_eq(json_object_size(bin), ARRAY_COUNT(bin_keys)
+		        + (prof_stats_present ? ARRAY_COUNT(prof_keys) : 0),
+		    "%s has an unexpected number of keys", row_name);
+		expect_json_object_has_keys(
+		    bin, bin_keys, ARRAY_COUNT(bin_keys), row_name);
+		char ctl_prefix[128];
+		malloc_snprintf(ctl_prefix, sizeof(ctl_prefix),
+		    "stats.arenas.%u.bins.%u", MALLCTL_ARENAS_ALL, i);
+		expect_json_ctl_fields(
+		    bin, ctl_prefix, bin_fields, ARRAY_COUNT(bin_fields));
+		if (prof_stats_present) {
+			expect_json_object_has_keys(
+			    bin, prof_keys, ARRAY_COUNT(prof_keys), row_name);
+			char prof_prefix[128];
+			malloc_snprintf(prof_prefix, sizeof(prof_prefix),
+			    "prof.stats.bins.%u", i);
+			expect_prof_stats(bin, prof_prefix);
+		}
+
+		json_fragment_t mutex;
+		expect_false(json_object_member(bin, "mutex", &mutex),
+		    "%s is missing mutex", row_name);
+		char mutex_prefix[160];
+		malloc_snprintf(mutex_prefix, sizeof(mutex_prefix), "%s.mutex",
+		    ctl_prefix);
+		expect_mutex_object(mutex, mutex_prefix);
+	}
+
+	json_fragment_t lextents;
+	expect_false(json_object_member(merged, "lextents", &lextents),
+	    "merged arena stats are missing lextents");
+	expect_zu_eq(json_array_size(lextents), nlextents,
+	    "lextents has an unexpected number of rows");
+	for (unsigned i = 0; i < nlextents; i++) {
+		json_fragment_t lextent;
+		expect_false(json_array_element(lextents, i, &lextent),
+		    "lextents is missing row %u", i);
+		char row_name[64];
+		malloc_snprintf(row_name, sizeof(row_name), "lextents[%u]", i);
+		expect_zu_eq(json_object_size(lextent), ARRAY_COUNT(lextent_keys)
+		        + (prof_stats_present ? ARRAY_COUNT(prof_keys) : 0),
+		    "%s has an unexpected number of keys", row_name);
+		expect_json_object_has_keys(lextent, lextent_keys,
+		    ARRAY_COUNT(lextent_keys), row_name);
+		char ctl_prefix[128];
+		malloc_snprintf(ctl_prefix, sizeof(ctl_prefix),
+		    "stats.arenas.%u.lextents.%u", MALLCTL_ARENAS_ALL, i);
+		expect_json_ctl_fields(lextent, ctl_prefix, lextent_fields,
+		    ARRAY_COUNT(lextent_fields));
+		if (prof_stats_present) {
+			expect_json_object_has_keys(lextent, prof_keys,
+			    ARRAY_COUNT(prof_keys), row_name);
+			char prof_prefix[128];
+			malloc_snprintf(prof_prefix, sizeof(prof_prefix),
+			    "prof.stats.lextents.%u", i);
+			expect_prof_stats(lextent, prof_prefix);
+		}
+	}
+
+	json_fragment_t extents;
+	expect_false(json_object_member(merged, "extents", &extents),
+	    "merged arena stats are missing extents");
+	expect_zu_eq(json_array_size(extents), SC_NPSIZES,
+	    "extents has an unexpected number of rows");
+	for (unsigned i = 0; i < SC_NPSIZES; i++) {
+		json_fragment_t extent;
+		expect_false(json_array_element(extents, i, &extent),
+		    "extents is missing row %u", i);
+		char row_name[64];
+		malloc_snprintf(row_name, sizeof(row_name), "extents[%u]", i);
+		expect_json_object_keys(
+		    extent, extent_keys, ARRAY_COUNT(extent_keys), row_name);
+		char ctl_prefix[128];
+		malloc_snprintf(ctl_prefix, sizeof(ctl_prefix),
+		    "stats.arenas.%u.extents.%u", MALLCTL_ARENAS_ALL, i);
+		expect_json_ctl_fields(extent, ctl_prefix, extent_fields,
+		    ARRAY_COUNT(extent_fields));
+	}
+
+	stats_buf_fini(&sbuf);
 }
 TEST_END
 
 int
 main(void) {
-	return test_no_reentrancy(test_json_stats_mutexes,
-	    test_hpa_shard_json_ndirty_huge,
-	    test_hpa_shard_json_contains_sec_stats,
-	    test_hpa_shard_json_contains_retained_stats);
+	return test_no_reentrancy(test_json_stats_global_and_arena,
+	    test_json_stats_arena_tables, test_json_stats_hpa,
+	    test_json_stats_arenas_and_options);
 }


### PR DESCRIPTION
Stats refactor - emit row by row using data descriptors

This PR builds on top of [PR 2959](https://github.com/jemalloc/jemalloc/pull/2959)  by separating per-size-class row emission and gathering. 

* First commit adds a descriptor-driven emitter for column tables and converts the bin, lextent, extent, and HPA pageslab tables to use shared per-row emit helpers. Rows remain streamed with O(1) memory, while explicit JSON column ordering is preserved. The emitter supports generic conditional columns and includes unit coverage for table rendering, JSON selection and ordering, and conditional fields. There are no intended output changes.

* Second commit adds those columns to JSON output in descriptor order and simplifies the code. Removed all four JSON-order arrays and most column enums. Text output remains unchanged.  Old JSON key/value remain, superset verification confirms only new fields were added.