### PR TITLE
Os layer 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2854,7 +2854,7 @@ fi
 ],
 [enable_pageid="0"]
 )
-if test "x$enable_pageid" = "x1" ; then
+if test "x$enable_pageid" = "x1" -a "x$have_prctl" = "x1" ; then
   AC_DEFINE([JEMALLOC_PAGEID], [ ], [ ])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -805,7 +805,6 @@ case "${host}" in
   *-*-freebsd*)
 	JE_APPEND_VS(CPPFLAGS, -D_BSD_SOURCE)
 	abi="elf"
-	AC_DEFINE([JEMALLOC_SYSCTL_VM_OVERCOMMIT], [ ], [ ])
 	force_lazy_lock="1"
 	;;
   *-*-dragonfly*)
@@ -825,7 +824,6 @@ case "${host}" in
 	glibc="0"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS], [ ], [ ])
 	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H], [ ], [ ])
-	AC_DEFINE([JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY], [ ], [ ])
 	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ], [ ])
 	AC_DEFINE([JEMALLOC_C11_ATOMICS], [ ], [ ])
 	force_tls="0"
@@ -840,7 +838,6 @@ case "${host}" in
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS], [ ], [ ])
 	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H], [ ], [ ])
-	AC_DEFINE([JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY], [ ], [ ])
 	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ], [ ])
 	if test "${LG_SIZEOF_PTR}" = "3"; then
 	  default_retain="1"
@@ -854,7 +851,6 @@ case "${host}" in
 	glibc="1"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS], [ ], [ ])
 	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H], [ ], [ ])
-	AC_DEFINE([JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY], [ ], [ ])
 	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ], [ ])
 	AC_DEFINE([JEMALLOC_USE_CXX_THROW], [ ], [ ])
 	if test "${LG_SIZEOF_PTR}" = "3"; then
@@ -867,7 +863,6 @@ case "${host}" in
 	JE_APPEND_VS(CPPFLAGS, -D_GNU_SOURCE)
 	abi="elf"
 	AC_DEFINE([JEMALLOC_HAS_ALLOCA_H], [ ], [ ])
-	AC_DEFINE([JEMALLOC_SYSCTL_VM_OVERCOMMIT], [ ], [ ])
 	AC_DEFINE([JEMALLOC_THREADED_INIT], [ ], [ ])
 	AC_DEFINE([JEMALLOC_USE_CXX_THROW], [ ], [ ])
 	;;

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -290,15 +290,6 @@
  */
 #undef JEMALLOC_ZONE
 
-/*
- * Methods for determining whether the OS overcommits.
- * JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY: Linux's
- *                                         /proc/sys/vm.overcommit_memory file.
- * JEMALLOC_SYSCTL_VM_OVERCOMMIT: FreeBSD's vm.overcommit sysctl.
- */
-#undef JEMALLOC_SYSCTL_VM_OVERCOMMIT
-#undef JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY
-
 /* Defined if madvise(2) is available. */
 #undef JEMALLOC_HAVE_MADVISE
 

--- a/include/jemalloc/internal/malloc_io.h
+++ b/include/jemalloc/internal/malloc_io.h
@@ -3,36 +3,15 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_types.h"
-
-#ifdef _WIN32
-#	ifdef _WIN64
-#		define FMT64_PREFIX "ll"
-#		define FMTPTR_PREFIX "ll"
-#	else
-#		define FMT64_PREFIX "ll"
-#		define FMTPTR_PREFIX ""
-#	endif
-#	define FMTd32 "d"
-#	define FMTu32 "u"
-#	define FMTx32 "x"
-#	define FMTd64 FMT64_PREFIX "d"
-#	define FMTu64 FMT64_PREFIX "u"
-#	define FMTx64 FMT64_PREFIX "x"
-#	define FMTdPTR FMTPTR_PREFIX "d"
-#	define FMTuPTR FMTPTR_PREFIX "u"
-#	define FMTxPTR FMTPTR_PREFIX "x"
-#else
-#	include <inttypes.h>
-#	define FMTd32 PRId32
-#	define FMTu32 PRIu32
-#	define FMTx32 PRIx32
-#	define FMTd64 PRId64
-#	define FMTu64 PRIu64
-#	define FMTx64 PRIx64
-#	define FMTdPTR PRIdPTR
-#	define FMTuPTR PRIuPTR
-#	define FMTxPTR PRIxPTR
-#endif
+/*
+ * os/fmt.h directly (not the os.h umbrella): this header is itself included
+ * from os/posix/error.h (for malloc_snprintf's declaration), so pulling in
+ * the full os.h here would risk the same circular-include hazard os/error.h
+ * avoids by not going through the umbrella either. os/fmt.h is a leaf module
+ * (macros only, no dependency back on malloc_io.h or anything else), so
+ * including it alone is safe.
+ */
+#include "jemalloc/internal/os/fmt.h"
 
 /* Size of stack-allocated buffer passed to buferror(). */
 #define BUFERROR_BUF 64

--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -56,4 +56,11 @@
  */
 #include "jemalloc/internal/os/error.h"
 
+/*
+ * Printf format-specifier macros. malloc_io.h includes os/fmt.h directly
+ * (not via this umbrella) for the same early-reachability reason as
+ * os/error.h above. Included here too for discoverability.
+ */
+#include "jemalloc/internal/os/fmt.h"
+
 #endif /* JEMALLOC_INTERNAL_OS_H */

--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -46,4 +46,7 @@
 /* CPU */
 #include "jemalloc/internal/os/cpu.h"
 
+/* VM */
+#include "jemalloc/internal/os/vm.h"
+
 #endif /* JEMALLOC_INTERNAL_OS_H */

--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -49,4 +49,11 @@
 /* VM */
 #include "jemalloc/internal/os/vm.h"
 
+/*
+ * Error codes. util.h includes os/error.h directly (not via this umbrella)
+ * since it's reachable too early in the include graph for the full os.h.
+ * Included here too for discoverability.
+ */
+#include "jemalloc/internal/os/error.h"
+
 #endif /* JEMALLOC_INTERNAL_OS_H */

--- a/include/jemalloc/internal/os/error.h
+++ b/include/jemalloc/internal/os/error.h
@@ -1,0 +1,35 @@
+#ifndef JEMALLOC_INTERNAL_OS_ERROR_H
+#define JEMALLOC_INTERNAL_OS_ERROR_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os/detect.h"
+
+/*
+ * Error-code interface: get/set the calling thread's last-error value, and
+ * render an error code to a human-readable string.
+ * Default: posix/.  Override: Windows.
+ *
+ * Included directly by util.h (not via the os.h umbrella): util.h is itself
+ * transitively included very early.  assert.h includes malloc_io.h then
+ * util.h, before either has any reason to know about mutex.h/base.h.  Thus,
+ * pulling in the full os.h from util.h would risk the same circular-include
+ * failure worked around in the VM module (base.h -> mutex.h -> os.h ->
+ * os/vm.h -> base.h).  This module's backends need nothing beyond libc/CRT
+ * error primitives and malloc_io.h's malloc_snprintf, so including it alone
+ * from util.h is safe.
+ */
+
+/* Functions required for implementation in each backend. */
+JEMALLOC_ALWAYS_INLINE int os_errno_get(void);
+JEMALLOC_ALWAYS_INLINE void os_errno_set(int errnum);
+JEMALLOC_ALWAYS_INLINE int os_strerror(int err, char *buf, size_t buflen);
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/error.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/error.h"
+#else
+#  error "OS layer: no error backend for this platform; add os/<os>/error.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_ERROR_H */

--- a/include/jemalloc/internal/os/fmt.h
+++ b/include/jemalloc/internal/os/fmt.h
@@ -1,0 +1,25 @@
+#ifndef JEMALLOC_INTERNAL_OS_FMT_H
+#define JEMALLOC_INTERNAL_OS_FMT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os/detect.h"
+
+/*
+ * Printf format-specifier macros for fixed-width and pointer-sized integers
+ * (FMTd32/FMTu32/FMTx32/FMTd64/FMTu64/FMTx64/FMTdPTR/FMTuPTR/FMTxPTR).
+ * Default: posix/ (<inttypes.h>'s PRId32 etc).  Override: Windows (MSVC's
+ * CRT historically didn't support the C99 <inttypes.h> macros the same way,
+ * so these are hand-rolled from an ll/I64-style prefix instead).
+ *
+ * Unlike other modules, this one defines only macros, no functions.
+ */
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/fmt.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/fmt.h"
+#else
+#  error "OS layer: no fmt backend for this platform; add os/<os>/fmt.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_FMT_H */

