### PR TITLE
Expose JEMALLOC_INFALLIBLE_NEW in the public header

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -217,7 +217,9 @@ any of the following arguments (not a definitive list) to 'configure':
     overloads still return null.  Disabled by default, and has no effect when
     C++ integration is disabled (`--disable-cxx`).  When enabled, under LTO
     this lets the compiler treat `operator new` as non-throwing and elide
-    exception-handling cleanup in callers.
+    exception-handling cleanup in callers.  The installed public header always
+    defines `JEMALLOC_INFALLIBLE_NEW` to `1` when this behavior is
+    enabled, and to `0` otherwise.
 
 * `--with-xslroot=<path>`
 

--- a/configure.ac
+++ b/configure.ac
@@ -421,7 +421,7 @@ if test "x$enable_cxx" != "x1" ; then
   enable_cxx_infallible_new="0"
 fi
 if test "x$enable_cxx_infallible_new" = "x1" ; then
-  AC_DEFINE([JEMALLOC_INFALLIBLE_NEW], [ ], [ ])
+  AC_DEFINE([JEMALLOC_INFALLIBLE_NEW], [1], [ ])
 fi
 AC_SUBST([enable_cxx])
 AC_SUBST([enable_cxx_exceptions])

--- a/include/jemalloc/internal/jemalloc_preamble.h.in
+++ b/include/jemalloc/internal/jemalloc_preamble.h.in
@@ -235,13 +235,7 @@ static const bool config_enable_cxx =
  * Whether the throwing operator new aborts on OOM instead of throwing
  * std::bad_alloc (--enable-cxx-infallible-new).
  */
-static const bool config_infallible_new =
-#ifdef JEMALLOC_INFALLIBLE_NEW
-    true
-#else
-    false
-#endif
-;
+static const bool config_infallible_new = JEMALLOC_INFALLIBLE_NEW;
 
 #if defined(_WIN32) || defined(__APPLE__) || defined(JEMALLOC_HAVE_SCHED_GETCPU)
 /* Currently percpu_arena depends on sched_getcpu. */

--- a/include/jemalloc/jemalloc_defs.h.in
+++ b/include/jemalloc/jemalloc_defs.h.in
@@ -52,6 +52,15 @@
 #undef JEMALLOC_CONFIG_ENV
 #undef JEMALLOC_CONFIG_FILE
 
+/*
+ * Whether throwing operator new aborts on OOM instead of throwing
+ * std::bad_alloc.  This is always defined to either 0 or 1.
+ */
+#undef JEMALLOC_INFALLIBLE_NEW
+#ifndef JEMALLOC_INFALLIBLE_NEW
+#  define JEMALLOC_INFALLIBLE_NEW 0
+#endif
+
 #ifdef _MSC_VER
 #  ifdef _WIN64
 #    define LG_SIZEOF_PTR_WIN 3

--- a/src/jemalloc_cpp.cpp
+++ b/src/jemalloc_cpp.cpp
@@ -66,7 +66,7 @@ void operator delete[](
 JEMALLOC_NOINLINE
 static void *
 handleOOM(std::size_t size, bool nothrow) {
-#ifdef JEMALLOC_INFALLIBLE_NEW
+#if JEMALLOC_INFALLIBLE_NEW
 	if (nothrow) {
 		return nullptr;
 	}

--- a/test/integration/cpp/basic.cpp
+++ b/test/integration/cpp/basic.cpp
@@ -1,4 +1,19 @@
+#include <type_traits>
+
 #include "test/jemalloc_test.h"
+
+#if JEMALLOC_INFALLIBLE_NEW != 0 && JEMALLOC_INFALLIBLE_NEW != 1
+#  error "JEMALLOC_INFALLIBLE_NEW must be 0 or 1"
+#endif
+
+using InfallibleNewConfig =
+    std::bool_constant<JEMALLOC_INFALLIBLE_NEW != 0>;
+
+void infallible_new_noexcept_probe()
+    noexcept(JEMALLOC_INFALLIBLE_NEW);
+
+static_assert(noexcept(infallible_new_noexcept_probe()) ==
+    InfallibleNewConfig::value);
 
 TEST_BEGIN(test_basic) {
 	auto foo = new long(4);

--- a/test/integration/cpp/failing_new.cpp
+++ b/test/integration/cpp/failing_new.cpp
@@ -2,6 +2,8 @@
 
 #include "test/jemalloc_test.h"
 
+static_assert(JEMALLOC_INFALLIBLE_NEW == 0);
+
 TEST_BEGIN(test_failing_alloc) {
 	bool saw_exception = false;
 	try {

--- a/test/integration/cpp/infallible_new.cpp
+++ b/test/integration/cpp/infallible_new.cpp
@@ -2,6 +2,8 @@
 
 #include "test/jemalloc_test.h"
 
+static_assert(JEMALLOC_INFALLIBLE_NEW == 1);
+
 /*
  * Verifies that, when jemalloc is built with --enable-cxx-infallible-new,
  * throwing operator new on OOM aborts via safety_check_fail. The test hook

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -493,6 +493,14 @@ TEST_BEGIN(test_mallctl_config) {
 	TEST_MALLCTL_CONFIG(utrace, bool);
 	TEST_MALLCTL_CONFIG(xmalloc, bool);
 
+	bool   infallible_new;
+	size_t infallible_new_size = sizeof(infallible_new);
+	expect_d_eq(mallctl("config.infallible_new", &infallible_new,
+	                &infallible_new_size, NULL, 0),
+	    0, "Unexpected mallctl() failure");
+	expect_b_eq(infallible_new, JEMALLOC_INFALLIBLE_NEW != 0,
+	    "Public compile-time and runtime infallible-new values differ");
+
 #undef TEST_MALLCTL_CONFIG
 }
 TEST_END


### PR DESCRIPTION
Define JEMALLOC_INFALLIBLE_NEW as 0 or 1 so consumers can use the configured operator new failure behavior in compile-time traits and noexcept specifications.