### PR TITLE
Os layer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@
 
 /src/*.[od]
 /src/*.sym
+/src/os/*.[od]
+/src/os/*.sym
 
 # These are semantically meaningful for clangd and related tooling.
 /build/

--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -10,17 +10,25 @@
  *
  *   os/posix/<module>.h  - the default, used by every POSIX platform.
  *   os/<os>/<module>.h   - an override, present ONLY when an OS specializes
- *                          that module.
+ *                          that module (e.g. windows/file.h).
  *
  * A dispatcher picks the OS-specific file when one exists and otherwise falls
  * back to posix/ (guarded by JEMALLOC_OS_POSIX), so any POSIX platform builds
  * without being enumerated anywhere.  A non-POSIX platform with no override
- * hits a #error.
+ * hits a #error.  Each os/<module>.h also declares the function prototypes
+ * its backends must implement, so a backend with a missing or mismatched
+ * function fails to compile instead of silently diverging.
  *
  * Adding OS support for a module (only when existing module headers cannot be
  * reused): create os/<os>/<module>.h (and later a matching src body when
  * necessary and add one branch to os/<module>.h.  Adding a whole new module:
  * module: create os/<module>.h + os/posix/<module>.h and #include it below.
  */
+
+/* Process */
+#include "jemalloc/internal/os/process.h"
+
+/* File I/O */
+#include "jemalloc/internal/os/file.h"
 
 #endif /* JEMALLOC_INTERNAL_OS_H */

--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -1,0 +1,26 @@
+#ifndef JEMALLOC_INTERNAL_OS_H
+#define JEMALLOC_INTERNAL_OS_H
+
+/*
+ * OS layer.
+ *
+ * Portable code includes this header to reach the OS-touching primitives it
+ * needs.  Each facility is a module with its own dispatcher (os/<module>.h)
+ * that selects an implementation:
+ *
+ *   os/posix/<module>.h  - the default, used by every POSIX platform.
+ *   os/<os>/<module>.h   - an override, present ONLY when an OS specializes
+ *                          that module.
+ *
+ * A dispatcher picks the OS-specific file when one exists and otherwise falls
+ * back to posix/ (guarded by JEMALLOC_OS_POSIX), so any POSIX platform builds
+ * without being enumerated anywhere.  A non-POSIX platform with no override
+ * hits a #error.
+ *
+ * Adding OS support for a module (only when existing module headers cannot be
+ * reused): create os/<os>/<module>.h (and later a matching src body when
+ * necessary and add one branch to os/<module>.h.  Adding a whole new module:
+ * module: create os/<module>.h + os/posix/<module>.h and #include it below.
+ */
+
+#endif /* JEMALLOC_INTERNAL_OS_H */

--- a/include/jemalloc/internal/os/detect.h
+++ b/include/jemalloc/internal/os/detect.h
@@ -1,0 +1,26 @@
+#ifndef JEMALLOC_INTERNAL_OS_DETECT_H
+#define JEMALLOC_INTERNAL_OS_DETECT_H
+
+/*
+ * Platform detection for the OS-layer dispatchers.
+ *
+ * Defines JEMALLOC_OS_POSIX when the target is POSIX, so a module dispatcher
+ * can fall back to os/posix/<module>.h for ANY POSIX platform without that
+ * platform being enumerated.  We treat the target as POSIX if the C library
+ * advertises _POSIX_VERSION (via <unistd.h>) or the compiler predefines
+ * __unix__/__unix.  Windows is handled by its own _WIN32 branch and never
+ * reaches here.
+ *
+ * Included (idempotently) by os.h and by every module dispatcher, so the
+ * dispatchers work whether reached through os.h or directly.
+ */
+#if !defined(_WIN32)
+#  if !defined(__has_include) || __has_include(<unistd.h>)
+#    include <unistd.h>
+#  endif
+#  if defined(_POSIX_VERSION) || defined(__unix__) || defined(__unix)
+#    define JEMALLOC_OS_POSIX
+#  endif
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_DETECT_H */

