### PR TITLE
Fix compilations warnings on MacOS.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,6 +36,10 @@ CXXFLAGS := $(strip $(CONFIGURE_CXXFLAGS) $(SPECIFIED_CXXFLAGS) $(EXTRA_CXXFLAGS
 LDFLAGS := @LDFLAGS@
 EXTRA_LDFLAGS := @EXTRA_LDFLAGS@
 LIBS := @LIBS@
+# $(CXX) links the C++ standard library itself, so passing it again explicitly
+# is redundant and makes some linkers (e.g. Apple ld) warn about a duplicate
+# library.  Strip it from links performed with $(CXX).
+CXX_LIBS := $(filter-out -lstdc++,$(LIBS))
 RPATH_EXTRA := @RPATH_EXTRA@
 SO := @so@
 IMPORTLIB := @importlib@
@@ -559,7 +563,7 @@ endif
 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) : $(if $(PIC_CFLAGS),$(C_PIC_OBJS),$(C_OBJS)) $(if $(PIC_CFLAGS),$(CPP_PIC_OBJS),$(CPP_OBJS))
 	@mkdir -p $(@D)
 ifeq (@enable_cxx@, 1)
-	$(CXX) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
+	$(CXX) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(CXX_LIBS) $(EXTRA_LDFLAGS)
 else
 	$(CC) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
 endif
@@ -582,7 +586,7 @@ $(objroot)test/integration/%$(EXE): $(objroot)test/integration/%.$(O) $(C_TESTLI
 
 $(objroot)test/integration/cpp/%$(EXE): $(objroot)test/integration/cpp/%.$(O) $(C_TESTLIB_INTEGRATION_OBJS) $(C_UTIL_INTEGRATION_OBJS) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB)
 	@mkdir -p $(@D)
-	$(CXX) $(LDTARGET) $(filter %.$(O),$^) $(call RPATH,$(objroot)lib) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB) $(LDFLAGS) $(filter-out -lm,$(LIBS)) -lm $(EXTRA_LDFLAGS)
+	$(CXX) $(LDTARGET) $(filter %.$(O),$^) $(call RPATH,$(objroot)lib) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB) $(LDFLAGS) $(filter-out -lm,$(CXX_LIBS)) -lm $(EXTRA_LDFLAGS)
 
 $(objroot)test/analyze/%$(EXE): $(objroot)test/analyze/%.$(O) $(C_JET_OBJS) $(C_TESTLIB_ANALYZE_OBJS)
 	@mkdir -p $(@D)
@@ -594,7 +598,7 @@ $(objroot)test/stress/%$(EXE): $(objroot)test/stress/%.$(O) $(C_JET_OBJS) $(C_TE
 
 $(objroot)test/stress/pa/pa_data_preprocessor$(EXE): $(objroot)test/stress/pa/pa_data_preprocessor.$(O)
 	@mkdir -p $(@D)
-	$(CXX) $(LDTARGET) $(filter %.$(O),$^) $(LDFLAGS) $(filter-out -lm,$(LIBS)) $(LM) $(EXTRA_LDFLAGS)
+	$(CXX) $(LDTARGET) $(filter %.$(O),$^) $(LDFLAGS) $(filter-out -lm,$(CXX_LIBS)) $(LM) $(EXTRA_LDFLAGS)
 
 $(objroot)test/stress/pa/pa_microbench$(EXE): $(objroot)test/stress/pa/pa_microbench.$(O) $(C_JET_OBJS) $(C_TESTLIB_STRESS_OBJS)
 	@mkdir -p $(@D)

--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,10 @@ if test "x$enable_cxx" = "x1" ; then
   if test "x${HAVE_CXX14}" = "x1" -o "x${HAVE_CXX17}" = "x1"; then
     JE_CXXFLAGS_ADD([-Wall])
     JE_CXXFLAGS_ADD([-Wextra])
+    dnl Mirror the C flags: this warning fires on the universal zero
+    dnl initializer idiom (e.g. the tcache/TSD static initializers) that is
+    dnl shared with the C++ sources via the internal headers.
+    JE_CXXFLAGS_ADD([-Wno-missing-braces])
     JE_CXXFLAGS_ADD([-g3])
 
     SAVED_LIBS="${LIBS}"


### PR DESCRIPTION
Fixes two issues. 1) Compilation warning:

```
include/jemalloc/internal/tsd_generic.h:107:24: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  107 |                         tsd_t initializer = TSD_INITIALIZER;
      |                                             ^~~~~~~~~~~~~~~
include/jemalloc/internal/tsd_internals.h:137:3: note: expanded from macro 'TSD_INITIALIZER'
  137 |                 TSD_DATA_SLOW_INITIALIZER                                      \
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
include/jemalloc/internal/tsd_internals.h:109:6: note: expanded from macro 'TSD_DATA_SLOW_INITIALIZER'
  109 |             TCACHE_SLOW_ZERO_INITIALIZER,                                      \
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/jemalloc/internal/tcache.h:29:5: note: expanded from macro 'TCACHE_SLOW_ZERO_INITIALIZER'
   29 |                 { 0 }                                                          \
      |                   ^
```

This happens when compiling C++ files as the flag `-Wno-missing-braces` was no being passed to cxx (that way it was passed to cc). Fix: pass that flag to cxx.

2) Linking warning:

```
ld: warning: ignoring duplicate libraries: '-lc++'
```

This happens because cxx links against std C++ lib by default and, when it was passed explicitly to the Appl ld, it'd issue a duplicated warning. Fix: filter out `-lstdc++` from the libs for cxx.

Testing: Built on MacOS and confirmed the warnings are gone. Also built on linux x64/arm64 to ensure there were no new issues.