### PR TITLE
Fix possible tcache corruption on fiber migration (under --enable-experimental-fiber-safe-tls)

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -707,4 +707,24 @@ jobs:
         make check
 
 
+  test-linux-lto-fiber-safe-tls:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang, lld and llvm
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang lld llvm
+
+    - name: Build and test (LTO, je_ prefix, fiber-safe TLS)
+      run: |
+        autoconf
+        CC=clang AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib \
+          ./configure --enable-experimental-fiber-safe-tls \
+            --with-jemalloc-prefix=je_ EXTRA_CFLAGS=-flto=thin
+        make -j3 EXTRA_LDFLAGS="-flto=thin -fuse-ld=lld"
+        make -j3 tests EXTRA_LDFLAGS="-flto=thin -fuse-ld=lld"
+        make check
+
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -226,6 +226,23 @@ any of the following arguments (not a definitive list) to 'configure':
     this lets the compiler treat `operator new` as non-throwing and elide
     exception-handling cleanup in callers.
 
+* `--enable-experimental-fiber-safe-tls`
+
+    Make jemalloc's own thread-local (TSD) access safe for fibers / stackful
+    coroutines that migrate between OS threads.
+
+    The compiler may legally compute a thread-local's address once and reuse
+    it; inlined into the allocator fast paths under whole-program LTO, that
+    address can be cached in a callee-saved register across a user-space
+    context switch and reused on the OS thread the fiber migrated to, so two
+    threads race on one tcache -- silent heap corruption (see issue #2890).
+    With this option every internal TSD access re-derives the address through
+    an out-of-line accessor behind an optimization barrier, which the compiler
+    cannot hoist or reuse across the switch.
+
+    This is a partial mitigation, not a whole-program fix: only TLS accesses
+    made by jemalloc itself are protected.
+
 * `--with-xslroot=<path>`
 
     Specify where to find DocBook XSL stylesheets when building the

--- a/Makefile.in
+++ b/Makefile.in
@@ -59,9 +59,11 @@ enable_autogen := @enable_autogen@
 enable_doc := @enable_doc@
 enable_shared := @enable_shared@
 enable_static := @enable_static@
+have_ucontext := @have_ucontext@
 enable_prof := @enable_prof@
 enable_zone_allocator := @enable_zone_allocator@
 enable_experimental_smallocx := @enable_experimental_smallocx@
+enable_experimental_fiber_safe_tls := @enable_experimental_fiber_safe_tls@
 MALLOC_CONF := @JEMALLOC_CPREFIX@MALLOC_CONF
 link_whole_archive := @link_whole_archive@
 DSO_LDFLAGS = @DSO_LDFLAGS@
@@ -345,6 +347,21 @@ ifeq (@enable_experimental_smallocx@, 1)
 TESTS_INTEGRATION += \
   $(srcroot)test/integration/smallocx.c
 endif
+# tcache_fiber_migration requires:
+# - LTO (-lflto)
+# - ucontext
+# --enable-experimental-fiber-safe-tls
+ifeq (elf, $(ABI))
+ifeq ($(enable_static), 1)
+ifeq (1, $(have_ucontext))
+ifeq (1, $(enable_experimental_fiber_safe_tls))
+ifneq (,$(findstring -flto,$(CFLAGS)))
+TESTS_INTEGRATION += $(srcroot)test/integration/tcache_fiber_migration.c
+endif
+endif
+endif
+endif
+endif
 ifeq (@enable_cxx@, 1)
 CPP_SRCS := $(srcroot)src/jemalloc_cpp.cpp
 TESTS_INTEGRATION_CPP := $(srcroot)test/integration/cpp/basic.cpp
@@ -577,6 +594,13 @@ $(objroot)test/unit/%$(EXE): $(objroot)test/unit/%.$(O) $(C_JET_OBJS) $(C_TESTLI
 $(objroot)test/integration/%$(EXE): $(objroot)test/integration/%.$(O) $(C_TESTLIB_INTEGRATION_OBJS) $(C_UTIL_INTEGRATION_OBJS) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB)
 	@mkdir -p $(@D)
 	$(CC) $(TEST_LD_MODE) $(LDTARGET) $(filter %.$(O),$^) $(call RPATH,$(objroot)lib) $(LJEMALLOC) $(LDFLAGS) $(filter-out -lm,$(filter -lrt -pthread -lstdc++,$(LIBS))) $(LM) $(EXTRA_LDFLAGS)
+
+# tcache_fiber_migration (issue #2890) must inline the allocator next to the
+# swapcontext, so link jemalloc statically (--whole-archive); whole-program LTO
+# does the inlining.
+$(objroot)test/integration/tcache_fiber_migration$(EXE): $(objroot)test/integration/tcache_fiber_migration.$(O) $(objroot)lib/$(LIBJEMALLOC).$(A)
+	@mkdir -p $(@D)
+	$(CC) $(LDTARGET) $(objroot)test/integration/tcache_fiber_migration.$(O) -Wl,--whole-archive $(objroot)lib/$(LIBJEMALLOC).$(A) -Wl,--no-whole-archive $(LDFLAGS) -pthread $(filter-out -lm,$(LIBS)) $(LM) $(EXTRA_LDFLAGS)
 
 $(objroot)test/integration/cpp/%$(EXE): $(objroot)test/integration/cpp/%.$(O) $(C_TESTLIB_INTEGRATION_OBJS) $(C_UTIL_INTEGRATION_OBJS) $(objroot)lib/$(LIBJEMALLOC).$(IMPORTLIB)
 	@mkdir -p $(@D)

--- a/configure.ac
+++ b/configure.ac
@@ -1217,6 +1217,25 @@ if test "$enable_shared$enable_static" = "00" ; then
   AC_MSG_ERROR([Please enable one of shared or static builds])
 fi
 
+dnl Whether ucontext fibers (getcontext/makecontext/swapcontext) actually link.
+dnl musl declares them in <ucontext.h> but exports no implementation, so a
+dnl link test is required -- a header check would pass and then fail to link.
+dnl Used to gate the tcache_fiber_migration test.
+JE_COMPILABLE([ucontext], [
+#include <ucontext.h>
+], [
+	ucontext_t uc, ret;
+	getcontext(&uc);
+	makecontext(&uc, (void (*)(void))0, 0);
+	swapcontext(&ret, &uc);
+], [je_cv_ucontext])
+if test "x${je_cv_ucontext}" = "xyes" ; then
+  have_ucontext="1"
+else
+  have_ucontext="0"
+fi
+AC_SUBST([have_ucontext])
+
 dnl Perform no name mangling by default.
 AC_ARG_WITH([mangling],
   [AS_HELP_STRING([--with-mangling=<map>], [Mangle symbols in <map>])],
@@ -1497,6 +1516,24 @@ if test "x$enable_experimental_smallocx" = "x1" ; then
   AC_DEFINE([JEMALLOC_EXPERIMENTAL_SMALLOCX_API], [ ], [ ])
 fi
 AC_SUBST([enable_experimental_smallocx])
+
+dnl Do not enable fiber-safe TLS access by default.
+AC_ARG_ENABLE([experimental_fiber_safe_tls],
+  [AS_HELP_STRING([--enable-experimental-fiber-safe-tls],
+                  [Make jemalloc's own TLS access safe for fibers that migrate across threads (partial mitigation; see INSTALL.md)])],
+[if test "x$enable_experimental_fiber_safe_tls" = "xno" ; then
+enable_experimental_fiber_safe_tls="0"
+else
+enable_experimental_fiber_safe_tls="1"
+fi
+],
+[enable_experimental_fiber_safe_tls="0"]
+)
+if test "x$enable_experimental_fiber_safe_tls" = "x1" ; then
+  AC_DEFINE([JEMALLOC_EXPERIMENTAL_FIBER_SAFE_TLS], [ ],
+            [Route TSD thread-local address computation through a noinline optimization-barrier accessor so the compiler cannot cache it across a user-space context switch.])
+fi
+AC_SUBST([enable_experimental_fiber_safe_tls])
 
 dnl Do not enable profiling by default.
 AC_ARG_ENABLE([prof],
@@ -3145,6 +3182,7 @@ AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([stats              : ${enable_stats}])
 AC_MSG_RESULT([user_config        : ${enable_user_config}])
 AC_MSG_RESULT([experimental_smallocx : ${enable_experimental_smallocx}])
+AC_MSG_RESULT([experimental_fiber_safe_tls : ${enable_experimental_fiber_safe_tls}])
 AC_MSG_RESULT([prof               : ${enable_prof}])
 AC_MSG_RESULT([prof-libunwind     : ${enable_prof_libunwind}])
 AC_MSG_RESULT([prof-frameptr      : ${enable_prof_frameptr}])

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -149,6 +149,14 @@
 #undef JEMALLOC_TLS_MODEL
 
 /*
+ * Route TSD thread-local address computation through a noinline
+ * optimization-barrier accessor so the compiler cannot cache it across a
+ * user-space context switch (fibers migrating between OS threads).  See
+ * tsd_tls_addr.h.
+ */
+#undef JEMALLOC_EXPERIMENTAL_FIBER_SAFE_TLS
+
+/*
  * JEMALLOC_DEBUG enables assertions and other sanity checks, and disables
  * inline functions.
  */

--- a/include/jemalloc/internal/tsd_malloc_thread_cleanup.h
+++ b/include/jemalloc/internal/tsd_malloc_thread_cleanup.h
@@ -5,6 +5,7 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/tsd_internals.h"
+#include "jemalloc/internal/tsd_tls_addr.h"
 #include "jemalloc/internal/tsd_types.h"
 
 #define JEMALLOC_TSD_TYPE_ATTR(type) __thread type JEMALLOC_TLS_MODEL
@@ -12,6 +13,9 @@
 extern JEMALLOC_TSD_TYPE_ATTR(tsd_t) tsd_tls;
 extern JEMALLOC_TSD_TYPE_ATTR(bool) tsd_initialized;
 extern bool tsd_booted;
+
+JEMALLOC_TLS_ADDR_DECLARE(tsd_tls)
+JEMALLOC_TLS_ADDR_DECLARE(tsd_initialized)
 
 /* Initialization/cleanup. */
 JEMALLOC_ALWAYS_INLINE bool
@@ -53,13 +57,15 @@ tsd_get_allocates(void) {
 /* Get/set. */
 JEMALLOC_ALWAYS_INLINE tsd_t *
 tsd_get(bool init) {
-	return &tsd_tls;
+	return JEMALLOC_TLS_ADDR(tsd_tls);
 }
 JEMALLOC_ALWAYS_INLINE void
 tsd_set(tsd_t *val) {
+	tsd_t *tsd = JEMALLOC_TLS_ADDR(tsd_tls);
+
 	assert(tsd_booted);
-	if (likely(&tsd_tls != val)) {
-		tsd_tls = (*val);
+	if (likely(tsd != val)) {
+		*tsd = (*val);
 	}
-	tsd_initialized = true;
+	*JEMALLOC_TLS_ADDR(tsd_initialized) = true;
 }

--- a/include/jemalloc/internal/tsd_tls.h
+++ b/include/jemalloc/internal/tsd_tls.h
@@ -5,6 +5,7 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/tsd_internals.h"
+#include "jemalloc/internal/tsd_tls_addr.h"
 #include "jemalloc/internal/tsd_types.h"
 
 #define JEMALLOC_TSD_TYPE_ATTR(type) __thread type JEMALLOC_TLS_MODEL
@@ -12,6 +13,8 @@
 extern JEMALLOC_TSD_TYPE_ATTR(tsd_t) tsd_tls;
 extern pthread_key_t tsd_tsd;
 extern bool          tsd_booted;
+
+JEMALLOC_TLS_ADDR_DECLARE(tsd_tls)
 
 /* Initialization/cleanup. */
 JEMALLOC_ALWAYS_INLINE bool
@@ -46,16 +49,18 @@ tsd_get_allocates(void) {
 /* Get/set. */
 JEMALLOC_ALWAYS_INLINE tsd_t *
 tsd_get(bool init) {
-	return &tsd_tls;
+	return JEMALLOC_TLS_ADDR(tsd_tls);
 }
 
 JEMALLOC_ALWAYS_INLINE void
 tsd_set(tsd_t *val) {
+	tsd_t *tsd = JEMALLOC_TLS_ADDR(tsd_tls);
+
 	assert(tsd_booted);
-	if (likely(&tsd_tls != val)) {
-		tsd_tls = (*val);
+	if (likely(tsd != val)) {
+		*tsd = (*val);
 	}
-	if (pthread_setspecific(tsd_tsd, (void *)(&tsd_tls)) != 0) {
+	if (pthread_setspecific(tsd_tsd, (void *)tsd) != 0) {
 		malloc_write("<jemalloc>: Error setting tsd.\n");
 		if (opt_abort) {
 			abort();

--- a/include/jemalloc/internal/tsd_tls_addr.h
+++ b/include/jemalloc/internal/tsd_tls_addr.h
@@ -1,0 +1,34 @@
+#ifndef JEMALLOC_INTERNAL_TSD_TLS_ADDR_H
+#define JEMALLOC_INTERNAL_TSD_TLS_ADDR_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+
+/**
+ * Under --enable-experimental-fiber-safe-tls generates accessors for TLS variables
+ * that does not allow compiler to hoist it.
+ *
+ * A raw `&tlsvar` is `thread_pointer + const_offset`, inlined into malloc/free under LTO
+ * can be hoisted across a swapcontext and reused on the OS thread a fiber migrated to -
+ * a stale tsd/tcache and silent heap corruption.
+ */
+#ifdef JEMALLOC_EXPERIMENTAL_FIBER_SAFE_TLS
+#  ifndef __GNUC__
+#    error "--enable-experimental-fiber-safe-tls requires GNU-style inline asm"
+#  endif
+#  define JEMALLOC_TLS_ADDR_DECLARE(tlsvar)                                    \
+	__typeof__(&(tlsvar)) jemalloc_tls_addr_##tlsvar(void);
+#  define JEMALLOC_TLS_ADDR_DEFINE(tlsvar)                                     \
+	JEMALLOC_NOINLINE __typeof__(&(tlsvar))                                       \
+	jemalloc_tls_addr_##tlsvar(void) {                                            \
+		__typeof__(&(tlsvar)) tls_addr = &(tlsvar);                                  \
+		__asm__ __volatile__("" : "+r"(tls_addr) : : "memory");                      \
+		return tls_addr;                                                             \
+	}
+#  define JEMALLOC_TLS_ADDR(tlsvar) (jemalloc_tls_addr_##tlsvar())
+#else
+#  define JEMALLOC_TLS_ADDR_DECLARE(tlsvar)
+#  define JEMALLOC_TLS_ADDR_DEFINE(tlsvar)
+#  define JEMALLOC_TLS_ADDR(tlsvar) (&(tlsvar))
+#endif
+
+#endif /* JEMALLOC_INTERNAL_TSD_TLS_ADDR_H */

--- a/include/jemalloc/internal/tsd_win.h
+++ b/include/jemalloc/internal/tsd_win.h
@@ -5,6 +5,7 @@
 
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/tsd_internals.h"
+#include "jemalloc/internal/tsd_tls_addr.h"
 #include "jemalloc/internal/tsd_types.h"
 
 /* val should always be the first field of tsd_wrapper_t since accessing
@@ -178,6 +179,8 @@ tsd_set(tsd_t *val) {
 extern JEMALLOC_TSD_TYPE_ATTR(tsd_wrapper_t) tsd_wrapper_tls;
 extern bool tsd_booted;
 
+JEMALLOC_TLS_ADDR_DECLARE(tsd_wrapper_tls)
+
 /* Initialization/cleanup. */
 JEMALLOC_ALWAYS_INLINE bool
 tsd_cleanup_wrapper(void) {
@@ -223,16 +226,18 @@ tsd_get_allocates(void) {
 /* Get/set. */
 JEMALLOC_ALWAYS_INLINE tsd_t *
 tsd_get(bool init) {
-	return &(tsd_wrapper_tls.val);
+	return &(JEMALLOC_TLS_ADDR(tsd_wrapper_tls)->val);
 }
 
 JEMALLOC_ALWAYS_INLINE void
 tsd_set(tsd_t *val) {
+	tsd_wrapper_t *wrapper = JEMALLOC_TLS_ADDR(tsd_wrapper_tls);
+
 	assert(tsd_booted);
-	if (likely(&(tsd_wrapper_tls.val) != val)) {
-		tsd_wrapper_tls.val = (*val);
+	if (likely(&wrapper->val != val)) {
+		wrapper->val = (*val);
 	}
-	tsd_wrapper_tls.initialized = true;
+	wrapper->initialized = true;
 }
 
 #endif // defined(JEMALLOC_LEGACY_WINDOWS_SUPPORT) || !defined(_MSC_VER)

--- a/scripts/gen_gh_actions.py
+++ b/scripts/gen_gh_actions.py
@@ -694,6 +694,31 @@ def generate_freebsd_job(arch):
     return job
 
 
+def generate_linux_lto_job():
+    """Dedicated lane for --enable-experimental-fiber-safe-tls (that requires
+    LTO, je_ prefix and --enable-experimental-fiber-safe-tls)"""
+    return """  test-linux-lto-fiber-safe-tls:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang, lld and llvm
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang lld llvm
+
+    - name: Build and test (LTO, je_ prefix, fiber-safe TLS)
+      run: |
+        autoconf
+        CC=clang AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib \\
+          ./configure --enable-experimental-fiber-safe-tls \\
+            --with-jemalloc-prefix=je_ EXTRA_CFLAGS=-flto=thin
+        make -j3 EXTRA_LDFLAGS="-flto=thin -fuse-ld=lld"
+        make -j3 tests EXTRA_LDFLAGS="-flto=thin -fuse-ld=lld"
+        make check
+"""
+
+
 def main():
     import sys
 
@@ -704,6 +729,7 @@ def main():
         jobs = '\n'.join((
             generate_linux_job(AMD64),
             generate_linux_job(ARM64),
+            generate_linux_lto_job(),
         ))
         print(GITHUB_ACTIONS_TEMPLATE.format(name='Linux CI', jobs=jobs))
 
@@ -727,6 +753,7 @@ def main():
         linux_jobs = '\n'.join((
             generate_linux_job(AMD64),
             generate_linux_job(ARM64),
+            generate_linux_lto_job(),
         ))
         macos_jobs = '\n'.join((
             generate_macos_job(AMD64),   # Intel

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -23,9 +23,12 @@ JEMALLOC_DIAGNOSTIC_IGNORE_MISSING_STRUCT_FIELD_INITIALIZERS
 #ifdef JEMALLOC_MALLOC_THREAD_CLEANUP
 JEMALLOC_TSD_TYPE_ATTR(tsd_t) tsd_tls = TSD_INITIALIZER;
 JEMALLOC_TSD_TYPE_ATTR(bool) JEMALLOC_TLS_MODEL tsd_initialized = false;
+JEMALLOC_TLS_ADDR_DEFINE(tsd_tls)
+JEMALLOC_TLS_ADDR_DEFINE(tsd_initialized)
 bool tsd_booted = false;
 #elif (defined(JEMALLOC_TLS))
 JEMALLOC_TSD_TYPE_ATTR(tsd_t) tsd_tls = TSD_INITIALIZER;
+JEMALLOC_TLS_ADDR_DEFINE(tsd_tls)
 pthread_key_t tsd_tsd;
 bool          tsd_booted = false;
 #elif (defined(_WIN32))
@@ -35,6 +38,7 @@ tsd_wrapper_t tsd_boot_wrapper = {TSD_INITIALIZER, false};
 #	else
 JEMALLOC_TSD_TYPE_ATTR(tsd_wrapper_t)
 tsd_wrapper_tls = {TSD_INITIALIZER, false};
+JEMALLOC_TLS_ADDR_DEFINE(tsd_wrapper_tls)
 #	endif
 bool tsd_booted = false;
 #	if JEMALLOC_WIN32_TLSGETVALUE2

--- a/test/integration/tcache_fiber_migration.c
+++ b/test/integration/tcache_fiber_migration.c
@@ -1,0 +1,148 @@
+/*
+ * Regression test for issue #2890: under whole-program LTO the inlined allocator
+ * fastpath caches the TLS-derived tcache base in a register across a
+ * swapcontext, so a fiber resumed on another OS thread uses the previous
+ * thread's tcache -> heap corruption.  See JEMALLOC_TLS_ADDR in tsd_tls_addr.h.
+ *
+ * Standalone build:
+ *
+ *   clang -O2 -flto=thin -fuse-ld=lld -D_GNU_SOURCE -D_REENTRANT -DJEMALLOC_NO_PRIVATE_NAMESPACE \
+ *         -Itest/include -Iinclude \
+ *         $(find src -name '*.c' | grep -v zone.c) \
+ *         test/integration/tcache_fiber_migration.c -pthread -lm \
+ *         -o tcache_fiber_migration
+ */
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <ucontext.h>
+
+#define JEMALLOC_MANGLE
+#include <jemalloc/jemalloc.h>
+
+enum {
+	num_fibers = 128,
+	num_workers = 8,
+	ops_per_fiber = 20 * 1000,
+	fiber_stack_size = 1 << 16,
+	/* Power of two; a fiber sits in at most one queue at a time. */
+	worker_queue_capacity = num_fibers
+};
+
+static ucontext_t fiber_context[num_fibers];
+/* Scheduler context to switch back to when a fiber yields; the resuming worker
+ * writes its own context here, so this changes when the fiber migrates. */
+static ucontext_t *return_context[num_fibers];
+static unsigned fiber_remaining_ops[num_fibers];
+static bool fiber_done[num_fibers];
+
+/*
+ * Per-worker ready queues: a fiber that yields on worker w is enqueued to
+ * worker (w + 1) % num_workers and can only be resumed there, so every resume
+ * is a cross-thread migration by construction.
+ */
+static unsigned ready_queue[num_workers][worker_queue_capacity];
+static unsigned ready_queue_head[num_workers];
+static unsigned ready_queue_tail[num_workers];
+static unsigned live_fibers;
+static pthread_mutex_t queue_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+static void
+push_ready_fiber(unsigned worker, unsigned id) {
+	pthread_mutex_lock(&queue_mtx);
+	ready_queue[worker][ready_queue_head[worker]++ &
+	    (worker_queue_capacity - 1)] = id;
+	pthread_mutex_unlock(&queue_mtx);
+}
+
+/* Returns a ready fiber id, -1 if none ready now, or -2 if all have finished. */
+static int
+pop_ready_fiber(unsigned worker) {
+	int id;
+	pthread_mutex_lock(&queue_mtx);
+	if (live_fibers == 0) {
+		id = -2;
+	} else if (ready_queue_tail[worker] != ready_queue_head[worker]) {
+		id = (int)ready_queue[worker][ready_queue_tail[worker]++ &
+		    (worker_queue_capacity - 1)];
+	} else {
+		id = -1;
+	}
+	pthread_mutex_unlock(&queue_mtx);
+	return id;
+}
+
+static void
+fiber_run(int id) {
+	void *p = malloc(64);
+	while (fiber_remaining_ops[id] > 0) {
+		fiber_remaining_ops[id]--;
+		free(p); /* push to the CURRENT thread's tcache */
+		/* Yield; resumed on the next worker thread (forced migration). */
+		swapcontext(&fiber_context[id], return_context[id]);
+		p = malloc(64); /* pop; must come from the NEW thread's tcache */
+		*(char *)p = (char)id;
+	}
+	free(p);
+	pthread_mutex_lock(&queue_mtx);
+	fiber_done[id] = true;
+	live_fibers--;
+	pthread_mutex_unlock(&queue_mtx);
+	swapcontext(&fiber_context[id], return_context[id]);
+}
+
+static void *
+worker_thread(void *arg) {
+	unsigned worker = (unsigned)(uintptr_t)arg;
+	ucontext_t scheduler_context;
+	for (;;) {
+		int id = pop_ready_fiber(worker);
+		if (id == -2) {
+			break;
+		}
+		if (id < 0) {
+			continue;
+		}
+		return_context[id] = &scheduler_context;
+		swapcontext(&scheduler_context, &fiber_context[id]);
+		if (!fiber_done[id]) {
+			/* Hand off to the next worker: forced migration. */
+			push_ready_fiber((worker + 1) % num_workers,
+			    (unsigned)id);
+		}
+	}
+	return NULL;
+}
+
+int
+main(void) {
+	void *stacks[num_fibers];
+	pthread_t threads[num_workers];
+	unsigned i;
+
+	live_fibers = num_fibers;
+	for (i = 0; i < num_fibers; i++) {
+		stacks[i] = malloc(fiber_stack_size);
+		fiber_remaining_ops[i] = ops_per_fiber;
+		getcontext(&fiber_context[i]);
+		fiber_context[i].uc_stack.ss_sp = stacks[i];
+		fiber_context[i].uc_stack.ss_size = fiber_stack_size;
+		fiber_context[i].uc_link = NULL;
+		makecontext(&fiber_context[i], (void (*)(void))fiber_run, 1, (int)i);
+		push_ready_fiber(i % num_workers, i);
+	}
+
+	for (i = 0; i < num_workers; i++) {
+		pthread_create(&threads[i], NULL, worker_thread,
+		    (void *)(uintptr_t)i);
+	}
+	for (i = 0; i < num_workers; i++) {
+		pthread_join(threads[i], NULL);
+	}
+	for (i = 0; i < num_fibers; i++) {
+		free(stacks[i]);
+	}
+
+	/* Completing without a tcache-corruption crash is success. */
+	return live_fibers == 0 ? 0 : 2;
+}


### PR DESCRIPTION
_Note, this the second, more simpler version of https://github.com/jemalloc/jemalloc/pull/2944/ without per-arch asm_

Under LTO `&tsd_tls` is hoisted out of the inlined malloc/free and survives swapcontext in a callee-saved register: a fiber resumed on another OS thread races on the old thread's tcache.

Fix it by taking the address in a noinline volatile-asm barrier accessor.

It is done under option, because it make the fastpath slower, on a microbench (that is very heavy depends on the most optimal case) the overhead is 35%, but this is unlikely the real world scenario.

Anyway here are some numbers for `microbench.c` compiled with LTO (AMD 5975WX):

type    |vanilla (ns)|`--enable-experimental-fiber-safe-tls` (ns)|optimized (ns)
--------|------------|-------------------------------------------|--------------
malloc  |6.51        |8.77 **(+34%)**                            |6.79 (4%)
mallocx |8.48        |10.62 **(25%)**                            |8.76 (3%)
free    |6.46        |8.68 **(34%)**                             |6.76 (5%)
dallocx |8.190       |10.97 **(33%)**                            |8.74 (7%)

(optimized version is a version that submitted in another PR with per-arch asm to reduce overhead)

Note though that **difference is less on a server CPUs** and even way less on ARM64:
- [AMD EPYC 9R14](https://pastila.nl/?00e097f0/ff3bc749c303ca64bce3860d74ab572e#7U7BcERPaGtfm9luNpexjw==GCM) - **23%**
- [Neoverse-V2 (**arm64**)](https://pastila.nl/?00e01df2/94c98976b67d5fa2eb2c955145407f60#g7hoK8X4LQZk+rocOcro4g==GCM) - **4%**

Fixes: https://github.com/jemalloc/jemalloc/issues/2890
Thanks to @xinydev