### PR TITLE
Fix edata_before_get address arithmetic

### DIFF
--- a/include/jemalloc/internal/edata.h
+++ b/include/jemalloc/internal/edata.h
@@ -467,7 +467,7 @@ edata_ps_get(const edata_t *edata) {
 
 static inline void *
 edata_before_get(const edata_t *edata) {
-	return (void *)((byte_t *)edata_base_get(edata) - PAGE);
+	return (void *)((uintptr_t)edata_base_get(edata) - PAGE);
 }
 
 static inline void *


### PR DESCRIPTION
edata_before_get computes the page immediately preceding an extent. When an extent starts at PAGE, that address is legitimately NULL and the caller uses the NULL result to avoid an rtree lookup.

Subtracting PAGE from a byte pointer is undefined unless the result stays within the pointed-to array. Clang can therefore assume the result is non-NULL and optimize away the caller's check. Subtract the integer addresses instead, then convert the result back to a pointer, so the PAGE case reliably produces NULL.
