### PR TITLE
Fix build warnings when building with GCC on macOS

### DIFF
--- a/src/mutex.c
+++ b/src/mutex.c
@@ -1,6 +1,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 
 #include "jemalloc/internal/assert.h"
+#include "jemalloc/internal/background_thread.h"
 #include "jemalloc/internal/malloc_io.h"
 #include "jemalloc/internal/mutex.h"
 #include "jemalloc/internal/spin.h"

--- a/src/prof.c
+++ b/src/prof.c
@@ -458,6 +458,8 @@ prof_tdata_reinit(tsd_t *tsd, prof_tdata_t *tdata) {
 	prof_thread_name_assert(tdata);
 	char thread_name[PROF_THREAD_NAME_MAX_LEN];
 	strncpy(thread_name, tdata->thread_name, PROF_THREAD_NAME_MAX_LEN);
+	/* Defensive only; the source is always terminated. */
+	thread_name[PROF_THREAD_NAME_MAX_LEN - 1] = '\0';
 	prof_tdata_detach(tsd, tdata);
 
 	return prof_tdata_init_impl(


### PR DESCRIPTION
Two issues when building on macOS.

1) --enable-lazy-lock does not build:

```
src/mutex.c:36:9: error: call to undeclared function 'pthread_create_wrapper'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

mutex.c lost its background_thread.h include when the jemalloc_internal_includes.h umbrella was dropped (de9ad145). Fix: add the include.

2) With --enable-prof, GCC 16 warns:

```
src/prof.c:460:9: warning: '__builtin_strncpy' specified bound 16 equals destination size [-Wstringop-truncation]
```

The source is always terminated by its writers, so this is defensive. Fix: terminate the copy explicitly, matching prof_data.c and prof_sys.c.

Testing: built on 2cabfc29 with GCC 16 and Apple clang 17; --enable-lazy-lock and --enable-prof both build clean.