### PR TITLE
Fix potential deadlock during arena_reset.

### DIFF
--- a/include/jemalloc/internal/background_thread.h
+++ b/include/jemalloc/internal/background_thread.h
@@ -16,7 +16,7 @@
 typedef enum {
 	background_thread_stopped,
 	background_thread_started,
-	/* Thread waits on the global lock when paused (for arena_reset). */
+	/* Thread waits on its condition variable when paused (arena_reset). */
 	background_thread_paused,
 } background_thread_state_t;
 

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -59,8 +59,8 @@ background_thread_arena_reset_begin(tsd_t *tsd, unsigned arena_ind) {
 		if (background_thread_enabled()) {
 			background_thread_info_t *info =
 			    background_thread_info_get(arena_ind);
-			assert(info->state == background_thread_started);
 			malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+			assert(info->state == background_thread_started);
 			info->state = background_thread_paused;
 			malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
 		}
@@ -73,9 +73,12 @@ background_thread_arena_reset_finish(tsd_t *tsd, unsigned arena_ind) {
 		if (background_thread_enabled()) {
 			background_thread_info_t *info =
 			    background_thread_info_get(arena_ind);
-			assert(info->state == background_thread_paused);
 			malloc_mutex_lock(tsd_tsdn(tsd), &info->mtx);
+			assert(info->state == background_thread_paused);
 			info->state = background_thread_started;
+#ifdef JEMALLOC_BACKGROUND_THREAD
+			pthread_cond_signal(&info->cond);
+#endif
 			malloc_mutex_unlock(tsd_tsdn(tsd), &info->mtx);
 		}
 		malloc_mutex_unlock(tsd_tsdn(tsd), &background_thread_lock);
@@ -351,11 +354,10 @@ background_thread_sleep(
 static bool
 background_thread_pause_check(tsdn_t *tsdn, background_thread_info_t *info) {
 	if (unlikely(info->state == background_thread_paused)) {
-		malloc_mutex_unlock(tsdn, &info->mtx);
-		/* Wait on global lock to update status. */
-		malloc_mutex_lock(tsdn, &background_thread_lock);
-		malloc_mutex_unlock(tsdn, &background_thread_lock);
-		malloc_mutex_lock(tsdn, &info->mtx);
+		while (info->state == background_thread_paused) {
+			int ret = background_thread_cond_wait(info, NULL);
+			assert(ret == 0);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Fix a deadlock between arena reset and background-thread shutdown.

### Reproduction

Configure a debug build:

```sh
./autogen.sh \
--enable-debug \
--disable-prof \
--with-lg-page=16 \
--with-malloc-conf=tcache:false

make -j64 test/unit/background_thread

# For faster reproduction, temporarily register only 
# test_background_thread_arena_reset in test/unit/background_thread.c.

for i in $(seq 1 5000); do
timeout 3s taskset -c 0,1 ./test/unit/background_thread \
  >/dev/null 2>&1
rc=$?

if [ "$rc" -eq 124 ]; then
  echo "TIMEOUT iteration=$i"
  break
elif [ "$rc" -ne 0 ]; then
  echo "FAIL iteration=$i rc=$rc"
  break
fi

if [ $((i % 250)) -eq 0 ]; then
  echo "passed=$i"
fi
done
```

Before the fix, one run produced:

passed=250
passed=500
TIMEOUT iteration=535

The failure is scheduler-sensitive. A single test invocation will usually
pass, while repeated fresh processes make the problematic interleaving more
likely.

### Root Cause

Arena reset temporarily changes the background worker assigned to the arena
from started to paused while holding the global
background_thread_lock.

Before this change, a worker that observed paused released its own
info->mtx and waited for the global lock:
```
malloc_mutex_unlock(tsdn, &info->mtx);
malloc_mutex_lock(tsdn, &background_thread_lock);
malloc_mutex_unlock(tsdn, &background_thread_lock);
malloc_mutex_lock(tsdn, &info->mtx);
```

The global lock was intended to act as a barrier: acquiring it meant arena
reset had finished and released the lock.

The deadlock occurs when shutdown acquires background_thread_lock before
the paused secondary worker does:
1. The control thread acquires background_thread_lock.
2. While still holding the lock, the control thread begins shutdown and
 waits for worker 0 to exit.
3. Worker 0 cannot exit until it stops and joins all secondary workers.
4. One secondary worker cannot exit because it is waiting to acquire
 background_thread_lock.
5. That lock cannot be released because the control thread is waiting for
 worker 0.


### Fix

Using the global lock on the second worker to indicate the background state
itself is risky with a strong assumption that once the global lock is acquired,
the worker background thread has a non-paused state. Although this is true
for now, this fix changes the wait to rely on pthread_cond_wait and checks
the state before finishing the waiting. Also, we let the arena_reset thread do
pthread_cond_signal to notify the waiting worker.

This eliminates the use of global lock on the worker background thread and
instead introduce another reliable mechanism for the worker to wake up and
continue when its state resumes.

With the fix, the focused arena-reset workload completed 5,000 consecutive
iterations under the same two-CPU affinity without a timeout.