--- a/include/jemalloc/internal/os/freebsd/overcommit.h
+++ b/include/jemalloc/internal/os/freebsd/overcommit.h
@@ -1,0 +1,45 @@
+#ifndef JEMALLOC_INTERNAL_OS_FREEBSD_OVERCOMMIT_H
+#define JEMALLOC_INTERNAL_OS_FREEBSD_OVERCOMMIT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include <sys/mman.h>
+#include <sys/sysctl.h>
+#ifdef __FreeBSD__
+#  include <vm/vm_param.h>
+#endif
+
+/* Defined in src/pages.c. */
+extern int mmap_flags;
+
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommits_sysctl(void) {
+	int    vm_overcommit;
+	size_t sz;
+
+	sz = sizeof(vm_overcommit);
+#  if defined(__FreeBSD__) && defined(VM_OVERCOMMIT)
+	int mib[2];
+
+	mib[0] = CTL_VM;
+	mib[1] = VM_OVERCOMMIT;
+	if (sysctl(mib, 2, &vm_overcommit, &sz, NULL, 0) != 0) {
+		return false; /* Error. */
+	}
+#  else
+	if (sysctlbyname("vm.overcommit", &vm_overcommit, &sz, NULL, 0) != 0) {
+		return false; /* Error. */
+	}
+#  endif
+
+	return ((vm_overcommit & 0x3) == 0);
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommit_boot(void) {
+	mmap_flags = MAP_PRIVATE | MAP_ANON;
+	os_overcommits = os_overcommits_sysctl();
+	return false;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_FREEBSD_OVERCOMMIT_H */

--- a/include/jemalloc/internal/os/linux/overcommit.h
+++ b/include/jemalloc/internal/os/linux/overcommit.h
@@ -1,0 +1,152 @@
+#ifndef JEMALLOC_INTERNAL_OS_LINUX_OVERCOMMIT_H
+#define JEMALLOC_INTERNAL_OS_LINUX_OVERCOMMIT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+
+#include <sys/mman.h>
+
+#ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
+/*
+ * Set by os_overcommit_boot()'s madvise_MADV_DONTNEED_zeroes_pages() probe,
+ * consumed by pages_purge_forced() in src/pages.c. Kept behind this macro
+ * (rather than assumed unconditional, even though every configure.ac Linux
+ * branch defines it today) so this file doesn't silently desync from
+ * configure.ac if that ever changes.
+ *
+ * Defined in src/pages.c.
+ */
+extern int madvise_dont_need_zeros_is_faulty;
+#endif
+
+/* Defined in src/pages.c. */
+extern int mmap_flags;
+
+#ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
+/*
+ * Check that MADV_DONTNEED will actually zero pages on subsequent access.
+ *
+ * Since qemu does not support this, yet [1], and you can get very tricky
+ * assert if you will run program with jemalloc in use under qemu:
+ *
+ *     <jemalloc>: ../contrib/jemalloc/src/extent.c:1195: Failed assertion: "p[i] == 0"
+ *
+ *   [1]: https://patchwork.kernel.org/patch/10576637/
+ */
+JEMALLOC_ALWAYS_INLINE int
+madvise_MADV_DONTNEED_zeroes_pages(void) {
+	size_t size = PAGE;
+
+	void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+	    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+	if (addr == MAP_FAILED) {
+		malloc_write(
+		    "<jemalloc>: Cannot allocate memory for "
+		    "MADV_DONTNEED check\n");
+		if (opt_abort) {
+			abort();
+		}
+	}
+
+	memset(addr, 'A', size);
+	int works;
+	if (madvise(addr, size, MADV_DONTNEED) == 0) {
+		works = memchr(addr, 'A', size) == NULL;
+	} else {
+		/*
+		 * If madvise() does not support MADV_DONTNEED, then we can
+		 * call it anyway, and use it's return code.
+		 */
+		works = 1;
+	}
+
+	if (munmap(addr, size) != 0) {
+		malloc_write(
+		    "<jemalloc>: Cannot deallocate memory for "
+		    "MADV_DONTNEED check\n");
+		if (opt_abort) {
+			abort();
+		}
+	}
+
+	return works;
+}
+#endif
+
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommits_proc(void) {
+	int  fd;
+	char buf[1];
+
+#  if defined(O_CLOEXEC)
+	fd = malloc_open(
+	    "/proc/sys/vm/overcommit_memory", O_RDONLY | O_CLOEXEC);
+#  else
+	fd = malloc_open("/proc/sys/vm/overcommit_memory", O_RDONLY);
+	if (fd != -1) {
+		fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+	}
+#  endif
+
+	if (fd == -1) {
+		return false; /* Error. */
+	}
+
+	ssize_t nread = malloc_read_fd(fd, &buf, sizeof(buf));
+	malloc_close(fd);
+
+	if (nread < 1) {
+		return false; /* Error. */
+	}
+	/*
+	 * /proc/sys/vm/overcommit_memory meanings:
+	 * 0: Heuristic overcommit.
+	 * 1: Always overcommit.
+	 * 2: Never overcommit.
+	 */
+	return (buf[0] == '0' || buf[0] == '1');
+}
+
+/*
+ * Bundles what pages_boot() used to do after the page-size check, on Linux:
+ *   1. DONTNEED-zeros probe (madvise_MADV_DONTNEED_zeroes_pages()).
+ *   2. mmap_flags assembly (MAP_PRIVATE | MAP_ANON, plus MAP_NORESERVE when
+ *      the kernel overcommits).
+ *   3. Overcommit detection via /proc/sys/vm/overcommit_memory
+ *      (os_overcommits_proc() above).
+ */
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommit_boot(void) {
+#ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
+	if (!opt_trust_madvise) {
+		madvise_dont_need_zeros_is_faulty =
+		    !madvise_MADV_DONTNEED_zeroes_pages();
+		if (madvise_dont_need_zeros_is_faulty) {
+			malloc_write(
+			    "<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)\n");
+			malloc_write(
+			    "<jemalloc>: (This is the expected behaviour if you are running under QEMU)\n");
+		}
+	} else {
+		/*
+		 * In case opt_trust_madvise is disable,
+		 * do not do runtime check.
+		 */
+		madvise_dont_need_zeros_is_faulty = 0;
+	}
+#endif
+
+	mmap_flags = MAP_PRIVATE | MAP_ANON;
+
+	os_overcommits = os_overcommits_proc();
+#ifdef MAP_NORESERVE
+	if (os_overcommits) {
+		mmap_flags |= MAP_NORESERVE;
+	}
+#endif
+
+	return false;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_LINUX_OVERCOMMIT_H */

--- a/include/jemalloc/internal/os/overcommit.h
+++ b/include/jemalloc/internal/os/overcommit.h
@@ -1,0 +1,47 @@
+#ifndef JEMALLOC_INTERNAL_OS_OVERCOMMIT_H
+#define JEMALLOC_INTERNAL_OS_OVERCOMMIT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/pages.h"
+
+/*
+ * Overcommit interface: boot-time detection of kernel memory-policy facts
+ * that src/pages.c and os/vm.h's reserve/commit primitives depend on --
+ * whether the kernel overcommits, and (Linux only) whether MADV_DONTNEED is
+ * known to zero pages and what mmap() flags to use.  Separate from os/vm.h
+ * because none of this is a VM reserve/commit primitive itself; it's boot-
+ * time policy detection that some of those primitives happen to read.
+ *
+ * Unlike every other os/<module>.h, this one has FOUR tiers instead of the
+ * usual two (posix/windows) or three (posix/windows/darwin): FreeBSD and
+ * Linux each have substantial, disjoint, dedicated detection logic (real
+ * sysctl/proc-file probing, not a one-line difference), so each gets its own
+ * file with no internal #ifdef __FreeBSD__/__linux__ branching -- unlike
+ * os/darwin/cpu.h (which duplicates two mostly-identical functions just to
+ * override a third), splitting these out duplicates nothing, since
+ * os_overcommits_sysctl() and os_overcommits_proc()/the DONTNEED-zeros probe
+ * never had anything in common to begin with. Default: posix/ (NetBSD
+ * hardcoded true, everyone else false -- matches this project's
+ * pre-refactor behavior for all of them). Overrides: Windows (never
+ * overcommits), FreeBSD/kFreeBSD (sysctl), Linux (/proc/sys/vm).
+ *
+ * State: `os_overcommits`, set by os_overcommit_boot(), read by os/vm.h's
+ * backends. Defined in src/pages.c.
+ */
+extern bool os_overcommits;
+
+JEMALLOC_ALWAYS_INLINE bool os_overcommit_boot(void);
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/overcommit.h"
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#  include "jemalloc/internal/os/freebsd/overcommit.h"
+#elif defined(__linux__)
+#  include "jemalloc/internal/os/linux/overcommit.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/overcommit.h"
+#else
+#  error "OS layer: no overcommit backend for this platform; add os/<os>/overcommit.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_OVERCOMMIT_H */

--- a/include/jemalloc/internal/os/posix/error.h
+++ b/include/jemalloc/internal/os/posix/error.h
@@ -1,0 +1,38 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_ERROR_H
+#define JEMALLOC_INTERNAL_OS_POSIX_ERROR_H
+
+/*
+ * POSIX error backend (errno, strerror_r).
+ */
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+
+JEMALLOC_ALWAYS_INLINE int
+os_errno_get(void) {
+	return errno;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_errno_set(int errnum) {
+	errno = errnum;
+}
+
+/*
+ * glibc provides a non-standard strerror_r() when _GNU_SOURCE is defined, so
+ * provide a wrapper.
+ */
+JEMALLOC_ALWAYS_INLINE int
+os_strerror(int err, char *buf, size_t buflen) {
+#if defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE)                  \
+    && defined(_GNU_SOURCE)
+	char *b = strerror_r(err, buf, buflen);
+	if (b != buf) {
+		malloc_snprintf(buf, buflen, "%s", b);
+	}
+	return 0;
+#else
+	return strerror_r(err, buf, buflen);
+#endif
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_ERROR_H */

--- a/include/jemalloc/internal/os/posix/fmt.h
+++ b/include/jemalloc/internal/os/posix/fmt.h
@@ -1,0 +1,16 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_FMT_H
+#define JEMALLOC_INTERNAL_OS_POSIX_FMT_H
+
+#include <inttypes.h>
+
+#define FMTd32 PRId32
+#define FMTu32 PRIu32
+#define FMTx32 PRIx32
+#define FMTd64 PRId64
+#define FMTu64 PRIu64
+#define FMTx64 PRIx64
+#define FMTdPTR PRIdPTR
+#define FMTuPTR PRIuPTR
+#define FMTxPTR PRIxPTR
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_FMT_H */

--- a/include/jemalloc/internal/os/posix/overcommit.h
+++ b/include/jemalloc/internal/os/posix/overcommit.h
@@ -1,0 +1,22 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_OVERCOMMIT_H
+#define JEMALLOC_INTERNAL_OS_POSIX_OVERCOMMIT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include <sys/mman.h>
+
+/* Defined in src/pages.c. */
+extern int mmap_flags;
+
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommit_boot(void) {
+	mmap_flags = MAP_PRIVATE | MAP_ANON;
+#ifdef __NetBSD__
+	os_overcommits = true;
+#else
+	os_overcommits = false;
+#endif
+	return false;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_OVERCOMMIT_H */

--- a/include/jemalloc/internal/os/posix/process.h
+++ b/include/jemalloc/internal/os/posix/process.h
@@ -14,4 +14,31 @@ os_process_id(void) {
 	return (int)getpid();
 }
 
+/*
+ * Shared by every POSIX platform: the four predicates below reproduce, in one
+ * place, exactly which platforms actually get pthread_atfork() registered.
+ *   - JEMALLOC_HAVE_PTHREAD_ATFORK: the function exists.
+ *   - !JEMALLOC_MUTEX_INIT_CB: on FreeBSD-libthr, _pthread_mutex_init_calloc_cb
+ *     makes libthr's own _malloc_prefork/_malloc_postfork drive the fork
+ *     dance instead.  Registering here would be redundant.
+ *   - !JEMALLOC_ZONE: on Darwin, malloc-zone fork callbacks subsume
+ *     pthread_atfork.
+ *   - !__native_client__: Native Client's sandbox doesn't support fork() at
+ *     all, and pthread_atfork() risked being an unresolved symbol in some
+ *     NaCl toolchains.  Registering it is both pointless and unsafe there.
+ */
+JEMALLOC_ALWAYS_INLINE bool
+os_process_register_atfork(void (*prepare)(void), void (*parent)(void),
+    void (*child)(void)) {
+#if defined(JEMALLOC_HAVE_PTHREAD_ATFORK) && !defined(JEMALLOC_MUTEX_INIT_CB) \
+    && !defined(JEMALLOC_ZONE) && !defined(__native_client__)
+	return pthread_atfork(prepare, parent, child) != 0;
+#else
+	(void)prepare;
+	(void)parent;
+	(void)child;
+	return false;
+#endif
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_POSIX_PROCESS_H */

--- a/include/jemalloc/internal/os/posix/vm.h
+++ b/include/jemalloc/internal/os/posix/vm.h
@@ -1,0 +1,290 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_VM_H
+#define JEMALLOC_INTERNAL_OS_POSIX_VM_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+#include "jemalloc/internal/bit_util.h"
+
+#include <sys/mman.h>
+#if defined(JEMALLOC_HAVE_PRCTL) && defined(JEMALLOC_PAGEID)
+#  include <sys/prctl.h>
+#  ifndef PR_SET_VMA
+#    define PR_SET_VMA 0x53564d41
+#    define PR_SET_VMA_ANON_NAME 0
+#  endif
+#endif
+#ifdef __NetBSD__
+#  include <sys/bitops.h> /* ilog2 */
+#endif
+
+#ifdef JEMALLOC_HAVE_VM_MAKE_TAG
+#  define PAGES_FD_TAG VM_MAKE_TAG(254U)
+#else
+#  define PAGES_FD_TAG -1
+#endif
+#define PAGES_PROT_COMMIT   (PROT_READ | PROT_WRITE)
+#define PAGES_PROT_DECOMMIT (PROT_NONE)
+
+/* mmap flags assembled by pages_boot(); MAP_PRIVATE | MAP_ANON (+ MAP_NORESERVE
+ * when the kernel overcommits). */
+extern int mmap_flags;
+
+#ifdef JEMALLOC_PAGEID
+JEMALLOC_ALWAYS_INLINE int
+os_page_id(void *addr, size_t size, const char *name) {
+#  ifdef JEMALLOC_HAVE_PRCTL
+	/*
+	 * While parsing `/proc/<pid>/maps` file, the block could appear as
+	 * 7f4836000000-7f4836800000 rw-p 00000000 00:00 0 [anon:jemalloc_pg_overcommit]`
+	 */
+	int n;
+	assert(addr != NULL);
+	n = prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, (uintptr_t)addr, size,
+	    (uintptr_t)name);
+	assert(n == 0 || (n == -1 && get_errno() == EINVAL));
+	return n;
+#  else
+	return 0;
+#  endif
+}
+#endif
+
+JEMALLOC_ALWAYS_INLINE void *
+os_vm_reserve(void *hint, size_t size, size_t alignment, bool *commit) {
+	assert(ALIGNMENT_ADDR2BASE(hint, os_page) == hint);
+	assert(ALIGNMENT_CEILING(size, os_page) == size);
+	assert(size != 0);
+
+	if (os_overcommits) {
+		*commit = true;
+	}
+
+	void *ret;
+	/*
+	 * We don't use MAP_FIXED here, because it can cause the *replacement*
+	 * of existing mappings, and we only want to create new mappings.
+	 */
+	{
+		int flags = mmap_flags;
+#ifdef __NetBSD__
+		/*
+		 * On NetBSD PAGE for a platform is defined to the
+		 * maximum page size of all machine architectures
+		 * for that platform, so that we can use the same
+		 * binaries across all machine architectures.
+		 */
+		if (alignment > os_page || PAGE > os_page) {
+			unsigned int a = ilog2(MAX(alignment, PAGE));
+			flags |= MAP_ALIGNED(a);
+		}
+#endif
+		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
+
+		ret = mmap(hint, size, prot, flags, PAGES_FD_TAG, 0);
+	}
+	assert(ret != NULL);
+
+	if (ret == MAP_FAILED) {
+		ret = NULL;
+	} else if (hint != NULL && ret != hint) {
+		/*
+		 * We succeeded in mapping memory, but not in the right place.
+		 */
+		os_vm_release(ret, size);
+		ret = NULL;
+	}
+	assert(ret == NULL || (hint == NULL && ret != hint)
+	    || (hint != NULL && ret == hint));
+#ifdef JEMALLOC_PAGEID
+	if (ret != NULL) {
+		os_page_id(ret, size,
+		    os_overcommits ? "jemalloc_pg_overcommit" : "jemalloc_pg");
+	}
+#endif
+	return ret;
+}
+
+#if defined(__FreeBSD__) && defined(MAP_EXCL)
+/*
+ * FreeBSD has mechanisms both to mmap at a specific address without
+ * touching existing mappings (MAP_EXCL), and to mmap with a specific
+ * alignment.
+ */
+#  define OS_VM_HAS_FIXED_ALIGNED_RESERVE
+
+JEMALLOC_ALWAYS_INLINE void *
+os_vm_reserve_aligned_fixed(void *addr, size_t size, size_t alignment,
+    bool *commit) {
+	if (os_overcommits) {
+		*commit = true;
+	}
+
+	int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
+	int flags = mmap_flags;
+
+	if (addr != NULL) {
+		flags |= MAP_FIXED | MAP_EXCL;
+	} else {
+		unsigned alignment_bits = ffs_zu(alignment);
+		assert(alignment_bits > 0);
+		flags |= MAP_ALIGNED(alignment_bits);
+	}
+
+	void *ret = mmap(addr, size, prot, flags, -1, 0);
+	if (ret == MAP_FAILED) {
+		ret = NULL;
+	}
+
+	return ret;
+}
+#endif
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_release(void *addr, size_t size) {
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
+	assert(ALIGNMENT_CEILING(size, os_page) == size);
+
+	if (munmap(addr, size) == -1) {
+		char buf[BUFERROR_BUF];
+
+		buferror(get_errno(), buf, sizeof(buf));
+		malloc_printf("<jemalloc>: Error in munmap(): %s\n", buf);
+		if (opt_abort) {
+			abort();
+		}
+	}
+}
+
+JEMALLOC_ALWAYS_INLINE void *
+os_vm_trim(void *addr, size_t alloc_size, size_t leadsize, size_t size,
+    bool *commit) {
+	assert(alloc_size >= leadsize + size);
+	void  *ret = (void *)((byte_t *)addr + leadsize);
+	size_t trailsize = alloc_size - leadsize - size;
+
+	(void)commit;
+	if (leadsize != 0) {
+		os_vm_release(addr, leadsize);
+	}
+	if (trailsize != 0) {
+		os_vm_release((void *)((byte_t *)ret + size), trailsize);
+	}
+	return ret;
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_commit_impl(void *addr, size_t size, bool commit) {
+	assert(PAGE_ADDR2BASE(addr) == addr);
+	assert(PAGE_CEILING(size) == size);
+
+	int   prot = commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
+	void *result = mmap(
+	    addr, size, prot, mmap_flags | MAP_FIXED, PAGES_FD_TAG, 0);
+	if (result == MAP_FAILED) {
+		return true;
+	}
+	if (result != addr) {
+		/*
+		 * We succeeded in mapping memory, but not in the right
+		 * place.
+		 */
+		os_vm_release(result, size);
+		return true;
+	}
+	return false;
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_commit(void *addr, size_t size) {
+	return os_vm_commit_impl(addr, size, true);
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_decommit(void *addr, size_t size) {
+	return os_vm_commit_impl(addr, size, false);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_mark_guards(void *head, void *tail) {
+	assert(head != NULL || tail != NULL);
+	assert(
+	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
+#ifdef JEMALLOC_HAVE_MPROTECT
+	if (head != NULL) {
+		mprotect(head, PAGE, PROT_NONE);
+	}
+	if (tail != NULL) {
+		mprotect(tail, PAGE, PROT_NONE);
+	}
+#else
+	/* Decommit sets the region to PROT_NONE. */
+	if (head != NULL) {
+		os_vm_decommit(head, PAGE);
+	}
+	if (tail != NULL) {
+		os_vm_decommit(tail, PAGE);
+	}
+#endif
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_unmark_guards(void *head, void *tail) {
+	assert(head != NULL || tail != NULL);
+	assert(
+	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
+#ifdef JEMALLOC_HAVE_MPROTECT
+	bool   head_and_tail = (head != NULL) && (tail != NULL);
+	size_t range = head_and_tail ? (uintptr_t)tail - (uintptr_t)head + PAGE
+	                             : SIZE_T_MAX;
+	/*
+	 * The amount of work that the kernel does in mprotect depends on the
+	 * range argument.  SC_LARGE_MINCLASS is an arbitrary threshold chosen
+	 * to prevent kernel from doing too much work that would outweigh the
+	 * savings of performing one less system call.
+	 */
+	bool ranged_mprotect = head_and_tail && range <= SC_LARGE_MINCLASS;
+	if (ranged_mprotect) {
+		mprotect(head, range, PROT_READ | PROT_WRITE);
+	} else {
+		if (head != NULL) {
+			mprotect(head, PAGE, PROT_READ | PROT_WRITE);
+		}
+		if (tail != NULL) {
+			mprotect(tail, PAGE, PROT_READ | PROT_WRITE);
+		}
+	}
+#else
+	if (head != NULL) {
+		os_vm_commit(head, PAGE);
+	}
+	if (tail != NULL) {
+		os_vm_commit(tail, PAGE);
+	}
+#endif
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_purge_lazy(void *addr, size_t size) {
+#if defined(JEMALLOC_PURGE_MADVISE_FREE)
+	return (madvise(addr, size,
+#  ifdef MADV_FREE
+	            MADV_FREE
+#  else
+	            JEMALLOC_MADV_FREE
+#  endif
+	            )
+	    != 0);
+#elif defined(JEMALLOC_PURGE_MADVISE_DONTNEED)                                \
+    && !defined(JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS)
+	return (madvise(addr, size, MADV_DONTNEED) != 0);
+#elif defined(JEMALLOC_PURGE_POSIX_MADVISE_DONTNEED)                          \
+    && !defined(JEMALLOC_PURGE_POSIX_MADVISE_DONTNEED_ZEROS)
+	return (posix_madvise(addr, size, POSIX_MADV_DONTNEED) != 0);
+#else
+	(void)addr;
+	(void)size;
+	not_reached();
+#endif
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_VM_H */

--- a/include/jemalloc/internal/os/posix/vm.h
+++ b/include/jemalloc/internal/os/posix/vm.h
@@ -2,6 +2,8 @@
 #define JEMALLOC_INTERNAL_OS_POSIX_VM_H
 
 #include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os/overcommit.h"
 
 #include "jemalloc/internal/bit_util.h"
 
@@ -24,10 +26,6 @@
 #endif
 #define PAGES_PROT_COMMIT   (PROT_READ | PROT_WRITE)
 #define PAGES_PROT_DECOMMIT (PROT_NONE)
-
-/* mmap flags assembled by pages_boot(); MAP_PRIVATE | MAP_ANON (+ MAP_NORESERVE
- * when the kernel overcommits). */
-extern int mmap_flags;
 
 #ifdef JEMALLOC_PAGEID
 JEMALLOC_ALWAYS_INLINE int
@@ -284,6 +282,23 @@ os_vm_purge_lazy(void *addr, size_t size) {
 	(void)addr;
 	(void)size;
 	not_reached();
+#endif
+}
+
+JEMALLOC_ALWAYS_INLINE size_t
+os_vm_page_size(void) {
+#ifdef __FreeBSD__
+	/*
+	 * This returns the value obtained from
+	 * the auxv vector, avoiding a syscall.
+	 */
+	return getpagesize();
+#else
+	long result = sysconf(_SC_PAGESIZE);
+	if (result == -1) {
+		return PAGE;
+	}
+	return (size_t)result;
 #endif
 }
 

--- a/include/jemalloc/internal/os/process.h
+++ b/include/jemalloc/internal/os/process.h
@@ -11,6 +11,12 @@
 
 /* Functions required for implementation in each backend. */
 JEMALLOC_ALWAYS_INLINE int os_process_id(void);
+/*
+ * Install fork handlers, returning true on failure.  A no-op returning false
+ * where fork handler registration doesn't apply.
+ */
+JEMALLOC_ALWAYS_INLINE bool os_process_register_atfork(
+    void (*prepare)(void), void (*parent)(void), void (*child)(void));
 
 #if defined(_WIN32)
 #  include "jemalloc/internal/os/windows/process.h"

--- a/include/jemalloc/internal/os/vm.h
+++ b/include/jemalloc/internal/os/vm.h
@@ -5,6 +5,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/malloc_io.h"
 #include "jemalloc/internal/os/detect.h"
+#include "jemalloc/internal/os/overcommit.h"
 #include "jemalloc/internal/pages.h"
 #include "jemalloc/internal/sc.h"
 
@@ -16,10 +17,10 @@
  * themselves.
  * Default: posix/.  Override: Windows (VirtualAlloc/VirtualFree).
  *
- * State: `os_overcommits`, set by pages_boot(), read directly by the
- * backends below.
+ * `os_overcommits` (read by os_vm_reserve/os_vm_commit_impl below) is
+ * declared and set by os/overcommit.h, a separate module -- boot-time
+ * kernel-policy detection isn't itself a VM reserve/commit primitive.
  */
-extern bool os_overcommits;
 
 /* Functions required for implementation in each backend. */
 JEMALLOC_ALWAYS_INLINE void *os_vm_reserve(
@@ -32,6 +33,7 @@ JEMALLOC_ALWAYS_INLINE bool os_vm_decommit(void *addr, size_t size);
 JEMALLOC_ALWAYS_INLINE void os_vm_mark_guards(void *head, void *tail);
 JEMALLOC_ALWAYS_INLINE void os_vm_unmark_guards(void *head, void *tail);
 JEMALLOC_ALWAYS_INLINE bool os_vm_purge_lazy(void *addr, size_t size);
+JEMALLOC_ALWAYS_INLINE size_t os_vm_page_size(void);
 
 #if defined(_WIN32)
 #  include "jemalloc/internal/os/windows/vm.h"

--- a/include/jemalloc/internal/os/vm.h
+++ b/include/jemalloc/internal/os/vm.h
@@ -1,0 +1,44 @@
+#ifndef JEMALLOC_INTERNAL_OS_VM_H
+#define JEMALLOC_INTERNAL_OS_VM_H
+
+#include "jemalloc/internal/jemalloc_internal_externs.h"
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os/detect.h"
+#include "jemalloc/internal/pages.h"
+#include "jemalloc/internal/sc.h"
+
+/*
+ * VM interface: raw page-level reserve/commit/decommit/guard/trim primitives
+ * used by src/pages.c. Platform-specific fast paths (e.g. the FreeBSD
+ * MAP_EXCL reservation shortcut) stay in src/pages.c, since they are
+ * portable decisions layered on top of these primitives, not primitives
+ * themselves.
+ * Default: posix/.  Override: Windows (VirtualAlloc/VirtualFree).
+ *
+ * State: `os_overcommits`, set by pages_boot(), read directly by the
+ * backends below.
+ */
+extern bool os_overcommits;
+
+/* Functions required for implementation in each backend. */
+JEMALLOC_ALWAYS_INLINE void *os_vm_reserve(
+    void *hint, size_t size, size_t alignment, bool *commit);
+JEMALLOC_ALWAYS_INLINE void os_vm_release(void *addr, size_t size);
+JEMALLOC_ALWAYS_INLINE void *os_vm_trim(void *addr, size_t alloc_size,
+    size_t leadsize, size_t size, bool *commit);
+JEMALLOC_ALWAYS_INLINE bool os_vm_commit(void *addr, size_t size);
+JEMALLOC_ALWAYS_INLINE bool os_vm_decommit(void *addr, size_t size);
+JEMALLOC_ALWAYS_INLINE void os_vm_mark_guards(void *head, void *tail);
+JEMALLOC_ALWAYS_INLINE void os_vm_unmark_guards(void *head, void *tail);
+JEMALLOC_ALWAYS_INLINE bool os_vm_purge_lazy(void *addr, size_t size);
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/vm.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/vm.h"
+#else
+#  error "OS layer: no vm backend for this platform; add os/<os>/vm.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_VM_H */

--- a/include/jemalloc/internal/os/windows/error.h
+++ b/include/jemalloc/internal/os/windows/error.h
@@ -1,0 +1,26 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_ERROR_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_ERROR_H
+
+/*
+ * Windows error backend (GetLastError/SetLastError, FormatMessageA).
+ */
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+JEMALLOC_ALWAYS_INLINE int
+os_errno_get(void) {
+	return GetLastError();
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_errno_set(int errnum) {
+	SetLastError(errnum);
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_strerror(int err, char *buf, size_t buflen) {
+	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, (LPSTR)buf,
+	    (DWORD)buflen, NULL);
+	return 0;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_ERROR_H */

--- a/include/jemalloc/internal/os/windows/fmt.h
+++ b/include/jemalloc/internal/os/windows/fmt.h
@@ -1,0 +1,21 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_FMT_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_FMT_H
+
+#ifdef _WIN64
+#  define FMT64_PREFIX "ll"
+#  define FMTPTR_PREFIX "ll"
+#else
+#  define FMT64_PREFIX "ll"
+#  define FMTPTR_PREFIX ""
+#endif
+#define FMTd32 "d"
+#define FMTu32 "u"
+#define FMTx32 "x"
+#define FMTd64 FMT64_PREFIX "d"
+#define FMTu64 FMT64_PREFIX "u"
+#define FMTx64 FMT64_PREFIX "x"
+#define FMTdPTR FMTPTR_PREFIX "d"
+#define FMTuPTR FMTPTR_PREFIX "u"
+#define FMTxPTR FMTPTR_PREFIX "x"
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_FMT_H */

--- a/include/jemalloc/internal/os/windows/overcommit.h
+++ b/include/jemalloc/internal/os/windows/overcommit.h
@@ -1,0 +1,20 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_OVERCOMMIT_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_OVERCOMMIT_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+JEMALLOC_ALWAYS_INLINE bool
+os_overcommit_boot(void) {
+	/*
+	 * Windows never overcommits, so this just hardcodes os_overcommits =
+	 * false.  There's no sysctl/proc-file probe to run (contrast with
+	 * os_overcommits_sysctl() in os/freebsd/overcommit.h and
+	 * os_overcommits_proc() in os/linux/overcommit.h) and no
+	 * DONTNEED-zeros probe or mmap_flags to assemble (both
+	 * POSIX/madvise-only concepts).
+	 */
+	os_overcommits = false;
+	return false;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_OVERCOMMIT_H */

--- a/include/jemalloc/internal/os/windows/process.h
+++ b/include/jemalloc/internal/os/windows/process.h
@@ -12,4 +12,14 @@ os_process_id(void) {
 	return (int)GetCurrentProcessId();
 }
 
+/* Windows has no fork(2)/pthread_atfork; always a no-op. */
+JEMALLOC_ALWAYS_INLINE bool
+os_process_register_atfork(void (*prepare)(void), void (*parent)(void),
+    void (*child)(void)) {
+	(void)prepare;
+	(void)parent;
+	(void)child;
+	return false;
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_WINDOWS_PROCESS_H */

--- a/include/jemalloc/internal/os/windows/vm.h
+++ b/include/jemalloc/internal/os/windows/vm.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_OS_WINDOWS_VM_H
 
 #include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os/overcommit.h"
 
 JEMALLOC_ALWAYS_INLINE void *
 os_vm_reserve(void *hint, size_t size, size_t alignment, bool *commit) {
@@ -110,6 +111,13 @@ JEMALLOC_ALWAYS_INLINE bool
 os_vm_purge_lazy(void *addr, size_t size) {
 	VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE);
 	return false;
+}
+
+JEMALLOC_ALWAYS_INLINE size_t
+os_vm_page_size(void) {
+	SYSTEM_INFO si;
+	GetSystemInfo(&si);
+	return (size_t)si.dwPageSize;
 }
 
 #endif /* JEMALLOC_INTERNAL_OS_WINDOWS_VM_H */

--- a/include/jemalloc/internal/os/windows/vm.h
+++ b/include/jemalloc/internal/os/windows/vm.h
@@ -1,0 +1,115 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_VM_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_VM_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+JEMALLOC_ALWAYS_INLINE void *
+os_vm_reserve(void *hint, size_t size, size_t alignment, bool *commit) {
+	assert(ALIGNMENT_ADDR2BASE(hint, os_page) == hint);
+	assert(ALIGNMENT_CEILING(size, os_page) == size);
+	assert(size != 0);
+	(void)alignment;
+
+	if (os_overcommits) {
+		*commit = true;
+	}
+
+	void *ret;
+	/*
+	 * If VirtualAlloc can't allocate at the given address when one is
+	 * given, it fails and returns NULL.
+	 */
+	ret = VirtualAlloc(hint, size, MEM_RESERVE | (*commit ? MEM_COMMIT : 0),
+	    PAGE_READWRITE);
+	assert(ret == NULL || (hint == NULL && ret != hint)
+	    || (hint != NULL && ret == hint));
+	return ret;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_release(void *addr, size_t size) {
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
+	assert(ALIGNMENT_CEILING(size, os_page) == size);
+
+	if (VirtualFree(addr, 0, MEM_RELEASE) == 0) {
+		char buf[BUFERROR_BUF];
+
+		buferror(get_errno(), buf, sizeof(buf));
+		malloc_printf("<jemalloc>: Error in VirtualFree(): %s\n", buf);
+		if (opt_abort) {
+			abort();
+		}
+	}
+}
+
+JEMALLOC_ALWAYS_INLINE void *
+os_vm_trim(void *addr, size_t alloc_size, size_t leadsize, size_t size,
+    bool *commit) {
+	assert(alloc_size >= leadsize + size);
+	void *ret = (void *)((byte_t *)addr + leadsize);
+
+	os_vm_release(addr, alloc_size);
+	void *new_addr = os_vm_reserve(ret, size, PAGE, commit);
+	if (new_addr == ret) {
+		return ret;
+	}
+	if (new_addr != NULL) {
+		os_vm_release(new_addr, size);
+	}
+	return NULL;
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_commit_impl(void *addr, size_t size, bool commit) {
+	assert(PAGE_ADDR2BASE(addr) == addr);
+	assert(PAGE_CEILING(size) == size);
+
+	return (commit
+	        ? (addr != VirtualAlloc(addr, size, MEM_COMMIT, PAGE_READWRITE))
+	        : (!VirtualFree(addr, size, MEM_DECOMMIT)));
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_commit(void *addr, size_t size) {
+	return os_vm_commit_impl(addr, size, true);
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_decommit(void *addr, size_t size) {
+	return os_vm_commit_impl(addr, size, false);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_mark_guards(void *head, void *tail) {
+	assert(head != NULL || tail != NULL);
+	assert(
+	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
+	/* Decommit sets the region to MEM_DECOMMIT. */
+	if (head != NULL) {
+		os_vm_decommit(head, PAGE);
+	}
+	if (tail != NULL) {
+		os_vm_decommit(tail, PAGE);
+	}
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_vm_unmark_guards(void *head, void *tail) {
+	assert(head != NULL || tail != NULL);
+	assert(
+	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
+	if (head != NULL) {
+		os_vm_commit(head, PAGE);
+	}
+	if (tail != NULL) {
+		os_vm_commit(tail, PAGE);
+	}
+}
+
+JEMALLOC_ALWAYS_INLINE bool
+os_vm_purge_lazy(void *addr, size_t size) {
+	VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE);
+	return false;
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_VM_H */

--- a/include/jemalloc/internal/util.h
+++ b/include/jemalloc/internal/util.h
@@ -3,6 +3,7 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_types.h"
+#include "jemalloc/internal/os/error.h"
 
 #define UTIL_INLINE static inline
 
@@ -66,21 +67,13 @@ max_zu(size_t a, size_t b) {
 /* Set error code. */
 UTIL_INLINE void
 set_errno(int errnum) {
-#ifdef _WIN32
-	SetLastError(errnum);
-#else
-	errno = errnum;
-#endif
+	os_errno_set(errnum);
 }
 
 /* Get last error code. */
 UTIL_INLINE int
 get_errno(void) {
-#ifdef _WIN32
-	return GetLastError();
-#else
-	return errno;
-#endif
+	return os_errno_get();
 }
 
 #ifdef _MSC_VER

--- a/src/jemalloc_init.c
+++ b/src/jemalloc_init.c
@@ -347,13 +347,18 @@ malloc_init_hard_recursible(void) {
 		}
 	}
 
-#if (defined(JEMALLOC_HAVE_PTHREAD_ATFORK) && !defined(JEMALLOC_MUTEX_INIT_CB) \
-    && !defined(JEMALLOC_ZONE) && !defined(_WIN32)                             \
-    && !defined(__native_client__))
-	/* LinuxThreads' pthread_atfork() allocates. */
-	if (pthread_atfork(jemalloc_prefork, jemalloc_postfork_parent,
-	        jemalloc_postfork_child)
-	    != 0) {
+#ifndef JEMALLOC_MUTEX_INIT_CB
+	/*
+	 * jemalloc_fork.c names these jemalloc_prefork()/jemalloc_postfork_
+	 * parent() only when !JEMALLOC_MUTEX_INIT_CB; under it they're exported
+	 * as _malloc_prefork()/_malloc_postfork() instead (FreeBSD-libthr calls
+	 * those directly, bypassing pthread_atfork() registration entirely --
+	 * see os_process_register_atfork()'s own !JEMALLOC_MUTEX_INIT_CB check).
+	 * Referencing the former names here unconditionally would be a link
+	 * error under JEMALLOC_MUTEX_INIT_CB, since they wouldn't exist.
+	 */
+	if (os_process_register_atfork(jemalloc_prefork,
+	        jemalloc_postfork_parent, jemalloc_postfork_child)) {
 		malloc_write("<jemalloc>: Error in pthread_atfork()\n");
 		if (opt_abort) {
 			abort();

--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -91,26 +91,9 @@ malloc_write(const char *s) {
 	}
 }
 
-/*
- * glibc provides a non-standard strerror_r() when _GNU_SOURCE is defined, so
- * provide a wrapper.
- */
 int
 buferror(int err, char *buf, size_t buflen) {
-#ifdef _WIN32
-	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, (LPSTR)buf,
-	    (DWORD)buflen, NULL);
-	return 0;
-#elif defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE)                \
-    && defined(_GNU_SOURCE)
-	char *b = strerror_r(err, buf, buflen);
-	if (b != buf) {
-		malloc_snprintf(buf, buflen, "%s", b);
-	}
-	return 0;
-#else
-	return strerror_r(err, buf, buflen);
-#endif
+	return os_strerror(err, buf, buflen);
 }
 
 uintmax_t

--- a/src/pages.c
+++ b/src/pages.c
@@ -14,21 +14,6 @@
 #		include <vm/vm_param.h>
 #	endif
 #endif
-#ifdef __NetBSD__
-#	include <sys/bitops.h> /* ilog2 */
-#endif
-#ifdef JEMALLOC_HAVE_VM_MAKE_TAG
-#	define PAGES_FD_TAG VM_MAKE_TAG(254U)
-#else
-#	define PAGES_FD_TAG -1
-#endif
-#if defined(JEMALLOC_HAVE_PRCTL) && defined(JEMALLOC_PAGEID)
-#	include <sys/prctl.h>
-#	ifndef PR_SET_VMA
-#		define PR_SET_VMA 0x53564d41
-#		define PR_SET_VMA_ANON_NAME 0
-#	endif
-#endif
 
 /******************************************************************************/
 /* Data. */
@@ -36,12 +21,10 @@
 /* Actual operating system page size, detected during bootstrap, <= PAGE. */
 size_t os_page;
 
-#ifndef _WIN32
-#	define PAGES_PROT_COMMIT (PROT_READ | PROT_WRITE)
-#	define PAGES_PROT_DECOMMIT (PROT_NONE)
-static int mmap_flags;
-#endif
-static bool os_overcommits;
+/* Set here. Consumed by os_vm_reserve/os_vm_commit in os/posix/vm.h. */
+int mmap_flags;
+/* Set here, consumed directly by the os/vm.h backends. */
+bool os_overcommits;
 
 const char *const thp_mode_names[] = {
     "default", "always", "never", "not supported"};
@@ -106,156 +89,12 @@ madvise_MADV_DONTNEED_zeroes_pages(void) {
 }
 #endif
 
-#ifdef JEMALLOC_PAGEID
-static int
-os_page_id(void *addr, size_t size, const char *name) {
-#	ifdef JEMALLOC_HAVE_PRCTL
-	/*
-	 * While parsing `/proc/<pid>/maps` file, the block could appear as
-	 * 7f4836000000-7f4836800000 rw-p 00000000 00:00 0 [anon:jemalloc_pg_overcommit]`
-	 */
-	int n;
-	assert(addr != NULL);
-	n = prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, (uintptr_t)addr, size,
-	    (uintptr_t)name);
-	assert(n == 0 || (n == -1 && get_errno() == EINVAL));
-	return n;
-#	else
-	return 0;
-#	endif
-}
-#endif
-
-/******************************************************************************/
-/*
- * Function prototypes for static functions that are referenced prior to
- * definition.
- */
-
-static void os_pages_unmap(void *addr, size_t size);
-
 /******************************************************************************/
 
 static void *
-os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
-	assert(ALIGNMENT_CEILING(size, os_page) == size);
-	assert(size != 0);
-
-	if (os_overcommits) {
-		*commit = true;
-	}
-
-	void *ret;
-#ifdef _WIN32
-	/*
-	 * If VirtualAlloc can't allocate at the given address when one is
-	 * given, it fails and returns NULL.
-	 */
-	ret = VirtualAlloc(addr, size, MEM_RESERVE | (*commit ? MEM_COMMIT : 0),
-	    PAGE_READWRITE);
-#else
-	/*
-	 * We don't use MAP_FIXED here, because it can cause the *replacement*
-	 * of existing mappings, and we only want to create new mappings.
-	 */
-	{
-		int flags = mmap_flags;
-#	ifdef __NetBSD__
-		/*
-		 * On NetBSD PAGE for a platform is defined to the
-		 * maximum page size of all machine architectures
-		 * for that platform, so that we can use the same
-		 * binaries across all machine architectures.
-		 */
-		if (alignment > os_page || PAGE > os_page) {
-			unsigned int a = ilog2(MAX(alignment, PAGE));
-			flags |= MAP_ALIGNED(a);
-		}
-#	endif
-		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
-
-		ret = mmap(addr, size, prot, flags, PAGES_FD_TAG, 0);
-	}
-	assert(ret != NULL);
-
-	if (ret == MAP_FAILED) {
-		ret = NULL;
-	} else if (addr != NULL && ret != addr) {
-		/*
-		 * We succeeded in mapping memory, but not in the right place.
-		 */
-		os_pages_unmap(ret, size);
-		ret = NULL;
-	}
-#endif
-	assert(ret == NULL || (addr == NULL && ret != addr)
-	    || (addr != NULL && ret == addr));
-#ifdef JEMALLOC_PAGEID
-	if (ret != NULL) {
-		os_page_id(ret, size,
-		    os_overcommits ? "jemalloc_pg_overcommit" : "jemalloc_pg");
-	}
-#endif
-	return ret;
-}
-
-static void *
-os_pages_trim(
+pages_trim(
     void *addr, size_t alloc_size, size_t leadsize, size_t size, bool *commit) {
-	void *ret = (void *)((byte_t *)addr + leadsize);
-
-	assert(alloc_size >= leadsize + size);
-#ifdef _WIN32
-	os_pages_unmap(addr, alloc_size);
-	void *new_addr = os_pages_map(ret, size, PAGE, commit);
-	if (new_addr == ret) {
-		return ret;
-	}
-	if (new_addr != NULL) {
-		os_pages_unmap(new_addr, size);
-	}
-	return NULL;
-#else
-	size_t trailsize = alloc_size - leadsize - size;
-
-	if (leadsize != 0) {
-		os_pages_unmap(addr, leadsize);
-	}
-	if (trailsize != 0) {
-		os_pages_unmap((void *)((byte_t *)ret + size), trailsize);
-	}
-	return ret;
-#endif
-}
-
-static void
-os_pages_unmap(void *addr, size_t size) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
-	assert(ALIGNMENT_CEILING(size, os_page) == size);
-
-#ifdef _WIN32
-	if (VirtualFree(addr, 0, MEM_RELEASE) == 0)
-#else
-	if (munmap(addr, size) == -1)
-#endif
-	{
-		char buf[BUFERROR_BUF];
-
-		buferror(get_errno(), buf, sizeof(buf));
-		malloc_printf(
-		    "<jemalloc>: Error in "
-#ifdef _WIN32
-		    "VirtualFree"
-#else
-		    "munmap"
-#endif
-		    "(): %s\n",
-		    buf);
-		if (opt_abort) {
-			abort();
-		}
-	}
+	return os_vm_trim(addr, alloc_size, leadsize, size, commit);
 }
 
 static void *
@@ -268,13 +107,13 @@ pages_map_slow(size_t size, size_t alignment, bool *commit) {
 
 	void *ret;
 	do {
-		void *pages = os_pages_map(NULL, alloc_size, alignment, commit);
+		void *pages = os_vm_reserve(NULL, alloc_size, alignment, commit);
 		if (pages == NULL) {
 			return NULL;
 		}
 		size_t leadsize = ALIGNMENT_CEILING((uintptr_t)pages, alignment)
 		    - (uintptr_t)pages;
-		ret = os_pages_trim(pages, alloc_size, leadsize, size, commit);
+		ret = pages_trim(pages, alloc_size, leadsize, size, commit);
 	} while (ret == NULL);
 
 	assert(ret != NULL);
@@ -287,34 +126,8 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	assert(alignment >= PAGE);
 	assert(ALIGNMENT_ADDR2BASE(addr, alignment) == addr);
 
-#if defined(__FreeBSD__) && defined(MAP_EXCL)
-	/*
-	 * FreeBSD has mechanisms both to mmap at specific address without
-	 * touching existing mappings, and to mmap with specific alignment.
-	 */
-	{
-		if (os_overcommits) {
-			*commit = true;
-		}
-
-		int prot = *commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
-		int flags = mmap_flags;
-
-		if (addr != NULL) {
-			flags |= MAP_FIXED | MAP_EXCL;
-		} else {
-			unsigned alignment_bits = ffs_zu(alignment);
-			assert(alignment_bits > 0);
-			flags |= MAP_ALIGNED(alignment_bits);
-		}
-
-		void *ret = mmap(addr, size, prot, flags, -1, 0);
-		if (ret == MAP_FAILED) {
-			ret = NULL;
-		}
-
-		return ret;
-	}
+#ifdef OS_VM_HAS_FIXED_ALIGNED_RESERVE
+	return os_vm_reserve_aligned_fixed(addr, size, alignment, commit);
 #endif
 	/*
 	 * Ideally, there would be a way to specify alignment to mmap() (like
@@ -322,7 +135,7 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 * hard to efficiently create aligned mappings.  The reliable, but
 	 * slow method is to create a mapping that is over-sized, then trim the
 	 * excess.  However, that always results in one or two calls to
-	 * os_pages_unmap(), and it can leave holes in the process's virtual
+	 * os_vm_release(), and it can leave holes in the process's virtual
 	 * memory map if memory grows downward.
 	 *
 	 * Optimistically try mapping precisely the right amount before falling
@@ -330,13 +143,13 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 * approach works most of the time.
 	 */
 
-	void *ret = os_pages_map(addr, size, os_page, commit);
+	void *ret = os_vm_reserve(addr, size, os_page, commit);
 	if (ret == NULL || ret == addr) {
 		return ret;
 	}
 	assert(addr == NULL);
 	if (ALIGNMENT_ADDR2OFFSET(ret, alignment) != 0) {
-		os_pages_unmap(ret, size);
+		os_vm_release(ret, size);
 		return pages_map_slow(size, alignment, commit);
 	}
 
@@ -349,37 +162,7 @@ pages_unmap(void *addr, size_t size) {
 	assert(PAGE_ADDR2BASE(addr) == addr);
 	assert(PAGE_CEILING(size) == size);
 
-	os_pages_unmap(addr, size);
-}
-
-static bool
-os_pages_commit(void *addr, size_t size, bool commit) {
-	assert(PAGE_ADDR2BASE(addr) == addr);
-	assert(PAGE_CEILING(size) == size);
-
-#ifdef _WIN32
-	return (commit
-	        ? (addr != VirtualAlloc(addr, size, MEM_COMMIT, PAGE_READWRITE))
-	        : (!VirtualFree(addr, size, MEM_DECOMMIT)));
-#else
-	{
-		int   prot = commit ? PAGES_PROT_COMMIT : PAGES_PROT_DECOMMIT;
-		void *result = mmap(
-		    addr, size, prot, mmap_flags | MAP_FIXED, PAGES_FD_TAG, 0);
-		if (result == MAP_FAILED) {
-			return true;
-		}
-		if (result != addr) {
-			/*
-			 * We succeeded in mapping memory, but not in the right
-			 * place.
-			 */
-			os_pages_unmap(result, size);
-			return true;
-		}
-		return false;
-	}
-#endif
+	os_vm_release(addr, size);
 }
 
 static bool
@@ -388,7 +171,7 @@ pages_commit_impl(void *addr, size_t size, bool commit) {
 		return true;
 	}
 
-	return os_pages_commit(addr, size, commit);
+	return commit ? os_vm_commit(addr, size) : os_vm_decommit(addr, size);
 }
 
 bool
@@ -403,61 +186,12 @@ pages_decommit(void *addr, size_t size) {
 
 void
 pages_mark_guards(void *head, void *tail) {
-	assert(head != NULL || tail != NULL);
-	assert(
-	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
-#ifdef JEMALLOC_HAVE_MPROTECT
-	if (head != NULL) {
-		mprotect(head, PAGE, PROT_NONE);
-	}
-	if (tail != NULL) {
-		mprotect(tail, PAGE, PROT_NONE);
-	}
-#else
-	/* Decommit sets to PROT_NONE / MEM_DECOMMIT. */
-	if (head != NULL) {
-		os_pages_commit(head, PAGE, false);
-	}
-	if (tail != NULL) {
-		os_pages_commit(tail, PAGE, false);
-	}
-#endif
+	os_vm_mark_guards(head, tail);
 }
 
 void
 pages_unmark_guards(void *head, void *tail) {
-	assert(head != NULL || tail != NULL);
-	assert(
-	    head == NULL || tail == NULL || (uintptr_t)head < (uintptr_t)tail);
-#ifdef JEMALLOC_HAVE_MPROTECT
-	bool   head_and_tail = (head != NULL) && (tail != NULL);
-	size_t range = head_and_tail ? (uintptr_t)tail - (uintptr_t)head + PAGE
-	                             : SIZE_T_MAX;
-	/*
-	 * The amount of work that the kernel does in mprotect depends on the
-	 * range argument.  SC_LARGE_MINCLASS is an arbitrary threshold chosen
-	 * to prevent kernel from doing too much work that would outweigh the
-	 * savings of performing one less system call.
-	 */
-	bool ranged_mprotect = head_and_tail && range <= SC_LARGE_MINCLASS;
-	if (ranged_mprotect) {
-		mprotect(head, range, PROT_READ | PROT_WRITE);
-	} else {
-		if (head != NULL) {
-			mprotect(head, PAGE, PROT_READ | PROT_WRITE);
-		}
-		if (tail != NULL) {
-			mprotect(tail, PAGE, PROT_READ | PROT_WRITE);
-		}
-	}
-#else
-	if (head != NULL) {
-		os_pages_commit(head, PAGE, true);
-	}
-	if (tail != NULL) {
-		os_pages_commit(tail, PAGE, true);
-	}
-#endif
+	os_vm_unmark_guards(head, tail);
 }
 
 bool
@@ -476,27 +210,7 @@ pages_purge_lazy(void *addr, size_t size) {
 		return true;
 	}
 
-#ifdef _WIN32
-	VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE);
-	return false;
-#elif defined(JEMALLOC_PURGE_MADVISE_FREE)
-	return (madvise(addr, size,
-#	ifdef MADV_FREE
-	            MADV_FREE
-#	else
-	            JEMALLOC_MADV_FREE
-#	endif
-	            )
-	    != 0);
-#elif defined(JEMALLOC_PURGE_MADVISE_DONTNEED)                                 \
-    && !defined(JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS)
-	return (madvise(addr, size, MADV_DONTNEED) != 0);
-#elif defined(JEMALLOC_PURGE_POSIX_MADVISE_DONTNEED)                           \
-    && !defined(JEMALLOC_PURGE_POSIX_MADVISE_DONTNEED_ZEROS)
-	return (posix_madvise(addr, size, POSIX_MADV_DONTNEED) != 0);
-#else
-	not_reached();
-#endif
+	return os_vm_purge_lazy(addr, size);
 }
 
 bool
@@ -932,7 +646,7 @@ pages_boot(void) {
 	/* Detect lazy purge runtime support. */
 	if (pages_can_purge_lazy) {
 		bool  committed = false;
-		void *madv_free_page = os_pages_map(
+		void *madv_free_page = os_vm_reserve(
 		    NULL, PAGE, PAGE, &committed);
 		if (madv_free_page == NULL) {
 			return true;
@@ -941,7 +655,7 @@ pages_boot(void) {
 		if (pages_purge_lazy(madv_free_page, PAGE)) {
 			pages_can_purge_lazy_runtime = false;
 		}
-		os_pages_unmap(madv_free_page, PAGE);
+		os_vm_release(madv_free_page, PAGE);
 	}
 #endif
 	if (init_process_madvise()) {

--- a/src/pages.c
+++ b/src/pages.c
@@ -8,22 +8,15 @@
 #include "jemalloc/internal/pages.h"
 #include "jemalloc/internal/sc.h"
 
-#ifdef JEMALLOC_SYSCTL_VM_OVERCOMMIT
-#	include <sys/sysctl.h>
-#	ifdef __FreeBSD__
-#		include <vm/vm_param.h>
-#	endif
-#endif
-
 /******************************************************************************/
 /* Data. */
 
 /* Actual operating system page size, detected during bootstrap, <= PAGE. */
 size_t os_page;
 
-/* Set here. Consumed by os_vm_reserve/os_vm_commit in os/posix/vm.h. */
+/* Set here. Consumed by os_vm_reserve/os_vm_commit_impl in os/posix/vm.h. */
 int mmap_flags;
-/* Set here, consumed directly by the os/vm.h backends. */
+/* Set here, consumed directly by the os/overcommit.h and os/vm.h backends. */
 bool os_overcommits;
 
 const char *const thp_mode_names[] = {
@@ -37,56 +30,9 @@ system_thp_mode_t init_system_thp_mode;
 static bool pages_can_purge_lazy_runtime = true;
 
 #ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
-static int madvise_dont_need_zeros_is_faulty = -1;
-/**
- * Check that MADV_DONTNEED will actually zero pages on subsequent access.
- *
- * Since qemu does not support this, yet [1], and you can get very tricky
- * assert if you will run program with jemalloc in use under qemu:
- *
- *     <jemalloc>: ../contrib/jemalloc/src/extent.c:1195: Failed assertion: "p[i] == 0"
- *
- *   [1]: https://patchwork.kernel.org/patch/10576637/
- */
-static int
-madvise_MADV_DONTNEED_zeroes_pages(void) {
-	size_t size = PAGE;
-
-	void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
-	    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
-	if (addr == MAP_FAILED) {
-		malloc_write(
-		    "<jemalloc>: Cannot allocate memory for "
-		    "MADV_DONTNEED check\n");
-		if (opt_abort) {
-			abort();
-		}
-	}
-
-	memset(addr, 'A', size);
-	int works;
-	if (madvise(addr, size, MADV_DONTNEED) == 0) {
-		works = memchr(addr, 'A', size) == NULL;
-	} else {
-		/*
-		 * If madvise() does not support MADV_DONTNEED, then we can
-		 * call it anyway, and use it's return code.
-		 */
-		works = 1;
-	}
-
-	if (munmap(addr, size) != 0) {
-		malloc_write(
-		    "<jemalloc>: Cannot deallocate memory for "
-		    "MADV_DONTNEED check\n");
-		if (opt_abort) {
-			abort();
-		}
-	}
-
-	return works;
-}
+/* Set by os_overcommit_boot()'s madvise_MADV_DONTNEED_zeroes_pages() probe
+ * (os/posix/overcommit.h), consumed by pages_purge_forced() below. */
+int madvise_dont_need_zeros_is_faulty = -1;
 #endif
 
 /******************************************************************************/
@@ -414,88 +360,6 @@ pages_purge_process_madvise(void *vec, size_t vec_len, size_t total_bytes) {
 	return pages_purge_process_madvise_impl(vec, vec_len, total_bytes);
 }
 
-static size_t
-os_page_detect(void) {
-#ifdef _WIN32
-	SYSTEM_INFO si;
-	GetSystemInfo(&si);
-	return si.dwPageSize;
-#elif defined(__FreeBSD__)
-	/*
-	 * This returns the value obtained from
-	 * the auxv vector, avoiding a syscall.
-	 */
-	return getpagesize();
-#else
-	long result = sysconf(_SC_PAGESIZE);
-	if (result == -1) {
-		return PAGE;
-	}
-	return (size_t)result;
-#endif
-}
-
-#ifdef JEMALLOC_SYSCTL_VM_OVERCOMMIT
-static bool
-os_overcommits_sysctl(void) {
-	int    vm_overcommit;
-	size_t sz;
-
-	sz = sizeof(vm_overcommit);
-#	if defined(__FreeBSD__) && defined(VM_OVERCOMMIT)
-	int mib[2];
-
-	mib[0] = CTL_VM;
-	mib[1] = VM_OVERCOMMIT;
-	if (sysctl(mib, 2, &vm_overcommit, &sz, NULL, 0) != 0) {
-		return false; /* Error. */
-	}
-#	else
-	if (sysctlbyname("vm.overcommit", &vm_overcommit, &sz, NULL, 0) != 0) {
-		return false; /* Error. */
-	}
-#	endif
-
-	return ((vm_overcommit & 0x3) == 0);
-}
-#endif
-
-#ifdef JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY
-static bool
-os_overcommits_proc(void) {
-	int  fd;
-	char buf[1];
-
-#	if defined(O_CLOEXEC)
-	fd = malloc_open(
-	    "/proc/sys/vm/overcommit_memory", O_RDONLY | O_CLOEXEC);
-#	else
-	fd = malloc_open("/proc/sys/vm/overcommit_memory", O_RDONLY);
-	if (fd != -1) {
-		fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
-	}
-#	endif
-
-	if (fd == -1) {
-		return false; /* Error. */
-	}
-
-	ssize_t nread = malloc_read_fd(fd, &buf, sizeof(buf));
-	malloc_close(fd);
-
-	if (nread < 1) {
-		return false; /* Error. */
-	}
-	/*
-	 * /proc/sys/vm/overcommit_memory meanings:
-	 * 0: Heuristic overcommit.
-	 * 1: Always overcommit.
-	 * 2: Never overcommit.
-	 */
-	return (buf[0] == '0' || buf[0] == '1');
-}
-#endif
-
 static bool
 pages_should_skip_set_thp_state(void) {
 	if (opt_thp == thp_mode_do_nothing
@@ -591,7 +455,7 @@ label_error:
 
 bool
 pages_boot(void) {
-	os_page = os_page_detect();
+	os_page = os_vm_page_size();
 	if (os_page > PAGE) {
 		malloc_write("<jemalloc>: Unsupported system page size\n");
 		if (opt_abort) {
@@ -600,41 +464,9 @@ pages_boot(void) {
 		return true;
 	}
 
-#ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
-	if (!opt_trust_madvise) {
-		madvise_dont_need_zeros_is_faulty =
-		    !madvise_MADV_DONTNEED_zeroes_pages();
-		if (madvise_dont_need_zeros_is_faulty) {
-			malloc_write(
-			    "<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)\n");
-			malloc_write(
-			    "<jemalloc>: (This is the expected behaviour if you are running under QEMU)\n");
-		}
-	} else {
-		/* In case opt_trust_madvise is disable,
-		 * do not do runtime check */
-		madvise_dont_need_zeros_is_faulty = 0;
+	if (os_overcommit_boot()) {
+		return true;
 	}
-#endif
-
-#ifndef _WIN32
-	mmap_flags = MAP_PRIVATE | MAP_ANON;
-#endif
-
-#ifdef JEMALLOC_SYSCTL_VM_OVERCOMMIT
-	os_overcommits = os_overcommits_sysctl();
-#elif defined(JEMALLOC_PROC_SYS_VM_OVERCOMMIT_MEMORY)
-	os_overcommits = os_overcommits_proc();
-#	ifdef MAP_NORESERVE
-	if (os_overcommits) {
-		mmap_flags |= MAP_NORESERVE;
-	}
-#	endif
-#elif defined(__NetBSD__)
-	os_overcommits = true;
-#else
-	os_overcommits = false;
-#endif
 
 	init_thp_state();
 


### PR DESCRIPTION
Following #2963  and #2972, this PR is the last of the OS layer migration, it covers modules process, VM management, boot-time setup for overcommit, error code handling, and FMT printf macros.

Some special cases in this PR:
1. Commit "Move boot and overcommit setup" is able to remove some macro symbols which were used to record the OS detection results found in `configure.ac`. Instead, per-OS dispatching is now done in `os.h`;
2. Error code handling and FMT module migration are required in some utilities and included before `os.h` is included. Still put them in the list of `os.h` dispatching list just for observability, they do not rely on `os.h` dispatching. 