### PR TITLE
add --Wno-missing-field-initializers to the C++ compiler options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,10 +342,11 @@ if test "x$enable_cxx" = "x1" ; then
   if test "x${HAVE_CXX14}" = "x1" -o "x${HAVE_CXX17}" = "x1"; then
     JE_CXXFLAGS_ADD([-Wall])
     JE_CXXFLAGS_ADD([-Wextra])
-    dnl Mirror the C flags: this warning fires on the universal zero
+    dnl Mirror the C flags: these warnings fire on the universal zero
     dnl initializer idiom (e.g. the tcache/TSD static initializers) that is
     dnl shared with the C++ sources via the internal headers.
     JE_CXXFLAGS_ADD([-Wno-missing-braces])
+    JE_CXXFLAGS_ADD([-Wno-missing-field-initializers])
     JE_CXXFLAGS_ADD([-g3])
 
     SAVED_LIBS="${LIBS}"


### PR DESCRIPTION
Add `--Wno-missing-field-initializers`  to the C++ compiler options to eliminate compilation warnings on some of the ci tests (the C options already have it). The warnings are in `tsd_generic.h` (lines 107 and 159) and are caused by the macro `TSD_INITIALIZER`.