### PR TITLE
Avoid background-thread reset shutdown deadlock

### DIFF
--- a/include/jemalloc/internal/background_thread.h
+++ b/include/jemalloc/internal/background_thread.h
@@ -16,7 +16,7 @@
 typedef enum {
 	background_thread_stopped,
 	background_thread_started,
-	/* Thread waits on the global lock when paused (for arena_reset). */
+	/* Thread waits on its condition variable while an arena is reset. */
 	background_thread_paused,
 } background_thread_state_t;
 

--- a/include/jemalloc/internal/test_hooks.h
+++ b/include/jemalloc/internal/test_hooks.h
@@ -5,6 +5,7 @@ extern JEMALLOC_EXPORT void (*test_hooks_arena_new_hook)(void);
 extern JEMALLOC_EXPORT void (*test_hooks_libc_hook)(void);
 extern JEMALLOC_EXPORT void (*test_hooks_safety_check_abort)(const char *);
 #if defined(JEMALLOC_JET) || defined(JEMALLOC_UNIT_TEST)
+extern JEMALLOC_EXPORT void (*test_hooks_background_thread_pause_hook)(void);
 extern JEMALLOC_EXPORT void (*test_hooks_tsd_bootstrap_hook)(void);
 #endif
 

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -59,8 +59,8 @@ background_thread_arena_reset_begin(tsd_t *tsd, unsigned arena_ind) {
 		if (background_thread_enabled()) {
 			background_thread_info_t *info =
 			    background_thread_info_get(arena_ind);
-			assert(info->state == background_thread_started);
 			malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+			assert(info->state == background_thread_started);
 			info->state = background_thread_paused;
 			malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
 		}
@@ -73,9 +73,12 @@ background_thread_arena_reset_finish(tsd_t *tsd, unsigned arena_ind) {
 		if (background_thread_enabled()) {
 			background_thread_info_t *info =
 			    background_thread_info_get(arena_ind);
-			assert(info->state == background_thread_paused);
 			malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+			assert(info->state == background_thread_paused);
 			info->state = background_thread_started;
+#ifdef JEMALLOC_BACKGROUND_THREAD
+			pthread_cond_signal(&info->cond);
+#endif
 			malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
 		}
 		malloc_mutex_unlock(tsd_tsdn(tsd), &background_thread_lock);
@@ -351,11 +354,18 @@ background_thread_sleep(
 static bool
 background_thread_pause_check(tsdn_t *tsdn, background_thread_info_t *info) {
 	if (unlikely(info->state == background_thread_paused)) {
-		malloc_mutex_unlock(tsdn, &info->mtx);
-		/* Wait on global lock to update status. */
-		malloc_mutex_lock(tsdn, &background_thread_lock);
-		malloc_mutex_unlock(tsdn, &background_thread_lock);
-		malloc_mutex_lock(tsdn, &info->mtx);
+#if defined(JEMALLOC_JET)
+		if (test_hooks_background_thread_pause_hook != NULL) {
+			malloc_mutex_unlock(tsdn, &info->mtx);
+			test_hooks_background_thread_pause_hook();
+			malloc_mutex_lock(tsdn, &info->mtx);
+		}
+#endif
+		/* Shutdown joins workers while holding background_thread_lock. */
+		do {
+			int ret = background_thread_cond_wait(info, NULL);
+			assert(ret == 0);
+		} while (info->state == background_thread_paused);
 		return true;
 	}
 

--- a/src/test_hooks.c
+++ b/src/test_hooks.c
@@ -16,5 +16,8 @@ void (*test_hooks_safety_check_abort)(const char *) = NULL;
 
 #if defined(JEMALLOC_JET) || defined(JEMALLOC_UNIT_TEST)
 JEMALLOC_EXPORT
+void (*test_hooks_background_thread_pause_hook)(void) = NULL;
+
+JEMALLOC_EXPORT
 void (*test_hooks_tsd_bootstrap_hook)(void) = NULL;
 #endif

--- a/test/unit/background_thread.c
+++ b/test/unit/background_thread.c
@@ -2,6 +2,11 @@
 
 #include "jemalloc/internal/util.h"
 
+#ifndef _WIN32
+#	include <signal.h>
+#	include <sys/wait.h>
+#endif
+
 static void
 test_switch_background_thread_ctl(bool new_val) {
 	bool   e0, e1;
@@ -149,6 +154,142 @@ TEST_BEGIN(test_background_thread_arena_reset) {
 }
 TEST_END
 
+#if defined(JEMALLOC_BACKGROUND_THREAD) && !defined(_WIN32)
+static atomic_b_t pause_hook_entered = ATOMIC_INIT(false);
+static atomic_b_t pause_hook_release = ATOMIC_INIT(false);
+
+static void
+background_thread_pause_hook(void) {
+	atomic_store_b(&pause_hook_entered, true, ATOMIC_RELEASE);
+	while (!atomic_load_b(&pause_hook_release, ATOMIC_ACQUIRE)) {
+		sleep_ns(1000 * 1000);
+	}
+}
+
+static bool
+background_thread_wait_for(atomic_b_t *flag) {
+	nstime_t start;
+	nstime_init_update(&start);
+	do {
+		if (atomic_load_b(flag, ATOMIC_ACQUIRE)) {
+			return false;
+		}
+		sleep_ns(1000 * 1000);
+		nstime_t now;
+		nstime_init_update(&now);
+		nstime_subtract(&now, &start);
+		if (nstime_sec(&now) >= 5) {
+			return true;
+		}
+	} while (true);
+}
+
+static int
+background_thread_pause_shutdown_child(void) {
+	bool enable = true;
+	if (mallctl("background_thread", NULL, NULL, &enable, sizeof(enable))
+	    != 0) {
+		return 1;
+	}
+
+	unsigned arena_ind;
+	do {
+		size_t sz = sizeof(arena_ind);
+		if (mallctl("arenas.create", &arena_ind, &sz, NULL, 0) != 0) {
+			return 1;
+		}
+	} while (arena_ind % max_background_threads == 0);
+
+	background_thread_info_t *info = background_thread_info_get(arena_ind);
+	tsd_t                    *tsd = tsd_fetch();
+	nstime_t                  start;
+	nstime_init_update(&start);
+	bool worker_ran = false;
+	while (!worker_ran) {
+		malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+		worker_ran = info->tot_n_runs > 0;
+		malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
+		if (worker_ran) {
+			break;
+		}
+		sleep_ns(1000 * 1000);
+		nstime_t now;
+		nstime_init_update(&now);
+		nstime_subtract(&now, &start);
+		if (nstime_sec(&now) >= 5) {
+			return 1;
+		}
+	}
+
+	atomic_store_b(&pause_hook_entered, false, ATOMIC_RELAXED);
+	atomic_store_b(&pause_hook_release, false, ATOMIC_RELAXED);
+	test_hooks_background_thread_pause_hook = background_thread_pause_hook;
+
+	background_thread_arena_reset_begin(tsd, arena_ind);
+	malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+	pthread_cond_signal(&info->cond);
+	malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
+	if (background_thread_wait_for(&pause_hook_entered)) {
+		return 1;
+	}
+	background_thread_arena_reset_finish(tsd, arena_ind);
+
+	malloc_mutex_lock(tsd_tsdn(tsd), &background_thread_lock);
+	background_thread_enabled_set(tsd_tsdn(tsd), false);
+	atomic_store_b(&pause_hook_release, true, ATOMIC_RELEASE);
+	bool err = background_threads_disable(tsd);
+	malloc_mutex_unlock(tsd_tsdn(tsd), &background_thread_lock);
+	return err ? 1 : 0;
+}
+#endif
+
+TEST_BEGIN(test_background_thread_pause_shutdown) {
+	test_skip_if(!have_background_thread);
+	test_skip_if(!config_stats);
+	test_skip_if(max_background_threads < 2);
+
+#if defined(JEMALLOC_BACKGROUND_THREAD) && !defined(_WIN32)
+	pid_t pid = fork();
+	if (pid == -1) {
+		test_fail("Unexpected fork() failure");
+		return;
+	}
+	if (pid == 0) {
+		_exit(background_thread_pause_shutdown_child());
+	}
+
+	nstime_t start;
+	nstime_init_update(&start);
+	int status;
+	pid_t wait_result;
+	while ((wait_result = waitpid(pid, &status, WNOHANG)) == 0) {
+		sleep_ns(1000 * 1000);
+		nstime_t now;
+		nstime_init_update(&now);
+		nstime_subtract(&now, &start);
+		if (nstime_sec(&now) >= 5) {
+			kill(pid, SIGKILL);
+			waitpid(pid, &status, 0);
+			test_fail("Background-thread shutdown deadlocked with a "
+			    "worker paused for arena reset");
+			return;
+		}
+	}
+	if (wait_result == -1) {
+		test_fail("Unexpected waitpid() failure");
+		return;
+	}
+	expect_true(WIFEXITED(status), "Child terminated abnormally");
+	if (WIFEXITED(status)) {
+		expect_d_eq(WEXITSTATUS(status), 0,
+		    "Child failed to exercise the pause/shutdown ordering");
+	}
+#else
+	test_skip("Background threads and fork(2) are required");
+#endif
+}
+TEST_END
+
 TEST_BEGIN(test_background_thread_stats_ctl) {
 	test_skip_if(!have_background_thread);
 	test_skip_if(!config_stats);
@@ -190,5 +331,6 @@ main(void) {
 	/* Background_thread creation tests reentrancy naturally. */
 	return test_no_reentrancy(test_background_thread_ctl,
 	    test_background_thread_running, test_background_thread_arena_reset,
+	    test_background_thread_pause_shutdown,
 	    test_background_thread_stats_ctl);
 }


### PR DESCRIPTION
A worker paused during arena reset could still be waiting for the global background-thread lock when shutdown reacquired it and began joining workers.

Wait on the worker condition variable instead, signal it when reset finishes, and add a bounded regression test.

@guangli-dai , will send you handoff