--- a/include/jemalloc/internal/os/file.h
+++ b/include/jemalloc/internal/os/file.h
@@ -1,0 +1,36 @@
+#ifndef JEMALLOC_INTERNAL_OS_FILE_H
+#define JEMALLOC_INTERNAL_OS_FILE_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os/detect.h"
+
+/*
+ * File I/O interface.
+ * Default: posix/.  Override: Windows (CRT <io.h>).
+ */
+
+/* Functions required for implementation in each backend. */
+JEMALLOC_ALWAYS_INLINE ssize_t os_file_write_once(int fd, const void *buf,
+    size_t bytes);
+JEMALLOC_ALWAYS_INLINE ssize_t os_file_read_once(int fd, void *buf,
+    size_t bytes);
+/*
+ * Full retry-until-bytes-or-error versions of the above: loop over the
+ * _once primitive until target bytes are transferred or a non-retryable
+ * error occurs. Retrying on EINTR is a POSIX-only concept (Windows has no
+ * such signal-interruption semantics for this call), so that decision lives
+ * entirely in each backend rather than leaking into callers.
+ */
+JEMALLOC_ALWAYS_INLINE ssize_t os_file_write(int fd, const void *buf,
+    size_t bytes);
+JEMALLOC_ALWAYS_INLINE ssize_t os_file_read(int fd, void *buf, size_t bytes);
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/file.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/file.h"
+#else
+#  error "OS layer: no file backend for this platform; add os/<os>/file.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_FILE_H */

