### PR TITLE
Fix MSVC diagnostics and pointer atomic initialization

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -1236,7 +1236,12 @@ arena_ptr_array_flush_impl_large(tsdn_t *tsdn, szind_t binind,
 	}
 }
 
+/* MSVC: keep each flush batch's stack allocations in its own frame. */
+#if defined(_MSC_VER) && !defined(__clang__)
+static JEMALLOC_NOINLINE void
+#else
 JEMALLOC_ALWAYS_INLINE void
+#endif
 arena_ptr_array_flush_impl(tsd_t *tsd, szind_t binind,
     cache_bin_ptr_array_t *arr, unsigned nflush, bool small,
     arena_t *stats_arena, cache_bin_stats_t **merge_stats) {

--- a/src/conf.c
+++ b/src/conf.c
@@ -258,7 +258,11 @@ conf_handle_bool(const char *v, size_t vlen, bool *result) {
 }
 
 JEMALLOC_DIAGNOSTIC_PUSH
+#if defined(_MSC_VER) && !defined(__clang__)
+JEMALLOC_DIAGNOSTIC_IGNORE(4505)
+#else
 JEMALLOC_DIAGNOSTIC_IGNORE("-Wunused-function")
+#endif
 
 JET_EXTERN bool
 conf_handle_signed(const char *v, size_t vlen, intmax_t min, intmax_t max,

--- a/src/thread_event_registry.c
+++ b/src/thread_event_registry.c
@@ -27,7 +27,11 @@ static user_hook_object_t uevents_storage[TE_MAX_USER_EVENTS] = {
 };
 
 static atomic_p_t uevent_obj_p[TE_MAX_USER_EVENTS] = {
+#ifdef _MSC_VER
+    ATOMIC_INIT(0),
+#else
     NULL,
+#endif
 };
 
 static inline bool

--- a/test/unit/atomic.c
+++ b/test/unit/atomic.c
@@ -8,6 +8,18 @@
  */
 #define expect_p_eq expect_ptr_eq
 
+#ifdef _MSC_VER
+#  define TEST_INIT_p(value) ((intptr_t)(value))
+#else
+#  define TEST_INIT_p(value) (value)
+#endif
+
+#define TEST_INIT_u64(value) (value)
+#define TEST_INIT_u32(value) (value)
+#define TEST_INIT_zu(value) (value)
+#define TEST_INIT_zd(value) (value)
+#define TEST_INIT_u(value) (value)
+
 /*
  * t: the non-atomic type, like "uint32_t".
  * ta: the short name for the type, like "u32".
@@ -21,7 +33,7 @@
 	t expected;							\
 	bool success;							\
 	/* This (along with the load below) also tests ATOMIC_LOAD. */	\
-	atomic_##ta##_t atom = ATOMIC_INIT(val1);			\
+	atomic_##ta##_t atom = ATOMIC_INIT(TEST_INIT_##ta(val1));			\
 									\
 	/* ATOMIC_INIT and load. */					\
 	val = atomic_load_##ta(&atom, ATOMIC_RELAXED);			\


### PR DESCRIPTION
**Issues:**
msbuild \msvc\jemalloc_vc2019.sln /m, gets warnings:
- \jemalloc\src\conf.c(261,1): warning C4081: expected ')'; found 'string' [{your-code-path}\jemalloc\msvc\project
       s\vc2019\jemalloc\jemalloc.vcxproj] 
- \jemalloc\src\thread_event_registry.c(29,1): warning C4047: 'initializing': 'atomic_repr_3_t' differs i
       n levels of indirection from 'void *' [{your-code-path}\jemalloc\msvc\projects\vc2019\jemalloc\jemalloc.vcxproj]

cl /c /TC /W3 /MT /O2 /DJEMALLOC_UNIT_TEST /DJEMALLOC_NO_PRIVATE_NAMESPACE /Iinclude /Itest/include /Iinclude/msvc_compat /Fo{your-code-path}\jemalloc\build\atomic-warning-c0y_uuw5\atomic-before.obj test/unit/atomic.c
gets warning:
- test/unit/atomic.c(198): warning C4047: 'initializing': 'atomic_repr_3_t' differs in levels of indirection from 'void *'

msbuild \msvc\jemalloc_vc2019.sln /p:Configuration=Release /m, gets warning:
- \jemalloc\msvc\projects\vc2019\jemalloc\jemalloc.vcxproj" (default target) (3) ->
       (Link target) ->
         {your-code-path}\jemalloc\src\arena.c(1314): warning C4750: 'arena_ptr_array_flush_impl': function with _alloca() inlin
       ed into a loop [{your-code-path}\jemalloc\msvc\projects\vc2019\jemalloc\jemalloc.vcxproj]

**Fix MSVC diagnostics, pointer atomic initialization, and flush-loop stack usage in four files:**

- `src/conf.c`: Suppress warning C4505 for native MSVC while retaining -Wunused-function suppression for other compilers.

- `src/thread_event_registry.c`: Use ATOMIC_INIT(0) for the pointer atomic array under _MSC_VER.
- `test/unit/atomic.c`: Add type-specific initializer macros to convert pointer values to MSVC’s integer-backed atomic representation.
- `src/arena.c`: Change arena_ptr_array_flush_impl() from always-inline to static JEMALLOC_NOINLINE for native MSVC. Retain always-inline behavior for other compilers, including clang-cl.

Why prevent inlining the flush helper?
The helper uses VARIABLE_ARRAY, which allocates stack memory through alloca on Windows. Inlining it into the batch-flush loop can accumulate stack allocations until the outer function returns, triggering C4750:

`warning C4750: 'arena_ptr_array_flush_impl': function with _alloca() inlined into a loop`
Preventing inlining gives each batch its own function frame, allowing its stack allocations to be released when the helper returns. The flush logic remains unchanged.