### PR TITLE
OS layer 4

### DIFF
--- a/include/jemalloc/internal/os.h
+++ b/include/jemalloc/internal/os.h
@@ -49,6 +49,9 @@
 /* VM */
 #include "jemalloc/internal/os/vm.h"
 
+/* Process maps (profiling) */
+#include "jemalloc/internal/os/proc_maps.h"
+
 /*
  * Error codes. util.h includes os/error.h directly (not via this umbrella)
  * since it's reachable too early in the include graph for the full os.h.

--- a/include/jemalloc/internal/os/cpu.h
+++ b/include/jemalloc/internal/os/cpu.h
@@ -5,15 +5,15 @@
 #include "jemalloc/internal/os/detect.h"
 
 /*
- * CPU interface: counts and current-CPU queries used for arena / tcache
- * sizing.
+ * CPU interface: counts, current-CPU queries, affinity, and yielding.
  * Default: posix/.  Override: Windows (GetSystemInfo /
- * GetCurrentProcessorNumber), Darwin (os_cpu_current() has no sched_getcpu()
- * to fall back on, so it reads the CPU index directly out of a CPU register
- * -- substantial enough, and different enough per-arch, to warrant its own
- * file rather than an inline #ifdef in posix/cpu.h; os_cpu_ncpus() and
- * os_cpu_count_is_deterministic() are identical to POSIX, so darwin/cpu.h
- * reuses posix/cpu.h for those instead of duplicating them).
+ * GetCurrentProcessorNumber / SwitchToThread; os_cpu_set_affinity() is an
+ * unreachable no-op), Darwin (os_cpu_current() has no sched_getcpu() to fall
+ * back on, so it reads the CPU index directly out of a CPU register;
+ * os_cpu_set_affinity() is an unreachable no-op; os_cpu_ncpus(),
+ * os_cpu_count_is_deterministic(), and os_cpu_yield() are identical to
+ * posix/'s, duplicated rather than shared via #include, matching every
+ * other os/<os>/<module>.h backend).
  */
 
 /* Functions required for implementation in each backend. */
@@ -26,6 +26,8 @@ JEMALLOC_ALWAYS_INLINE int os_cpu_current(void);
  * compiled out on both), so their backends are no-ops.
  */
 JEMALLOC_ALWAYS_INLINE bool os_cpu_set_affinity(int cpu);
+/* Yield the current thread's remaining timeslice to the scheduler. */
+JEMALLOC_ALWAYS_INLINE void os_cpu_yield(void);
 
 #if defined(_WIN32)
 #  include "jemalloc/internal/os/windows/cpu.h"

--- a/include/jemalloc/internal/os/cpu.h
+++ b/include/jemalloc/internal/os/cpu.h
@@ -20,6 +20,12 @@
 JEMALLOC_ALWAYS_INLINE unsigned os_cpu_ncpus(void);
 JEMALLOC_ALWAYS_INLINE bool os_cpu_count_is_deterministic(void);
 JEMALLOC_ALWAYS_INLINE int os_cpu_current(void);
+/*
+ * Pin the calling thread to cpu, returning true on failure. Windows and
+ * Darwin never actually run this (background_thread.c, its only caller, is
+ * compiled out on both), so their backends are no-ops.
+ */
+JEMALLOC_ALWAYS_INLINE bool os_cpu_set_affinity(int cpu);
 
 #if defined(_WIN32)
 #  include "jemalloc/internal/os/windows/cpu.h"

--- a/include/jemalloc/internal/os/darwin/cpu.h
+++ b/include/jemalloc/internal/os/darwin/cpu.h
@@ -2,13 +2,15 @@
 #define JEMALLOC_INTERNAL_OS_DARWIN_CPU_H
 
 /*
- * Darwin CPU backend. os_cpu_ncpus()/os_cpu_count_is_deterministic() are
- * identical to posix/cpu.h's (macOS has no CPU_COUNT/sched_getaffinity()
- * either, so both already fall through to the same sysconf() path) --
+ * Darwin CPU backend. os_cpu_ncpus(), os_cpu_count_is_deterministic(), and
+ * os_cpu_yield() are identical to posix/cpu.h's (macOS has no
+ * CPU_COUNT/sched_getaffinity() either, so the first two already fall
+ * through to the same sysconf() path, and sched_yield() is standard POSIX),
  * duplicated here rather than shared via #include, matching every other
  * os/<os>/<module>.h backend (each is self-contained; see os/darwin/mutex.h).
  * os_cpu_current() is genuinely different: no sched_getcpu() on macOS, so it
  * reads the CPU index directly out of a CPU register instead.
+ * os_cpu_set_affinity() is an unreachable no-op (see os/cpu.h).
  */
 #include "jemalloc/internal/jemalloc_preamble.h"
 
