### PR TITLE
Background flaky test on FreeBSD 32-bit CI fix

### DIFF
--- a/include/jemalloc/internal/os/posix/file.h
+++ b/include/jemalloc/internal/os/posix/file.h
@@ -14,6 +14,14 @@
 JEMALLOC_ALWAYS_INLINE ssize_t
 os_file_write_once(int fd, const void *buf, size_t bytes) {
 #if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_write)
+	/*
+	 * Use syscall(2) rather than write(2) when possible in order to avoid
+	 * the possibility of memory allocation within libc.  This is necessary
+	 * on FreeBSD; most operating systems do not have this problem though.
+	 *
+	 * syscall() returns long or int, depending on platform, so capture the
+	 * result in the widest plausible type to avoid compiler warnings.
+	 */
 	return (ssize_t)syscall(SYS_write, fd, buf, bytes);
 #else
 	return (ssize_t)write(fd, buf, bytes);

--- a/test/unit/background_thread_enable.c
+++ b/test/unit/background_thread_enable.c
@@ -14,8 +14,12 @@ max_test_narenas(void) {
 	 */
 	unsigned ret = 10 * ncpus;
 
-	/* Limit the max to avoid VM exhaustion on 32-bit . */
-	return ret > 256 ? 256 : ret;
+	/*
+	 * These arenas remain live for the rest of the test process.  Leave
+	 * enough address space for the worker thread in the toggle stress test,
+	 * particularly on 32-bit platforms where its stack allocation can fail.
+	 */
+	return ret > 64 ? 64 : ret;
 }
 
 TEST_BEGIN(test_deferred) {


### PR DESCRIPTION
1. Fix the test by reducing narenas used there to avoid virtual memory address exhaustion on 32-bit platforms;
2. Add comments in to retain the context as a follow-up of #2963 