### PR TITLE
Fix SEC shard count integer overflow (#2892)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -937,8 +937,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 				CONF_CONTINUE;
 			}
 			CONF_HANDLE_SIZE_T(opt_hpa_sec_opts.nshards,
-			    "hpa_sec_nshards", 0, 0, CONF_CHECK_MIN,
-			    CONF_DONT_CHECK_MAX, true);
+			    "hpa_sec_nshards", 0, 255, CONF_CHECK_MIN,
+			    CONF_CHECK_MAX, true);
 			CONF_HANDLE_SIZE_T(opt_hpa_sec_opts.max_alloc,
 			    "hpa_sec_max_alloc", PAGE,
 			    USIZE_GROW_SLOW_THRESHOLD, CONF_CHECK_MIN,
@@ -947,8 +947,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			    "hpa_sec_max_bytes", SEC_OPTS_MAX_BYTES_DEFAULT, 0,
 			    CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
 			CONF_HANDLE_SIZE_T(opt_pac_sec_opts.nshards,
-			    "experimental_pac_sec_nshards", 0, 0,
-			    CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
+			    "experimental_pac_sec_nshards", 0, 255,
+			    CONF_CHECK_MIN, CONF_CHECK_MAX, true);
 			CONF_HANDLE_SIZE_T(opt_pac_sec_opts.max_alloc,
 			    "experimental_pac_sec_max_alloc", PAGE,
 			    USIZE_GROW_SLOW_THRESHOLD, CONF_CHECK_MIN,

--- a/src/sec.c
+++ b/src/sec.c
@@ -36,6 +36,7 @@ sec_init(tsdn_t *tsdn, sec_t *sec, base_t *base, const sec_opts_t *opts) {
 		sec->opts.max_alloc = 0;
 		return false;
 	}
+	assert(opts->nshards <= 255);
 	assert(opts->max_alloc >= PAGE);
 
 	/*


### PR DESCRIPTION
Fixes #2892

**Description:**
The Small Extent Cache (SEC) configuration allowed the `nshards` to be configured with any `size_t` value. However, the internal functions that select and cache shard identifiers (like `sec_shard_pick`) use a `uint8_t`. If `nshards` exceeded 255, the shard IDs silently wrapped around. Furthermore, an unbounded `nshards` triggered a multiplication integer overflow when allocating the internal SEC metadata arrays.

This PR introduces two safety nets:
1. `hpa_sec_nshards` and `experimental_pac_sec_nshards` in `src/conf.c` now use `CONF_CHECK_MAX` with a maximum limit of 255. Any configuration values greater than 255 will automatically be clipped safely.
2. `sec_init()` in `src/sec.c` now asserts `opts->nshards <= 255` to guarantee no oversized configurations can trigger a buffer overflow or wrap-around programmatically.