@@ -89,6 +91,11 @@ JEMALLOC_ALWAYS_INLINE bool
 os_cpu_set_affinity(int cpu) {
 	(void)cpu;
 	return false;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_cpu_yield(void) {
+	sched_yield();
 }
 
 #endif /* JEMALLOC_INTERNAL_OS_DARWIN_CPU_H */

--- a/include/jemalloc/internal/os/darwin/cpu.h
+++ b/include/jemalloc/internal/os/darwin/cpu.h
@@ -85,4 +85,10 @@ os_cpu_current(void) {
 #endif
 }
 
+JEMALLOC_ALWAYS_INLINE bool
+os_cpu_set_affinity(int cpu) {
+	(void)cpu;
+	return false;
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_DARWIN_CPU_H */

--- a/include/jemalloc/internal/os/darwin/proc_maps.h
+++ b/include/jemalloc/internal/os/darwin/proc_maps.h
@@ -22,7 +22,7 @@ typedef struct segment_command os_segment_command_t;
 #	define OS_LC_SEGMENT_VALUE LC_SEGMENT
 #endif
 
-JEMALLOC_ALWAYS_INLINE long
+JEMALLOC_ALWAYS_INLINE uint64_t
 os_prof_pid_namespace(void) {
 	/* Not supported on Darwin. */
 	return 0;

--- a/include/jemalloc/internal/os/darwin/proc_maps.h
+++ b/include/jemalloc/internal/os/darwin/proc_maps.h
@@ -1,0 +1,87 @@
+#ifndef JEMALLOC_INTERNAL_OS_DARWIN_PROC_MAPS_H
+#define JEMALLOC_INTERNAL_OS_DARWIN_PROC_MAPS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+
+#include <mach-o/dyld.h>
+
+#define JEMALLOC_OS_PROF_NO_OPEN_MAPS
+
+#ifdef __LP64__
+typedef struct mach_header_64     os_mach_header_t;
+typedef struct segment_command_64 os_segment_command_t;
+#	define OS_MH_MAGIC_VALUE MH_MAGIC_64
+#	define OS_MH_CIGAM_VALUE MH_CIGAM_64
+#	define OS_LC_SEGMENT_VALUE LC_SEGMENT_64
+#else
+typedef struct mach_header     os_mach_header_t;
+typedef struct segment_command os_segment_command_t;
+#	define OS_MH_MAGIC_VALUE MH_MAGIC
+#	define OS_MH_CIGAM_VALUE MH_CIGAM
+#	define OS_LC_SEGMENT_VALUE LC_SEGMENT
+#endif
+
+JEMALLOC_ALWAYS_INLINE long
+os_prof_pid_namespace(void) {
+	/* Not supported on Darwin. */
+	return 0;
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_prof_open_maps(void) {
+	/* Darwin dumps dyld images instead of reading an fd-based maps file. */
+	return -1;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_prof_dump_dyld_image_vmaddr(buf_writer_t *buf_writer, uint32_t image_index) {
+	const os_mach_header_t *header = (const os_mach_header_t *)
+	    _dyld_get_image_header(image_index);
+	if (header == NULL
+	    || (header->magic != OS_MH_MAGIC_VALUE
+	        && header->magic != OS_MH_CIGAM_VALUE)) {
+		/* Invalid header. */
+		return;
+	}
+
+	intptr_t             slide = _dyld_get_image_vmaddr_slide(image_index);
+	const char          *name = _dyld_get_image_name(image_index);
+	struct load_command *load_cmd = (struct load_command *)((char *)header
+	    + sizeof(os_mach_header_t));
+	for (uint32_t i = 0; load_cmd && (i < header->ncmds); i++) {
+		if (load_cmd->cmd == OS_LC_SEGMENT_VALUE) {
+			const os_segment_command_t *segment_cmd =
+			    (const os_segment_command_t *)load_cmd;
+			if (!strcmp(segment_cmd->segname, "__TEXT")) {
+				char buffer[PATH_MAX + 1];
+				malloc_snprintf(buffer, sizeof(buffer),
+				    "%016llx-%016llx: %s\n",
+				    segment_cmd->vmaddr + slide,
+				    segment_cmd->vmaddr + slide
+				        + segment_cmd->vmsize,
+				    name);
+				buf_writer_cb(buf_writer, buffer);
+				return;
+			}
+		}
+		load_cmd = (struct load_command *)((char *)load_cmd
+		    + load_cmd->cmdsize);
+	}
+}
+
+/*
+ * No proc map file to read on Darwin, so os_prof_dump_maps() walks
+ * dyld-loaded images for backtrace instead.  open_maps is never called here.
+ */
+JEMALLOC_ALWAYS_INLINE void
+os_prof_dump_maps(buf_writer_t *buf_writer, int (*open_maps)(void)) {
+	(void)open_maps;
+	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
+	uint32_t image_count = _dyld_image_count();
+	for (uint32_t i = 0; i < image_count; i++) {
+		os_prof_dump_dyld_image_vmaddr(buf_writer, i);
+	}
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_DARWIN_PROC_MAPS_H */

--- a/include/jemalloc/internal/os/file.h
+++ b/include/jemalloc/internal/os/file.h
@@ -24,6 +24,9 @@ JEMALLOC_ALWAYS_INLINE ssize_t os_file_read_once(int fd, void *buf,
 JEMALLOC_ALWAYS_INLINE ssize_t os_file_write(int fd, const void *buf,
     size_t bytes);
 JEMALLOC_ALWAYS_INLINE ssize_t os_file_read(int fd, void *buf, size_t bytes);
+/* Read the target of the symlink at path into buf. */
+JEMALLOC_ALWAYS_INLINE ssize_t os_readlink(const char *path, char *buf,
+    size_t bufsize);
 
 #if defined(_WIN32)
 #  include "jemalloc/internal/os/windows/file.h"

--- a/include/jemalloc/internal/os/freebsd/proc_maps.h
+++ b/include/jemalloc/internal/os/freebsd/proc_maps.h
@@ -1,0 +1,65 @@
+#ifndef JEMALLOC_INTERNAL_OS_FREEBSD_PROC_MAPS_H
+#define JEMALLOC_INTERNAL_OS_FREEBSD_PROC_MAPS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+
+JEMALLOC_ALWAYS_INLINE long
+os_prof_pid_namespace(void) {
+	long ret = 0;
+	char buf[PATH_MAX];
+	ssize_t linklen =
+#ifndef JEMALLOC_READLINKAT
+	    readlink("/proc/curproc/ns/pid", buf, PATH_MAX)
+#else
+	    readlinkat(AT_FDCWD, "/proc/curproc/ns/pid", buf, PATH_MAX)
+#endif
+	    ;
+
+	/* namespace string is expected to be like pid:[4026531836] */
+	if (linklen > 0) {
+		/* Trim the trailing "]" */
+		buf[linklen - 1] = '\0';
+		char *index = strtok(buf, "pid:[");
+		ret = atol(index);
+	}
+
+	return ret;
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_prof_open_maps(void) {
+	int mfd;
+
+#if defined(O_CLOEXEC)
+	mfd = open("/proc/curproc/map", O_RDONLY | O_CLOEXEC);
+#else
+	mfd = open("/proc/curproc/map", O_RDONLY);
+	if (mfd != -1) {
+		fcntl(mfd, F_SETFD, fcntl(mfd, F_GETFD) | FD_CLOEXEC);
+	}
+#endif
+
+	return mfd;
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_prof_dump_read_maps_cb(void *read_cbopaque, void *buf, size_t limit) {
+	int mfd = *(int *)read_cbopaque;
+	assert(mfd != -1);
+	return malloc_read_fd(mfd, buf, limit);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_prof_dump_maps(buf_writer_t *buf_writer, int (*open_maps)(void)) {
+	int mfd = open_maps();
+	if (mfd == -1) {
+		return;
+	}
+
+	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
+	buf_writer_pipe(buf_writer, os_prof_dump_read_maps_cb, &mfd);
+	close(mfd);
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_FREEBSD_PROC_MAPS_H */

--- a/include/jemalloc/internal/os/freebsd/proc_maps.h
+++ b/include/jemalloc/internal/os/freebsd/proc_maps.h
@@ -3,18 +3,13 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os/file.h"
 
 JEMALLOC_ALWAYS_INLINE long
 os_prof_pid_namespace(void) {
 	long ret = 0;
 	char buf[PATH_MAX];
-	ssize_t linklen =
-#ifndef JEMALLOC_READLINKAT
-	    readlink("/proc/curproc/ns/pid", buf, PATH_MAX)
-#else
-	    readlinkat(AT_FDCWD, "/proc/curproc/ns/pid", buf, PATH_MAX)
-#endif
-	    ;
+	ssize_t linklen = os_readlink("/proc/curproc/ns/pid", buf, PATH_MAX);
 
 	/* namespace string is expected to be like pid:[4026531836] */
 	if (linklen > 0) {

--- a/include/jemalloc/internal/os/freebsd/proc_maps.h
+++ b/include/jemalloc/internal/os/freebsd/proc_maps.h
@@ -5,21 +5,11 @@
 #include "jemalloc/internal/malloc_io.h"
 #include "jemalloc/internal/os/file.h"
 
-JEMALLOC_ALWAYS_INLINE long
+JEMALLOC_ALWAYS_INLINE uint64_t
 os_prof_pid_namespace(void) {
-	long ret = 0;
-	char buf[PATH_MAX];
-	ssize_t linklen = os_readlink("/proc/curproc/ns/pid", buf, PATH_MAX);
-
-	/* namespace string is expected to be like pid:[4026531836] */
-	if (linklen > 0) {
-		/* Trim the trailing "]" */
-		buf[linklen - 1] = '\0';
-		char *index = strtok(buf, "pid:[");
-		ret = atol(index);
-	}
-
-	return ret;
+	char    buf[PATH_MAX];
+	ssize_t linklen = os_readlink("/proc/curproc/ns/pid", buf, sizeof(buf));
+	return os_prof_parse_pid_namespace(buf, sizeof(buf), linklen);
 }
 
 JEMALLOC_ALWAYS_INLINE int

--- a/include/jemalloc/internal/os/posix/cpu.h
+++ b/include/jemalloc/internal/os/posix/cpu.h
@@ -84,4 +84,43 @@ os_cpu_current(void) {
 #endif
 }
 
+JEMALLOC_ALWAYS_INLINE bool
+os_cpu_set_affinity(int cpu) {
+#if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)                                  \
+    || defined(JEMALLOC_HAVE_PTHREAD_SETAFFINITY_NP)
+#	if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)
+	cpu_set_t cpuset;
+#	else
+#		ifndef __NetBSD__
+	cpuset_t cpuset;
+#		else
+	cpuset_t *cpuset;
+#		endif
+#	endif
+
+#	ifndef __NetBSD__
+	CPU_ZERO(&cpuset);
+	CPU_SET(cpu, &cpuset);
+#	else
+	cpuset = cpuset_create();
+#	endif
+
+#	if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)
+	return (sched_setaffinity(0, sizeof(cpu_set_t), &cpuset) != 0);
+#	else
+#		ifndef __NetBSD__
+	int ret = pthread_setaffinity_np(
+	    pthread_self(), sizeof(cpuset_t), &cpuset);
+#		else
+	int ret = pthread_setaffinity_np(
+	    pthread_self(), cpuset_size(cpuset), cpuset);
+	cpuset_destroy(cpuset);
+#		endif
+	return ret != 0;
+#	endif
+#else
+	return false;
+#endif
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_POSIX_CPU_H */

--- a/include/jemalloc/internal/os/posix/cpu.h
+++ b/include/jemalloc/internal/os/posix/cpu.h
@@ -123,4 +123,9 @@ os_cpu_set_affinity(int cpu) {
 #endif
 }
 
+JEMALLOC_ALWAYS_INLINE void
+os_cpu_yield(void) {
+	sched_yield();
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_POSIX_CPU_H */

--- a/include/jemalloc/internal/os/posix/file.h
+++ b/include/jemalloc/internal/os/posix/file.h
@@ -73,4 +73,13 @@ os_file_read(int fd, void *buf, size_t bytes) {
 	return bytes_read;
 }
 
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_readlink(const char *path, char *buf, size_t bufsize) {
+#ifndef JEMALLOC_READLINKAT
+	return readlink(path, buf, bufsize);
+#else
+	return readlinkat(AT_FDCWD, path, buf, bufsize);
+#endif
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_POSIX_FILE_H */

--- a/include/jemalloc/internal/os/posix/proc_maps.h
+++ b/include/jemalloc/internal/os/posix/proc_maps.h
@@ -6,21 +6,11 @@
 #include "jemalloc/internal/os/file.h"
 #include "jemalloc/internal/os/process.h"
 
-JEMALLOC_ALWAYS_INLINE long
+JEMALLOC_ALWAYS_INLINE uint64_t
 os_prof_pid_namespace(void) {
-	long ret = 0;
-	char buf[PATH_MAX];
-	ssize_t linklen = os_readlink("/proc/self/ns/pid", buf, PATH_MAX);
-
-	/* namespace string is expected to be like pid:[4026531836] */
-	if (linklen > 0) {
-		/* Trim the trailing "]" */
-		buf[linklen - 1] = '\0';
-		char *index = strtok(buf, "pid:[");
-		ret = atol(index);
-	}
-
-	return ret;
+	char    buf[PATH_MAX];
+	ssize_t linklen = os_readlink("/proc/self/ns/pid", buf, sizeof(buf));
+	return os_prof_parse_pid_namespace(buf, sizeof(buf), linklen);
 }
 
 JEMALLOC_ALWAYS_INLINE int

--- a/include/jemalloc/internal/os/posix/proc_maps.h
+++ b/include/jemalloc/internal/os/posix/proc_maps.h
@@ -3,19 +3,14 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os/file.h"
 #include "jemalloc/internal/os/process.h"
 
 JEMALLOC_ALWAYS_INLINE long
 os_prof_pid_namespace(void) {
 	long ret = 0;
 	char buf[PATH_MAX];
-	ssize_t linklen =
-#ifndef JEMALLOC_READLINKAT
-	    readlink("/proc/self/ns/pid", buf, PATH_MAX)
-#else
-	    readlinkat(AT_FDCWD, "/proc/self/ns/pid", buf, PATH_MAX)
-#endif
-	    ;
+	ssize_t linklen = os_readlink("/proc/self/ns/pid", buf, PATH_MAX);
 
 	/* namespace string is expected to be like pid:[4026531836] */
 	if (linklen > 0) {

--- a/include/jemalloc/internal/os/posix/proc_maps.h
+++ b/include/jemalloc/internal/os/posix/proc_maps.h
@@ -1,0 +1,82 @@
+#ifndef JEMALLOC_INTERNAL_OS_POSIX_PROC_MAPS_H
+#define JEMALLOC_INTERNAL_OS_POSIX_PROC_MAPS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+#include "jemalloc/internal/os/process.h"
+
+JEMALLOC_ALWAYS_INLINE long
+os_prof_pid_namespace(void) {
+	long ret = 0;
+	char buf[PATH_MAX];
+	ssize_t linklen =
+#ifndef JEMALLOC_READLINKAT
+	    readlink("/proc/self/ns/pid", buf, PATH_MAX)
+#else
+	    readlinkat(AT_FDCWD, "/proc/self/ns/pid", buf, PATH_MAX)
+#endif
+	    ;
+
+	/* namespace string is expected to be like pid:[4026531836] */
+	if (linklen > 0) {
+		/* Trim the trailing "]" */
+		buf[linklen - 1] = '\0';
+		char *index = strtok(buf, "pid:[");
+		ret = atol(index);
+	}
+
+	return ret;
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_prof_open_ro_cloexec(const char *filename) {
+	int mfd;
+
+#if defined(O_CLOEXEC)
+	mfd = open(filename, O_RDONLY | O_CLOEXEC);
+#else
+	mfd = open(filename, O_RDONLY);
+	if (mfd != -1) {
+		fcntl(mfd, F_SETFD, fcntl(mfd, F_GETFD) | FD_CLOEXEC);
+	}
+#endif
+
+	return mfd;
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_prof_open_maps(void) {
+	int  pid = os_process_id();
+	char filename[PATH_MAX + 1];
+
+	malloc_snprintf(filename, sizeof(filename), "/proc/%d/task/%d/maps",
+	    pid, pid);
+	int mfd = os_prof_open_ro_cloexec(filename);
+	if (mfd == -1) {
+		malloc_snprintf(filename, sizeof(filename), "/proc/%d/maps",
+		    pid);
+		mfd = os_prof_open_ro_cloexec(filename);
+	}
+	return mfd;
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_prof_dump_read_maps_cb(void *read_cbopaque, void *buf, size_t limit) {
+	int mfd = *(int *)read_cbopaque;
+	assert(mfd != -1);
+	return malloc_read_fd(mfd, buf, limit);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_prof_dump_maps(buf_writer_t *buf_writer, int (*open_maps)(void)) {
+	int mfd = open_maps();
+	if (mfd == -1) {
+		return;
+	}
+
+	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
+	buf_writer_pipe(buf_writer, os_prof_dump_read_maps_cb, &mfd);
+	close(mfd);
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_POSIX_PROC_MAPS_H */

--- a/include/jemalloc/internal/os/proc_maps.h
+++ b/include/jemalloc/internal/os/proc_maps.h
@@ -1,0 +1,40 @@
+#ifndef JEMALLOC_INTERNAL_OS_PROC_MAPS_H
+#define JEMALLOC_INTERNAL_OS_PROC_MAPS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/buf_writer.h"
+#include "jemalloc/internal/os/detect.h"
+
+/*
+ * Process-maps interface: pid-namespace lookup and MAPPED_LIBRARIES dumping
+ * for profiling (used in src/prof_sys.c).
+ * Default: posix/ (Linux-style /proc). Override: FreeBSD/DragonFly
+ * (/proc/curproc/... paths), Darwin (no /proc; walks dyld images instead),
+ * Windows (neither concept is implemented).
+ */
+
+/* Functions required for implementation in each backend. */
+JEMALLOC_ALWAYS_INLINE long os_prof_pid_namespace(void);
+JEMALLOC_ALWAYS_INLINE int os_prof_open_maps(void);
+/*
+ * Takes the caller's current prof_dump_open_maps hook as a parameter instead
+ * of reaching for prof_sys.h's JET_MUTABLE global directly: prof_sys.h pulls
+ * in prof.h -> mutex.h -> os.h, which would re-enter this file mid-expansion.
+ * Darwin ignores the parameter (no fd-based maps to open there).
+ */
+JEMALLOC_ALWAYS_INLINE void os_prof_dump_maps(
+    buf_writer_t *buf_writer, int (*open_maps)(void));
+
+#if defined(_WIN32)
+#  include "jemalloc/internal/os/windows/proc_maps.h"
+#elif defined(__APPLE__)
+#  include "jemalloc/internal/os/darwin/proc_maps.h"
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#  include "jemalloc/internal/os/freebsd/proc_maps.h"
+#elif defined(JEMALLOC_OS_POSIX)
+#  include "jemalloc/internal/os/posix/proc_maps.h"
+#else
+#  error "OS layer: no proc_maps backend for this platform; add os/<os>/proc_maps.h"
+#endif
+
+#endif /* JEMALLOC_INTERNAL_OS_PROC_MAPS_H */

--- a/include/jemalloc/internal/os/proc_maps.h
+++ b/include/jemalloc/internal/os/proc_maps.h
@@ -13,8 +13,42 @@
  * Windows (neither concept is implemented).
  */
 
+/*
+ * Parse a procfs pid-namespace symlink target of the form "pid:[<id>]".
+ * This helper function is currently used only by posix and FreeBSD/DragonFly
+ * backends.
+ */
+JEMALLOC_ALWAYS_INLINE uint64_t
+os_prof_parse_pid_namespace(const char *buf, size_t buf_size, ssize_t linklen) {
+	static const char prefix[] = "pid:[";
+	const size_t      prefix_len = sizeof(prefix) - 1;
+
+	if (linklen <= 0 || (size_t)linklen >= buf_size) {
+		return 0;
+	}
+	size_t len = (size_t)linklen;
+	if (len <= prefix_len + 1 || buf[len - 1] != ']'
+	    || memcmp(buf, prefix, prefix_len) != 0) {
+		return 0;
+	}
+
+	uint64_t ns = 0;
+	for (size_t i = prefix_len; i < len - 1; i++) {
+		unsigned char c = (unsigned char)buf[i];
+		if (c < '0' || c > '9') {
+			return 0;
+		}
+		uint64_t digit = (uint64_t)(c - '0');
+		if (ns > (UINT64_MAX - digit) / 10) {
+			return 0;
+		}
+		ns = ns * 10 + digit;
+	}
+	return ns;
+}
+
 /* Functions required for implementation in each backend. */
-JEMALLOC_ALWAYS_INLINE long os_prof_pid_namespace(void);
+JEMALLOC_ALWAYS_INLINE uint64_t os_prof_pid_namespace(void);
 JEMALLOC_ALWAYS_INLINE int os_prof_open_maps(void);
 /*
  * Takes the caller's current prof_dump_open_maps hook as a parameter instead

--- a/include/jemalloc/internal/os/windows/cpu.h
+++ b/include/jemalloc/internal/os/windows/cpu.h
@@ -20,4 +20,10 @@ os_cpu_current(void) {
 	return (int)GetCurrentProcessorNumber();
 }
 
+JEMALLOC_ALWAYS_INLINE bool
+os_cpu_set_affinity(int cpu) {
+	(void)cpu;
+	return false;
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_WINDOWS_CPU_H */

--- a/include/jemalloc/internal/os/windows/cpu.h
+++ b/include/jemalloc/internal/os/windows/cpu.h
@@ -26,4 +26,9 @@ os_cpu_set_affinity(int cpu) {
 	return false;
 }
 
+JEMALLOC_ALWAYS_INLINE void
+os_cpu_yield(void) {
+	SwitchToThread();
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_WINDOWS_CPU_H */

--- a/include/jemalloc/internal/os/windows/file.h
+++ b/include/jemalloc/internal/os/windows/file.h
@@ -49,4 +49,13 @@ os_file_read(int fd, void *buf, size_t bytes) {
 	return bytes_read;
 }
 
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_readlink(const char *path, char *buf, size_t bufsize) {
+	/* No symlink concept used here on Windows. */
+	(void)path;
+	(void)buf;
+	(void)bufsize;
+	return -1;
+}
+
 #endif /* JEMALLOC_INTERNAL_OS_WINDOWS_FILE_H */

--- a/include/jemalloc/internal/os/windows/proc_maps.h
+++ b/include/jemalloc/internal/os/windows/proc_maps.h
@@ -4,7 +4,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/malloc_io.h"
 
-JEMALLOC_ALWAYS_INLINE long
+JEMALLOC_ALWAYS_INLINE uint64_t
 os_prof_pid_namespace(void) {
 	/* Not supported on Windows. */
 	return 0;

--- a/include/jemalloc/internal/os/windows/proc_maps.h
+++ b/include/jemalloc/internal/os/windows/proc_maps.h
@@ -1,0 +1,42 @@
+#ifndef JEMALLOC_INTERNAL_OS_WINDOWS_PROC_MAPS_H
+#define JEMALLOC_INTERNAL_OS_WINDOWS_PROC_MAPS_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/malloc_io.h"
+
+JEMALLOC_ALWAYS_INLINE long
+os_prof_pid_namespace(void) {
+	/* Not supported on Windows. */
+	return 0;
+}
+
+JEMALLOC_ALWAYS_INLINE int
+os_prof_open_maps(void) {
+	/* Not implemented on Windows. */
+	return -1;
+}
+
+JEMALLOC_ALWAYS_INLINE ssize_t
+os_prof_dump_read_maps_cb(void *read_cbopaque, void *buf, size_t limit) {
+	int mfd = *(int *)read_cbopaque;
+	assert(mfd != -1);
+	return malloc_read_fd(mfd, buf, limit);
+}
+
+JEMALLOC_ALWAYS_INLINE void
+os_prof_dump_maps(buf_writer_t *buf_writer, int (*open_maps)(void)) {
+	/*
+	 * With the default Windows hook, the rest of this function is
+	 * unreachable.
+	 */
+	int mfd = open_maps();
+	if (mfd == -1) {
+		return;
+	}
+
+	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
+	buf_writer_pipe(buf_writer, os_prof_dump_read_maps_cb, &mfd);
+	close(mfd);
+}
+
+#endif /* JEMALLOC_INTERNAL_OS_WINDOWS_PROC_MAPS_H */

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -61,12 +61,12 @@ extern size_t os_page;
  * re-commit, but doing so is racy, and if re-commit fails it's a pain to
  * propagate the "poisoned" memory state.  Since we typically decommit as the
  * next step after purging on Windows anyway, there's no point in adding such
- * complexity.
+ * complexity.  Neither condition can be true on Windows, so no Windows
+ * detection is needed here.
  */
-#if !defined(_WIN32)                                                           \
-    && ((defined(JEMALLOC_PURGE_MADVISE_DONTNEED)                              \
-            && defined(JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS))                 \
-        || defined(JEMALLOC_MAPS_COALESCE))
+#if (defined(JEMALLOC_PURGE_MADVISE_DONTNEED)                                  \
+        && defined(JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS))                     \
+    || defined(JEMALLOC_MAPS_COALESCE)
 #	define PAGES_CAN_PURGE_FORCED
 #endif
 

--- a/include/jemalloc/internal/spin.h
+++ b/include/jemalloc/internal/spin.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_SPIN_H
 
 #include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/os.h"
 
 #define SPIN_INITIALIZER                                                       \
 	{ 0U }
@@ -30,11 +31,7 @@ spin_adaptive(spin_t *spin) {
 		}
 		spin->iteration++;
 	} else {
-#ifdef _WIN32
-		SwitchToThread();
-#else
-		sched_yield();
-#endif
+		os_cpu_yield();
 	}
 }
 

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -199,45 +199,6 @@ background_thread_info_init(tsdn_t *tsdn, background_thread_info_t *info) {
 	}
 }
 
-static inline bool
-set_current_thread_affinity(int cpu) {
-#	if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)                           \
-	    || defined(JEMALLOC_HAVE_PTHREAD_SETAFFINITY_NP)
-#		if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)
-	cpu_set_t cpuset;
-#		else
-#			ifndef __NetBSD__
-	cpuset_t cpuset;
-#			else
-	cpuset_t *cpuset;
-#			endif
-#		endif
-
-#		ifndef __NetBSD__
-	CPU_ZERO(&cpuset);
-	CPU_SET(cpu, &cpuset);
-#		else
-	cpuset = cpuset_create();
-#		endif
-
-#		if defined(JEMALLOC_HAVE_SCHED_SETAFFINITY)
-	return (sched_setaffinity(0, sizeof(cpu_set_t), &cpuset) != 0);
-#		else
-#			ifndef __NetBSD__
-	int ret = pthread_setaffinity_np(
-	    pthread_self(), sizeof(cpuset_t), &cpuset);
-#			else
-	int ret = pthread_setaffinity_np(
-	    pthread_self(), cpuset_size(cpuset), cpuset);
-	cpuset_destroy(cpuset);
-#			endif
-	return ret != 0;
-#		endif
-#	else
-	return false;
-#	endif
-}
-
 #	define BILLION UINT64_C(1000000000)
 /* Minimal sleep interval 100 ms. */
 #	define BACKGROUND_THREAD_MIN_INTERVAL_NS (BILLION / 10)
@@ -601,7 +562,7 @@ background_thread_entry(void *ind_arg) {
 	pthread_set_name_np(pthread_self(), "jemalloc_bg_thd");
 #	endif
 	if (opt_percpu_arena != percpu_arena_disabled) {
-		set_current_thread_affinity((int)thread_ind);
+		os_cpu_set_affinity((int)thread_ind);
 	}
 	/*
 	 * Start periodic background work.  We use internal tsd which avoids

--- a/src/conf.c
+++ b/src/conf.c
@@ -330,34 +330,26 @@ obtain_malloc_conf(unsigned which_source, char readlink_buf[PATH_MAX + 1]) {
 		ret = NULL;
 		break;
 #else
-		ssize_t linklen = 0;
-#	ifndef _WIN32
 		int         saved_errno = errno;
 		const char *linkname =
-#		ifdef JEMALLOC_PREFIX
+#	ifdef JEMALLOC_PREFIX
 		    "/etc/" JEMALLOC_PREFIX "malloc.conf"
-#		else
+#	else
 		    "/etc/malloc.conf"
-#		endif
+#	endif
 		    ;
 
 		/*
 		 * Try to use the contents of the "/etc/malloc.conf" symbolic
 		 * link's name.
 		 */
-#		ifndef JEMALLOC_READLINKAT
-		linklen = readlink(linkname, readlink_buf, PATH_MAX);
-#		else
-		linklen = readlinkat(
-		    AT_FDCWD, linkname, readlink_buf, PATH_MAX);
-#		endif
+		ssize_t linklen = os_readlink(linkname, readlink_buf, PATH_MAX);
 		if (linklen == -1) {
 			/* No configuration specified. */
 			linklen = 0;
 			/* Restore errno. */
 			set_errno(saved_errno);
 		}
-#	endif
 		readlink_buf[linklen] = '\0';
 		ret = readlink_buf;
 		break;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -25,10 +25,12 @@ static malloc_mutex_t *postponed_mutexes = NULL;
 /******************************************************************************/
 /*
  * We intercept pthread_create() calls in order to toggle isthreaded if the
- * process goes multi-threaded.
+ * process goes multi-threaded.  Note JEMALLOC_LAZY_LOCK is already
+ * force-disabled in configure.ac for all Windows so no extra _WIN32 check
+ * is needed here.
  */
 
-#if defined(JEMALLOC_LAZY_LOCK) && !defined(_WIN32)
+#ifdef JEMALLOC_LAZY_LOCK
 JEMALLOC_EXPORT int
 pthread_create(pthread_t *__restrict thread,
     const pthread_attr_t *__restrict attr, void *(*start_routine)(void *),

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -488,41 +488,6 @@ prof_getpid(void) {
 	return os_process_id();
 }
 
-static long
-prof_get_pid_namespace(void) {
-	long ret = 0;
-
-#if defined(_WIN32) || defined(__APPLE__)
-	// Not supported, do nothing.
-#else
-	char        buf[PATH_MAX];
-	const char *linkname =
-#	if defined(__FreeBSD__) || defined(__DragonFly__)
-	    "/proc/curproc/ns/pid"
-#	else
-	    "/proc/self/ns/pid"
-#	endif
-	    ;
-	ssize_t linklen =
-#	ifndef JEMALLOC_READLINKAT
-	    readlink(linkname, buf, PATH_MAX)
-#	else
-	    readlinkat(AT_FDCWD, linkname, buf, PATH_MAX)
-#	endif
-	    ;
-
-	// namespace string is expected to be like pid:[4026531836]
-	if (linklen > 0) {
-		// Trim the trailing "]"
-		buf[linklen - 1] = '\0';
-		char *index = strtok(buf, "pid:[");
-		ret = atol(index);
-	}
-#endif
-
-	return ret;
-}
-
 /*
  * This buffer is rather large for stack allocation, so use a single buffer for
  * all profile dumps; protected by prof_dump_mtx.
@@ -609,142 +574,21 @@ prof_dump_close(prof_dump_arg_t *arg) {
 	}
 }
 
-#ifdef __APPLE__
-#	include <mach-o/dyld.h>
-
-#	ifdef __LP64__
-typedef struct mach_header_64     mach_header_t;
-typedef struct segment_command_64 segment_command_t;
-#		define MH_MAGIC_VALUE MH_MAGIC_64
-#		define MH_CIGAM_VALUE MH_CIGAM_64
-#		define LC_SEGMENT_VALUE LC_SEGMENT_64
-#	else
-typedef struct mach_header     mach_header_t;
-typedef struct segment_command segment_command_t;
-#		define MH_MAGIC_VALUE MH_MAGIC
-#		define MH_CIGAM_VALUE MH_CIGAM
-#		define LC_SEGMENT_VALUE LC_SEGMENT
-#	endif
-
-static void
-prof_dump_dyld_image_vmaddr(buf_writer_t *buf_writer, uint32_t image_index) {
-	const mach_header_t *header = (const mach_header_t *)
-	    _dyld_get_image_header(image_index);
-	if (header == NULL
-	    || (header->magic != MH_MAGIC_VALUE
-	        && header->magic != MH_CIGAM_VALUE)) {
-		// Invalid header
-		return;
-	}
-
-	intptr_t             slide = _dyld_get_image_vmaddr_slide(image_index);
-	const char          *name = _dyld_get_image_name(image_index);
-	struct load_command *load_cmd = (struct load_command *)((char *)header
-	    + sizeof(mach_header_t));
-	for (uint32_t i = 0; load_cmd && (i < header->ncmds); i++) {
-		if (load_cmd->cmd == LC_SEGMENT_VALUE) {
-			const segment_command_t *segment_cmd =
-			    (const segment_command_t *)load_cmd;
-			if (!strcmp(segment_cmd->segname, "__TEXT")) {
-				char buffer[PATH_MAX + 1];
-				malloc_snprintf(buffer, sizeof(buffer),
-				    "%016llx-%016llx: %s\n",
-				    segment_cmd->vmaddr + slide,
-				    segment_cmd->vmaddr + slide
-				        + segment_cmd->vmsize,
-				    name);
-				buf_writer_cb(buf_writer, buffer);
-				return;
-			}
-		}
-		load_cmd = (struct load_command *)((char *)load_cmd
-		    + load_cmd->cmdsize);
-	}
-}
-
-static void
-prof_dump_dyld_maps(buf_writer_t *buf_writer) {
-	uint32_t image_count = _dyld_image_count();
-	for (uint32_t i = 0; i < image_count; i++) {
-		prof_dump_dyld_image_vmaddr(buf_writer, i);
-	}
-}
-
+#ifdef JEMALLOC_OS_PROF_NO_OPEN_MAPS
+/*
+ * No fd-based maps file to read on this platform (os_prof_dump_maps() below
+ * doesn't consult this hook at all); left NULL so tests that mock it know to
+ * skip themselves.
+ */
 prof_dump_open_maps_t *JET_MUTABLE prof_dump_open_maps = NULL;
+#else
+prof_dump_open_maps_t *JET_MUTABLE prof_dump_open_maps = os_prof_open_maps;
+#endif
 
 static void
 prof_dump_maps(buf_writer_t *buf_writer) {
-	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
-	/* No proc map file to read on MacOS, dump dyld maps for backtrace. */
-	prof_dump_dyld_maps(buf_writer);
+	os_prof_dump_maps(buf_writer, prof_dump_open_maps);
 }
-#else /* !__APPLE__ */
-#	ifndef _WIN32
-JEMALLOC_FORMAT_PRINTF(1, 2)
-static int
-prof_open_maps_internal(const char *format, ...) {
-	int     mfd;
-	va_list ap;
-	char    filename[PATH_MAX + 1];
-
-	va_start(ap, format);
-	malloc_vsnprintf(filename, sizeof(filename), format, ap);
-	va_end(ap);
-
-#		if defined(O_CLOEXEC)
-	mfd = open(filename, O_RDONLY | O_CLOEXEC);
-#		else
-	mfd = open(filename, O_RDONLY);
-	if (mfd != -1) {
-		fcntl(mfd, F_SETFD, fcntl(mfd, F_GETFD) | FD_CLOEXEC);
-	}
-#		endif
-
-	return mfd;
-}
-#	endif
-
-static int
-prof_dump_open_maps_impl(void) {
-	int mfd;
-
-	cassert(config_prof);
-#	if defined(__FreeBSD__) || defined(__DragonFly__)
-	mfd = prof_open_maps_internal("/proc/curproc/map");
-#	elif defined(_WIN32)
-	mfd = -1; // Not implemented
-#	else
-	int pid = prof_getpid();
-
-	mfd = prof_open_maps_internal("/proc/%d/task/%d/maps", pid, pid);
-	if (mfd == -1) {
-		mfd = prof_open_maps_internal("/proc/%d/maps", pid);
-	}
-#	endif
-	return mfd;
-}
-prof_dump_open_maps_t *JET_MUTABLE prof_dump_open_maps =
-    prof_dump_open_maps_impl;
-
-static ssize_t
-prof_dump_read_maps_cb(void *read_cbopaque, void *buf, size_t limit) {
-	int mfd = *(int *)read_cbopaque;
-	assert(mfd != -1);
-	return malloc_read_fd(mfd, buf, limit);
-}
-
-static void
-prof_dump_maps(buf_writer_t *buf_writer) {
-	int mfd = prof_dump_open_maps();
-	if (mfd == -1) {
-		return;
-	}
-
-	buf_writer_cb(buf_writer, "\nMAPPED_LIBRARIES:\n");
-	buf_writer_pipe(buf_writer, prof_dump_read_maps_cb, &mfd);
-	close(mfd);
-}
-#endif /* __APPLE__ */
 
 static bool
 prof_dump(
@@ -827,7 +671,7 @@ prof_dump_filename(tsd_t *tsd, char *filename, char v, uint64_t vseq) {
 			/* "<prefix>.<pid_namespace>.<pid>.<seq>.v<vseq>.heap" */
 			malloc_snprintf(filename, DUMP_FILENAME_BUFSIZE,
 			    "%s.%ld.%d.%" FMTu64 ".%c%" FMTu64 ".heap", prefix,
-			    prof_get_pid_namespace(), prof_getpid(),
+			    os_prof_pid_namespace(), prof_getpid(),
 			    prof_dump_seq, v, vseq);
 		} else {
 			/* "<prefix>.<pid>.<seq>.v<vseq>.heap" */
@@ -840,7 +684,7 @@ prof_dump_filename(tsd_t *tsd, char *filename, char v, uint64_t vseq) {
 			/* "<prefix>.<pid_namespace>.<pid>.<seq>.<v>.heap" */
 			malloc_snprintf(filename, DUMP_FILENAME_BUFSIZE,
 			    "%s.%ld.%d.%" FMTu64 ".%c.heap", prefix,
-			    prof_get_pid_namespace(), prof_getpid(),
+			    os_prof_pid_namespace(), prof_getpid(),
 			    prof_dump_seq, v);
 		} else {
 			/* "<prefix>.<pid>.<seq>.<v>.heap" */
@@ -858,7 +702,7 @@ prof_get_default_filename(tsdn_t *tsdn, char *filename, uint64_t ind) {
 	if (opt_prof_pid_namespace) {
 		malloc_snprintf(filename, PROF_DUMP_FILENAME_LEN,
 		    "%s.%ld.%d.%" FMTu64 ".json", prof_prefix_get(tsdn),
-		    prof_get_pid_namespace(), prof_getpid(), ind);
+		    os_prof_pid_namespace(), prof_getpid(), ind);
 	} else {
 		malloc_snprintf(filename, PROF_DUMP_FILENAME_LEN,
 		    "%s.%d.%" FMTu64 ".json", prof_prefix_get(tsdn),

--- a/src/prof_sys.c
+++ b/src/prof_sys.c
@@ -670,8 +670,8 @@ prof_dump_filename(tsd_t *tsd, char *filename, char v, uint64_t vseq) {
 		if (opt_prof_pid_namespace) {
 			/* "<prefix>.<pid_namespace>.<pid>.<seq>.v<vseq>.heap" */
 			malloc_snprintf(filename, DUMP_FILENAME_BUFSIZE,
-			    "%s.%ld.%d.%" FMTu64 ".%c%" FMTu64 ".heap", prefix,
-			    os_prof_pid_namespace(), prof_getpid(),
+			    "%s.%" FMTu64 ".%d.%" FMTu64 ".%c%" FMTu64 ".heap",
+			    prefix, os_prof_pid_namespace(), prof_getpid(),
 			    prof_dump_seq, v, vseq);
 		} else {
 			/* "<prefix>.<pid>.<seq>.v<vseq>.heap" */
@@ -683,7 +683,7 @@ prof_dump_filename(tsd_t *tsd, char *filename, char v, uint64_t vseq) {
 		if (opt_prof_pid_namespace) {
 			/* "<prefix>.<pid_namespace>.<pid>.<seq>.<v>.heap" */
 			malloc_snprintf(filename, DUMP_FILENAME_BUFSIZE,
-			    "%s.%ld.%d.%" FMTu64 ".%c.heap", prefix,
+			    "%s.%" FMTu64 ".%d.%" FMTu64 ".%c.heap", prefix,
 			    os_prof_pid_namespace(), prof_getpid(),
 			    prof_dump_seq, v);
 		} else {
@@ -701,8 +701,9 @@ prof_get_default_filename(tsdn_t *tsdn, char *filename, uint64_t ind) {
 	malloc_mutex_lock(tsdn, &prof_dump_filename_mtx);
 	if (opt_prof_pid_namespace) {
 		malloc_snprintf(filename, PROF_DUMP_FILENAME_LEN,
-		    "%s.%ld.%d.%" FMTu64 ".json", prof_prefix_get(tsdn),
-		    os_prof_pid_namespace(), prof_getpid(), ind);
+		    "%s.%" FMTu64 ".%d.%" FMTu64 ".json",
+		    prof_prefix_get(tsdn), os_prof_pid_namespace(),
+		    prof_getpid(), ind);
 	} else {
 		malloc_snprintf(filename, PROF_DUMP_FILENAME_LEN,
 		    "%s.%d.%" FMTu64 ".json", prof_prefix_get(tsdn),

--- a/test/unit/prof_mdump.c
+++ b/test/unit/prof_mdump.c
@@ -5,6 +5,73 @@
 static const char *test_filename = "test_filename";
 static bool        did_prof_dump_open;
 
+TEST_BEGIN(test_prof_parse_pid_namespace) {
+	struct test_case_s {
+		const char *input;
+		size_t      buf_size;
+		ssize_t     linklen;
+		uint64_t    expected;
+	} test_cases[] = {
+	    /* A typical valid namespace ID. */
+	    {"pid:[1234]", sizeof("pid:[1234]"),
+	                     sizeof("pid:[1234]") - 1, UINT64_C(1234)},
+	    /* The shortest valid namespace ID contains one digit. */
+	    {"pid:[1]", sizeof("pid:[1]"), sizeof("pid:[1]") - 1,
+	        UINT64_C(1)},
+	    /* Leading zeroes do not change the parsed value. */
+	    {"pid:[0001234]", sizeof("pid:[0001234]"),
+	        sizeof("pid:[0001234]") - 1, UINT64_C(1234)},
+	    /* A realistic namespace ID must fit on 32-bit platforms. */
+	    {"pid:[4026531836]", sizeof("pid:[4026531836]"),
+	        sizeof("pid:[4026531836]") - 1, UINT64_C(4026531836)},
+	    /* UINT64_MAX is the largest representable namespace ID. */
+	    {"pid:[18446744073709551615]",
+	        sizeof("pid:[18446744073709551615]"),
+	        sizeof("pid:[18446744073709551615]") - 1, UINT64_MAX},
+	    /* Reject an incorrect prefix. */
+	    {"pid-:[1234]", sizeof("pid-:[1234]"),
+	        sizeof("pid-:[1234]") - 1, 0},
+	    /* Reject non-digit characters within the namespace ID. */
+	    {"pid:[12a4]", sizeof("pid:[12a4]"), sizeof("pid:[12a4]") - 1,
+	        0},
+	    /* Reject an explicit positive sign, only digits are allowed. */
+	    {"pid:[+1234]", sizeof("pid:[+1234]"),
+	        sizeof("pid:[+1234]") - 1, 0},
+	    /* Reject negative namespace IDs. */
+	    {"pid:[-1]", sizeof("pid:[-1]"), sizeof("pid:[-1]") - 1, 0},
+	    /* Reject a namespace ID with no digits. */
+	    {"pid:[]", sizeof("pid:[]"), sizeof("pid:[]") - 1, 0},
+	    /* Reject an input without the closing bracket. */
+	    {"pid:[1234", sizeof("pid:[1234"), sizeof("pid:[1234") - 1, 0},
+	    /* Reject trailing content included within linklen. */
+	    {"pid:[1234]x", sizeof("pid:[1234]x"),
+	        sizeof("pid:[1234]x") - 1, 0},
+	    /* Reject a value one greater than UINT64_MAX. */
+	    {"pid:[18446744073709551616]",
+	        sizeof("pid:[18446744073709551616]"),
+	        sizeof("pid:[18446744073709551616]") - 1, 0},
+	    /* Only bytes before linklen belong to the symlink target. */
+	    {"pid:[12]junk", sizeof("pid:[12]junk"), sizeof("pid:[12]") - 1,
+	        UINT64_C(12)},
+	    /* Reject linklen equal to buf_size as potentially truncated. */
+	    {"pid:[1234]", sizeof("pid:[1234]") - 1,
+	        sizeof("pid:[1234]") - 1, 0},
+	    /* A zero linklen means readlink returned no data. */
+	    {"pid:[1234]", sizeof("pid:[1234]"), 0, 0},
+	    /* A negative linklen represents a readlink error. */
+	    {"pid:[1234]", sizeof("pid:[1234]"), -1, 0}};
+
+	size_t test_case_count = ARRAY_SIZE(test_cases);
+	for (size_t i = 0; i < test_case_count; i++) {
+		struct test_case_s *test_case = &test_cases[i];
+		expect_u64_eq(os_prof_parse_pid_namespace(test_case->input,
+		                 test_case->buf_size, test_case->linklen),
+		    test_case->expected, "Unexpected result for test case %zu",
+		    i);
+	}
+}
+TEST_END
+
 static int
 prof_dump_open_file_intercept(const char *filename, int mode) {
 	int fd;
@@ -211,6 +278,6 @@ TEST_END
 
 int
 main(void) {
-	return test(
-	    test_mdump_normal, test_mdump_output_error, test_mdump_maps_error);
+	return test(test_prof_parse_pid_namespace, test_mdump_normal,
+	    test_mdump_output_error, test_mdump_maps_error);
 }


### PR DESCRIPTION
Remove some unnecessary OS detection conditions and migrate some more modules to the OS layer:
1. process maps and PID namespace;
2. CPU affinity setup;
3. Spin's thread yield;
4. symlink reading.
