### PR TITLE
Fix zero-size aligned allocation/deallocation size mismatch

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -1197,6 +1197,7 @@ JEMALLOC_ATTR(malloc) je_valloc(size_t size) {
 	static_opts_init(&sopts);
 	dynamic_opts_init(&dopts);
 
+	sopts.bump_empty_aligned_alloc = true;
 	sopts.null_out_result_on_error = true;
 	sopts.min_alignment = PAGE;
 	sopts.oom_string =
@@ -1230,6 +1231,7 @@ JEMALLOC_ATTR(malloc) je_pvalloc(size_t size) {
 	static_opts_init(&sopts);
 	dynamic_opts_init(&dopts);
 
+	sopts.bump_empty_aligned_alloc = true;
 	sopts.null_out_result_on_error = true;
 	sopts.min_alignment = PAGE;
 	sopts.oom_string =
@@ -1910,11 +1912,12 @@ je_dallocx(void *ptr, int flags) {
 }
 
 JEMALLOC_ALWAYS_INLINE size_t
-inallocx(tsdn_t *tsdn, size_t size, int flags) {
+inallocx(tsdn_t *tsdn, size_t size, int flags, bool bump_empty_aligned_alloc) {
 	check_entry_exit_locking(tsdn);
 	size_t usize;
 	/* In case of out of range, let the user see it rather than fail. */
-	aligned_usize_get(size, MALLOCX_ALIGN_GET(flags), &usize, NULL, false);
+	aligned_usize_get(size, MALLOCX_ALIGN_GET(flags), &usize, NULL,
+	    bump_empty_aligned_alloc);
 	check_entry_exit_locking(tsdn);
 	return usize;
 }
@@ -1933,7 +1936,9 @@ sdallocx_default(void *ptr, size_t size, int flags) {
 
 	tsd_t *tsd = tsd_fetch_min();
 	bool   fast = tsd_fast(tsd);
-	size_t usize = inallocx(tsd_tsdn(tsd), size, flags);
+	/* Match the zero-to-one normalization used by aligned allocation APIs. */
+	size_t usize = inallocx(tsd_tsdn(tsd), size, flags,
+	    /* bump_empty_aligned_alloc */ true);
 	check_entry_exit_locking(tsd_tsdn(tsd));
 
 	unsigned  tcache_ind = mallocx_tcache_get(flags);
@@ -1975,7 +1980,8 @@ JEMALLOC_ATTR(pure) je_nallocx(size_t size, int flags) {
 	tsdn = tsdn_fetch();
 	check_entry_exit_locking(tsdn);
 
-	usize = inallocx(tsdn, size, flags);
+	usize = inallocx(
+	    tsdn, size, flags, /* bump_empty_aligned_alloc */ false);
 	if (unlikely(usize > SC_LARGE_MAXCLASS)) {
 		LOG("core.nallocx.exit", "result: %zu", ZU(0));
 		return 0;

--- a/test/unit/size_check.c
+++ b/test/unit/size_check.c
@@ -71,9 +71,32 @@ TEST_BEGIN(test_invalid_size_sdallocx_noflags) {
 }
 TEST_END
 
+TEST_BEGIN(test_valid_zero_size_aligned_sdallocx) {
+	test_skip_if(!config_opt_size_checks);
+
+	const size_t alignment = PAGE;
+	void        *ptr = aligned_alloc(alignment, 0);
+	assert_ptr_not_null(ptr, "Unexpected aligned_alloc() failure");
+
+	fake_abort_called = false;
+	test_hooks_safety_check_abort = &fake_abort;
+	sdallocx(ptr, 0, MALLOCX_ALIGN(alignment));
+	bool failed = fake_abort_called;
+	test_hooks_safety_check_abort = NULL;
+
+	if (failed) {
+		/* The intercepted mismatch path deliberately did not free ptr. */
+		free(ptr);
+	}
+	expect_false(
+	    failed, "Valid zero-sized aligned deallocation failed size check");
+}
+TEST_END
+
 int
 main(void) {
 	return test(test_invalid_size_sdallocx,
 	    test_invalid_size_sdallocx_nonzero_flag,
-	    test_invalid_size_sdallocx_noflags);
+	    test_invalid_size_sdallocx_noflags,
+	    test_valid_zero_size_aligned_sdallocx);
 }


### PR DESCRIPTION
## Problem

In jemalloc’s C++ wrapper, `alignedNewImpl()` routes through `je_aligned_alloc()`, where `imalloc_body()` calls `aligned_usize_get()` with `bump_empty_aligned_alloc=true`. A zero-sized over-aligned allocation is therefore treated as size 1 before alignment rounding. For example, `(size=0, alignment=64)` is allocated from the 64-byte size class.

However for the corresponding zero-size over-aligned deallocation path `alignedSizedDeleteImpl()`, `inallocx()` called `aligned_usize_get()` with `bump_empty_aligned_alloc=false`. The same `(size=0, alignment=64)` pair was consequently classified as the minimum size class instead of 64 bytes.

`isfree()` then trusted this incorrect usable size and could return the allocation to the wrong tcache bin. With optional size checks enabled, this caused an abort; otherwise, it could produce overlapping allocations and heap corruption.

## Fix

Propagate the zero-size normalization policy through `inallocx()`, enabling it for `sdallocx()` while preserving the existing `nallocx()` behavior.

## Test

Added a regression test that allocates zero bytes with alignment and deallocates it using the original zero-size hint.
