### PR TITLE
Use the cache-bin limit for tcache_nslots_small_max

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -759,13 +759,13 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			 */
 			CONF_HANDLE_SSIZE_T(opt_lg_tcache_nslots_mul,
 			    "lg_tcache_nslots_mul", -16, 16)
-			/* Ditto with values past 2048. */
+			/* Clip excessive cache-bin slot counts. */
 			CONF_HANDLE_UNSIGNED(opt_tcache_nslots_small_min,
 			    "tcache_nslots_small_min", 1, 2048, CONF_CHECK_MIN,
 			    CONF_CHECK_MAX, /* clip */ true)
 			CONF_HANDLE_UNSIGNED(opt_tcache_nslots_small_max,
-			    "tcache_nslots_small_max", 1, 2048, CONF_CHECK_MIN,
-			    CONF_CHECK_MAX, /* clip */ true)
+			    "tcache_nslots_small_max", 1, CACHE_BIN_NCACHED_MAX,
+			    CONF_CHECK_MIN, CONF_CHECK_MAX, /* clip */ true)
 			CONF_HANDLE_UNSIGNED(opt_tcache_nslots_large,
 			    "tcache_nslots_large", 1, 2048, CONF_CHECK_MIN,
 			    CONF_CHECK_MAX, /* clip */ true)

--- a/test/unit/conf_init_1.c
+++ b/test/unit/conf_init_1.c
@@ -1,6 +1,7 @@
 #include "test/jemalloc_test.h"
 
-const char *malloc_conf = "dirty_decay_ms:1234";
+const char *malloc_conf =
+    "dirty_decay_ms:1234,tcache_nslots_small_max:65535";
 
 TEST_BEGIN(test_malloc_conf_dirty_decay_ms) {
 #ifdef _WIN32
@@ -17,7 +18,24 @@ TEST_BEGIN(test_malloc_conf_dirty_decay_ms) {
 }
 TEST_END
 
+TEST_BEGIN(test_malloc_conf_tcache_nslots_small_max) {
+#ifdef _WIN32
+	test_skip("not supported on win32");
+#endif
+
+	unsigned tcache_nslots_small_max;
+	size_t sz = sizeof(tcache_nslots_small_max);
+
+	int err = mallctl("opt.tcache_nslots_small_max",
+	    &tcache_nslots_small_max, &sz, NULL, 0);
+	assert_d_eq(err, 0, "Unexpected mallctl failure");
+	expect_zu_eq(tcache_nslots_small_max, CACHE_BIN_NCACHED_MAX,
+	    "tcache_nslots_small_max should match the cache-bin limit");
+}
+TEST_END
+
 int
 main(void) {
-	return test(test_malloc_conf_dirty_decay_ms);
+	return test(test_malloc_conf_dirty_decay_ms,
+	    test_malloc_conf_tcache_nslots_small_max);
 }


### PR DESCRIPTION
The configuration parser clips tcache_nslots_small_max at 2048, even though cache bins can represent up to CACHE_BIN_NCACHED_MAX entries. The tcache code already enforces that representation limit.

Use the representation limit when parsing the option, and add a regression test for clipping to that limit. The default remains unchanged.