--- a/include/jemalloc/internal/os/posix/file.h
+++ b/include/jemalloc/internal/os/posix/file.h
@@ -1,0 +1,68 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_FILE_H
+#define JEMALLOC_INTERNAL_OS_POSIX_FILE_H
+
+/*
+ * POSIX file-I/O backend (read/write syscalls). Direct syscalls where
+ * available.
+ */
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#ifdef JEMALLOC_USE_SYSCALL
+#  include <sys/syscall.h>
+#endif
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_write_once(int fd, const void *buf, size_t bytes) {
+#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_write)
+	return (ssize_t)syscall(SYS_write, fd, buf, bytes);
+#else
+	return (ssize_t)write(fd, buf, bytes);
+#endif
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_read_once(int fd, void *buf, size_t bytes) {
+#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_read)
+	return (ssize_t)syscall(SYS_read, fd, buf, bytes);
+#else
+	return (ssize_t)read(fd, buf, bytes);
+#endif
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_write(int fd, const void *buf, size_t bytes) {
+	size_t bytes_written = 0;
+	do {
+		ssize_t result = os_file_write_once(fd,
+		    &((const byte_t *)buf)[bytes_written], bytes - bytes_written);
+		if (result < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			return result;
+		}
+		bytes_written += result;
+	} while (bytes_written < bytes);
+	return bytes_written;
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_read(int fd, void *buf, size_t bytes) {
+	size_t bytes_read = 0;
+	do {
+		ssize_t result = os_file_read_once(
+		    fd, &((byte_t *)buf)[bytes_read], bytes - bytes_read);
+		if (result < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			return result;
+		} else if (result == 0) {
+			break;
+		}
+		bytes_read += result;
+	} while (bytes_read < bytes);
+	return bytes_read;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_FILE_H */

--- a/include/jemalloc/internal/os/posix/process.h
+++ b/include/jemalloc/internal/os/posix/process.h
@@ -1,0 +1,17 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_PROCESS_H
+#define JEMALLOC_INTERNAL_OS_POSIX_PROCESS_H
+
+/*
+ * POSIX process backend (getpid()).
+ */
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+JEMALLOC_ALWAYS_INLINE int
+os_process_id(void) {
+	return (int)getpid();
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_PROCESS_H */

--- a/include/jemalloc/internal/os/process.h
+++ b/include/jemalloc/internal/os/process.h
@@ -1,0 +1,23 @@
+#ifndef JEMALLOC_INTERNAL_OS_PROCESS_H
+#define JEMALLOC_INTERNAL_OS_PROCESS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os/detect.h"
+
+/*
+ * Process interface.
+ * Default: posix/.  Override: Windows (GetCurrentProcessId).
+ */
+
+/* Functions required for implementation in each backend. */
+JEMALLOC_ALWAYS_INLINE int os_process_id(void);
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/process.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/process.h"
+#else
+#  error "OS layer: no process backend for this platform; add os/<os>/process.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_PROCESS_H */

--- a/include/jemalloc/internal/os/windows/file.h
+++ b/include/jemalloc/internal/os/windows/file.h
@@ -1,0 +1,52 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_FILE_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_FILE_H
+
+/*
+ * Windows file-I/O backend, via the C runtime io.h (_read/_write).
+ */
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include <io.h>
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_write_once(int fd, const void *buf, size_t bytes) {
+	return (ssize_t)write(fd, buf, (unsigned int)bytes);
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_read_once(int fd, void *buf, size_t bytes) {
+	return (ssize_t)read(fd, buf, (unsigned int)bytes);
+}
+
+/* No EINTR/signal-interruption semantics on Windows: never retry on error. */
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_write(int fd, const void *buf, size_t bytes) {
+	size_t bytes_written = 0;
+	do {
+		ssize_t result = os_file_write_once(fd,
+		    &((const byte_t *)buf)[bytes_written], bytes - bytes_written);
+		if (result < 0) {
+			return result;
+		}
+		bytes_written += result;
+	} while (bytes_written < bytes);
+	return bytes_written;
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_file_read(int fd, void *buf, size_t bytes) {
+	size_t bytes_read = 0;
+	do {
+		ssize_t result = os_file_read_once(
+		    fd, &((byte_t *)buf)[bytes_read], bytes - bytes_read);
+		if (result < 0) {
+			return result;
+		} else if (result == 0) {
+			break;
+		}
+		bytes_read += result;
+	} while (bytes_read < bytes);
+	return bytes_read;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_FILE_H */

--- a/include/jemalloc/internal/os/windows/process.h
+++ b/include/jemalloc/internal/os/windows/process.h
@@ -1,0 +1,15 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_PROCESS_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_PROCESS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+/*
+ * Windows process backend (GetCurrentProcessId()).
+ */
+
+JEMALLOC_ALWAYS_INLINE int
+os_process_id(void) {
+	return (int)GetCurrentProcessId();
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_PROCESS_H */

--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -1,6 +1,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os.h"
 #include "jemalloc/internal/util.h"
 
 #ifdef assert
@@ -758,79 +759,14 @@ malloc_printf(const char *format, ...) {
 	va_end(ap);
 }
 
-static ssize_t
-malloc_write_fd_syscall(int fd, const void *buf, size_t count) {
-#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_write)
-	/*
-	 * Use syscall(2) rather than write(2) when possible in order to avoid
-	 * the possibility of memory allocation within libc.  This is necessary
-	 * on FreeBSD; most operating systems do not have this problem though.
-	 *
-	 * syscall() returns long or int, depending on platform, so capture the
-	 * result in the widest plausible type to avoid compiler warnings.
-	 */
-	return (ssize_t)syscall(SYS_write, fd, buf, count);
-#else
-	return (ssize_t)write(fd, buf,
-#	ifdef _WIN32
-	    (unsigned int)
-#	endif
-	        count);
-#endif
-}
-
 ssize_t
 malloc_write_fd(int fd, const void *buf, size_t count) {
-	size_t bytes_written = 0;
-	do {
-		ssize_t result = malloc_write_fd_syscall(fd,
-		    &((const byte_t *)buf)[bytes_written],
-		    count - bytes_written);
-		if (result < 0) {
-#ifndef _WIN32
-			if (errno == EINTR) {
-				continue;
-			}
-#endif
-			return result;
-		}
-		bytes_written += result;
-	} while (bytes_written < count);
-	return bytes_written;
-}
-
-static ssize_t
-malloc_read_fd_syscall(int fd, void *buf, size_t count) {
-#if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_read)
-	return (ssize_t)syscall(SYS_read, fd, buf, count);
-#else
-	return (ssize_t)read(fd, buf,
-#	ifdef _WIN32
-	    (unsigned int)
-#	endif
-	        count);
-#endif
+	return os_file_write(fd, buf, count);
 }
 
 ssize_t
 malloc_read_fd(int fd, void *buf, size_t count) {
-	size_t bytes_read = 0;
-	do {
-		ssize_t result = malloc_read_fd_syscall(
-		    fd, &((byte_t *)buf)[bytes_read], count - bytes_read);
-		if (result < 0) {
-#ifndef _WIN32
-			if (errno == EINTR) {
-				continue;
-			}
-#endif
-			return result;
-		} else if (result == 0) {
-			break;
-		}
-		bytes_read += result;
-	} while (bytes_read < count);
-	return bytes_read;
+	return os_file_read(fd, buf, count);
 }
 
 /*

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -6,6 +6,7 @@
 #include "jemalloc/internal/jemalloc_internal_inlines_a.h"
 #include "jemalloc/internal/malloc_io.h"
 #include "jemalloc/internal/mutex.h"
+#include "jemalloc/internal/os.h"
 #include "jemalloc/internal/prof.h"
 #include "jemalloc/internal/prof_data.h"
 #include "jemalloc/internal/prof_inlines.h"
@@ -484,11 +485,7 @@ prof_sys_thread_name_fetch(tsd_t *tsd) {
 
 int
 prof_getpid(void) {
-#ifdef _WIN32
-	return GetCurrentProcessId();
-#else
-	return getpid();
-#endif
+	return os_process_id();
 }
 
 static long

--- a/test/unit/malloc_io.c
+++ b/test/unit/malloc_io.c
@@ -1,5 +1,9 @@
 #include "test/jemalloc_test.h"
 
+#ifndef O_BINARY
+#  define O_BINARY 0
+#endif
+
 TEST_BEGIN(test_malloc_strtoumax_no_endptr) {
 	int err;
 
@@ -269,9 +273,145 @@ TEST_BEGIN(test_malloc_snprintf_zero_size) {
 }
 TEST_END
 
+/*
+ * Exercised via malloc_open()/malloc_close() (existing, already
+ * cross-platform malloc_io.h wrappers) rather than an anonymous pipe: this
+ * mirrors how malloc_write_fd()/malloc_read_fd() are actually used in
+ * production (pages.c, prof_stack_range.c both read/write real files;
+ * nothing in jemalloc ever pipes through them). Written and read back via
+ * separate malloc_open() calls rather than a shared fd + seek-to-0, since
+ * malloc_lseek() (like the os_file_lseek() removed earlier) has no
+ * production caller either.
+ *
+ * The file itself is created via fopen()/fclose(), not malloc_open(): the
+ * latter is never called with O_CREAT in production (only O_RDONLY, on
+ * files that already exist), and its 2-arg signature has no mode_t
+ * parameter to pass along if it were -- calling the underlying variadic
+ * open() with O_CREAT but no mode gives the new file garbage permissions.
+ */
+static const char *test_io_filename = "malloc_io_test_file.tmp";
+
+static void
+create_empty_test_io_file(void) {
+	FILE *fp = fopen(test_io_filename, "wb");
+	assert_ptr_not_null(fp, "Unexpected fopen() failure");
+	fclose(fp);
+}
+
+TEST_BEGIN(test_malloc_write_read_fd_roundtrip) {
+	create_empty_test_io_file();
+	int fd = malloc_open(test_io_filename, O_WRONLY | O_BINARY);
+	assert_d_ne(fd, -1, "Unexpected malloc_open() failure");
+
+	static const char data[] =
+	    "malloc_write_fd()/malloc_read_fd() round-trip test payload.";
+
+	ssize_t written = malloc_write_fd(fd, data, sizeof(data));
+	expect_zd_eq(written, (ssize_t)sizeof(data),
+	    "malloc_write_fd() should write the full buffer");
+	malloc_close(fd);
+
+	fd = malloc_open(test_io_filename, O_RDONLY | O_BINARY);
+	assert_d_ne(fd, -1, "Unexpected malloc_open() failure");
+
+	char buf[sizeof(data)];
+	memset(buf, 0, sizeof(buf));
+	ssize_t nread = malloc_read_fd(fd, buf, sizeof(buf));
+	expect_zd_eq(nread, (ssize_t)sizeof(data),
+	    "malloc_read_fd() should read back everything that was written");
+	expect_d_eq(memcmp(buf, data, sizeof(data)), 0,
+	    "Round-tripped data should be unchanged");
+
+	malloc_close(fd);
+	remove(test_io_filename);
+}
+TEST_END
+
+TEST_BEGIN(test_malloc_read_fd_eof) {
+	create_empty_test_io_file();
+	int fd = malloc_open(test_io_filename, O_RDONLY | O_BINARY);
+	assert_d_ne(fd, -1, "Unexpected malloc_open() failure");
+
+	char buf[8];
+	ssize_t nread = malloc_read_fd(fd, buf, sizeof(buf));
+	expect_zd_eq(nread, 0,
+	    "malloc_read_fd() should report an empty file as a zero-length "
+	    "read (EOF)");
+
+	malloc_close(fd);
+	remove(test_io_filename);
+}
+TEST_END
+
+TEST_BEGIN(test_malloc_write_read_fd_accumulate) {
+	create_empty_test_io_file();
+	int fd = malloc_open(test_io_filename, O_WRONLY | O_BINARY);
+	assert_d_ne(fd, -1, "Unexpected malloc_open() failure");
+
+	static const char part1[] = "0123456789";
+	static const char part2[] = "abcdefghij";
+	size_t full_len = sizeof(part1) - 1 + sizeof(part2) - 1;
+
+	/*
+	 * Two separate writes, read back with a single malloc_read_fd() call
+	 * for the combined length.  This verifies that data written in
+	 * separate calls comes back in order and undamaged; it's also the
+	 * scenario malloc_read_fd()'s accumulate-until-count-satisfied loop
+	 * exists to handle, on platforms/fds where one read() doesn't return
+	 * everything at once.
+	 */
+	expect_zd_eq(malloc_write_fd(fd, part1, sizeof(part1) - 1),
+	    (ssize_t)sizeof(part1) - 1, "Unexpected short write");
+	expect_zd_eq(malloc_write_fd(fd, part2, sizeof(part2) - 1),
+	    (ssize_t)sizeof(part2) - 1, "Unexpected short write");
+	malloc_close(fd);
+
+	fd = malloc_open(test_io_filename, O_RDONLY | O_BINARY);
+	assert_d_ne(fd, -1, "Unexpected malloc_open() failure");
+
+	char buf[64];
+	memset(buf, 0, sizeof(buf));
+	ssize_t nread = malloc_read_fd(fd, buf, full_len);
+	expect_zd_eq(nread, (ssize_t)full_len,
+	    "malloc_read_fd() should return the full combined length");
+	expect_d_eq(memcmp(buf, part1, sizeof(part1) - 1), 0,
+	    "Unexpected content for the first part");
+	expect_d_eq(memcmp(buf + sizeof(part1) - 1, part2, sizeof(part2) - 1),
+	    0, "Unexpected content for the second part");
+
+	malloc_close(fd);
+	remove(test_io_filename);
+}
+TEST_END
+
+TEST_BEGIN(test_malloc_write_read_fd_bad_fd) {
+#ifndef _WIN32
+	/*
+	 * -1 is never a valid fd, on any platform; both wrappers should
+	 * propagate the error rather than loop forever. Not run on Windows:
+	 * the MSVC CRT's _read()/_write() route an invalid fd through
+	 * _invalid_parameter_handler(), which can raise a debug assertion
+	 * instead of returning -1/EBADF like POSIX guarantees. So
+	 * "negative return for a bad fd" isn't actually a portable contract
+	 * to test against on that CRT.
+	 */
+	expect_zd_lt(
+	    malloc_write_fd(-1, "x", 1), (ssize_t)0, "Expected write error");
+	char buf[1];
+	expect_zd_lt(malloc_read_fd(-1, buf, sizeof(buf)), (ssize_t)0,
+	    "Expected read error");
+#else
+	test_skip("Invalid-fd handling is not a portable contract on the "
+	    "MSVC CRT; see comment above");
+#endif
+}
+TEST_END
+
 int
 main(void) {
 	return test(test_malloc_strtoumax_no_endptr, test_malloc_strtoumax,
 	    test_malloc_snprintf_truncated, test_malloc_snprintf,
-	    test_malloc_snprintf_zero_size);
+	    test_malloc_snprintf_zero_size, test_malloc_write_read_fd_roundtrip,
+	    test_malloc_read_fd_eof, test_malloc_write_read_fd_accumulate,
+	    test_malloc_write_read_fd_bad_fd);
 }


### PR DESCRIPTION
## Motivation

The OS-specific pieces jemalloc depends on — mutexes/condvars, file I/O, clocks, virtual memory,
/proc reads, CPU/thread queries, fork handling, DSS — currently live inline across many .c/.h
files, each behind its own #ifdef ladder. OS-touching logic ends up scattered and duplicated:
there is no single place to see what the allocator actually requires from the OS, and porting to a
new platform means hunting #ifdefs throughout the tree.

## Design

`os.h` is the single header portable code includes. Each facility gets a dispatcher
`os/<module>.h` that picks `os/posix/<module>.h` (default) or `os/<os>/<module>.h` (override, e.g.
Windows) based on `JEMALLOC_OS_POSIX` (`os/detect.h`). Adding a new module means dropping in a
dispatcher + posix/override files and wiring one include into `os.h`; adding OS support for an
existing module means dropping in one override file.


## Behavior

Purely mechanical — no logic changes. Verified line-by-line against the pre-refactor
code (syscall sequences, casts, EINTR retry loop, short-read/write accumulation, EOF handling all
preserved exactly) and independently confirmed by two adversarial reviews (Codex, Gemini) with no
findings.

